### PR TITLE
feat(F010-Phase1): Project context schema extension

### DIFF
--- a/a2a/cstp/decision_service.py
+++ b/a2a/cstp/decision_service.py
@@ -97,12 +97,16 @@ class ProjectContext:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "ProjectContext":
         """Create from dictionary."""
+        # Cast pr and line to int to prevent type pollution from external inputs
+        pr_val = data.get("pr")
+        line_val = data.get("line")
+
         return cls(
             project=data.get("project"),
             feature=data.get("feature"),
-            pr=data.get("pr"),
+            pr=int(pr_val) if pr_val is not None else None,
             file=data.get("file"),
-            line=data.get("line"),
+            line=int(line_val) if line_val is not None else None,
             commit=data.get("commit"),
         )
 
@@ -406,6 +410,8 @@ def build_embedding_text(request: RecordDecisionRequest) -> str:
             parts.append(f"Feature: {pc.feature}")
         if pc.file:
             parts.append(f"File: {pc.file}")
+        if pc.pr is not None:
+            parts.append(f"PR #{pc.pr}")
 
     return "\n".join(parts)
 

--- a/tests/test_decision_service.py
+++ b/tests/test_decision_service.py
@@ -493,9 +493,28 @@ class TestRecordDecisionRequestWithProjectContext:
         assert req.project_context.project == "owner/repo"
         assert req.project_context.feature == "api-v2"
         assert req.project_context.pr == 42
+        assert isinstance(req.project_context.pr, int)
         assert req.project_context.file == "src/api.py"
         assert req.project_context.line == 100
+        assert isinstance(req.project_context.line, int)
         assert req.project_context.commit == "abc123d"
+
+    def test_from_dict_casts_string_pr_to_int(self) -> None:
+        """String PR number is cast to int."""
+        data = {
+            "decision": "Test",
+            "confidence": 0.8,
+            "category": "architecture",
+            "pr": "42",  # String, not int
+            "line": "100",  # String, not int
+        }
+        req = RecordDecisionRequest.from_dict(data)
+
+        assert req.project_context is not None
+        assert req.project_context.pr == 42
+        assert isinstance(req.project_context.pr, int)
+        assert req.project_context.line == 100
+        assert isinstance(req.project_context.line, int)
 
     def test_from_dict_without_project_context(self) -> None:
         """No project context when fields absent."""
@@ -563,6 +582,7 @@ class TestBuildEmbeddingTextWithProjectContext:
                 project="owner/repo",
                 feature="api-v2",
                 file="src/api.py",
+                pr=42,
             ),
         )
         text = build_embedding_text(req)
@@ -570,4 +590,4 @@ class TestBuildEmbeddingTextWithProjectContext:
         assert "Project: owner/repo" in text
         assert "Feature: api-v2" in text
         assert "File: src/api.py" in text
-
+        assert "PR #42" in text


### PR DESCRIPTION
## Summary

Phase 1 of F010: Adds project context fields to `recordDecision`.

## New Fields

| Field | Type | Description |
|-------|------|-------------|
| project | string | Repository (owner/repo) |
| feature | string | Feature/epic name |
| pr | integer | PR number |
| file | string | File path |
| line | integer | Line number |
| commit | string | Commit SHA |

## Changes

- `ProjectContext` dataclass with from_dict, to_dict, has_any
- `RecordDecisionRequest` includes project_context
- YAML persistence includes project fields
- ChromaDB metadata includes project/feature/pr/file
- Embedding text includes project/feature/file

## Tests

- ProjectContext parsing and serialization
- RecordDecisionRequest with/without project context
- build_decision_yaml includes project fields
- build_embedding_text includes project fields