### PR TITLE
feat(F010-Phase4): Automatic outcome attribution

### DIFF
--- a/a2a/cstp/attribution_service.py
+++ b/a2a/cstp/attribution_service.py
@@ -1,0 +1,291 @@
+"""Attribution service for automatic outcome linking.
+
+Provides mechanisms to automatically attribute outcomes to decisions
+based on PR stability and file:line matching.
+"""
+
+import logging
+import os
+import tempfile
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from .decision_service import DECISIONS_PATH
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AttributionResult:
+    """Result of attributing an outcome to a decision."""
+
+    id: str
+    outcome: str
+    reason: str
+    path: str
+    updated: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "id": self.id,
+            "outcome": self.outcome,
+            "reason": self.reason,
+            "path": self.path,
+            "updated": self.updated,
+        }
+
+
+@dataclass
+class AttributeOutcomesRequest:
+    """Request to attribute outcomes to decisions."""
+
+    project: str
+    since: str | None = None
+    stability_days: int = 14
+    dry_run: bool = False
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "AttributeOutcomesRequest":
+        """Create from dictionary (JSON-RPC params)."""
+        project = data.get("project")
+        if not project:
+            raise ValueError("project is required")
+
+        return cls(
+            project=project,
+            since=data.get("since"),
+            stability_days=data.get("stabilityDays", 14),
+            dry_run=data.get("dryRun", False),
+        )
+
+
+@dataclass
+class AttributeOutcomesResponse:
+    """Response from outcome attribution."""
+
+    processed: int
+    attributed: dict[str, int] = field(default_factory=dict)
+    decisions: list[AttributionResult] = field(default_factory=list)
+    query_time: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "processed": self.processed,
+            "attributed": self.attributed,
+            "decisions": [d.to_dict() for d in self.decisions],
+            "queryTime": self.query_time,
+        }
+
+
+async def find_pending_decisions(
+    project: str,
+    since: str | None = None,
+    decisions_path: str | None = None,
+) -> list[tuple[Path, dict[str, Any]]]:
+    """Find pending decisions for a project.
+
+    Args:
+        project: Project to filter by (owner/repo).
+        since: Only decisions after this date.
+        decisions_path: Override for decisions directory.
+
+    Returns:
+        List of (path, data) tuples for pending decisions.
+    """
+    base = Path(decisions_path or DECISIONS_PATH)
+    results: list[tuple[Path, dict[str, Any]]] = []
+
+    if not base.exists():
+        return results
+
+    for yaml_file in base.rglob("*-decision-*.yaml"):
+        try:
+            with open(yaml_file) as f:
+                data = yaml.safe_load(f)
+
+            if not data:
+                continue
+
+            # Must be pending
+            if data.get("status") != "pending":
+                continue
+
+            # Must match project
+            if data.get("project") != project:
+                continue
+
+            # Check date filter
+            if since:
+                decision_date = data.get("date", "")
+                if isinstance(decision_date, str):
+                    date_str = decision_date[:10]
+                    if date_str < since:
+                        continue
+
+            results.append((yaml_file, data))
+
+        except Exception:
+            continue
+
+    return results
+
+
+def is_pr_stable(
+    pr_number: int,
+    project: str,
+    stability_days: int,
+    decision_date: str,
+) -> bool:
+    """Check if a PR is stable (no bugs reported within stability window).
+
+    This is a simplified check based on decision age.
+    A real implementation would query GitHub issues.
+
+    Args:
+        pr_number: PR number.
+        project: Project identifier.
+        stability_days: Days to consider stable.
+        decision_date: When the decision was made.
+
+    Returns:
+        True if PR is considered stable.
+    """
+    try:
+        # Parse decision date
+        if "T" in decision_date:
+            dt = datetime.fromisoformat(decision_date.replace("Z", "+00:00"))
+        else:
+            dt = datetime.strptime(decision_date, "%Y-%m-%d").replace(tzinfo=UTC)
+
+        # Check if enough time has passed
+        now = datetime.now(UTC)
+        age = now - dt
+        return age.days >= stability_days
+
+    except Exception:
+        return False
+
+
+async def update_decision_outcome(
+    path: Path,
+    outcome: str,
+    reason: str,
+    dry_run: bool = False,
+) -> bool:
+    """Update a decision file with outcome.
+
+    Uses atomic write (tempfile + os.replace).
+
+    Args:
+        path: Path to decision file.
+        outcome: Outcome value (success, partial, failure, abandoned).
+        reason: Reason for the attribution.
+        dry_run: If True, don't actually write.
+
+    Returns:
+        True if updated successfully.
+    """
+    if dry_run:
+        return True
+
+    try:
+        with open(path) as f:
+            data = yaml.safe_load(f)
+
+        data["status"] = "reviewed"
+        data["outcome"] = outcome
+        data["reviewed_at"] = datetime.now(UTC).isoformat()
+        data["auto_attributed"] = True
+        data["attribution_reason"] = reason
+
+        # Atomic write
+        temp_fd, temp_path = tempfile.mkstemp(suffix=".yaml", dir=path.parent)
+        try:
+            with os.fdopen(temp_fd, "w") as f:
+                yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+            os.replace(temp_path, path)
+            return True
+        except Exception:
+            if os.path.exists(temp_path):
+                os.unlink(temp_path)
+            raise
+
+    except Exception as e:
+        logger.warning("Failed to update decision %s: %s", path, e)
+        return False
+
+
+async def attribute_outcomes(
+    request: AttributeOutcomesRequest,
+    decisions_path: str | None = None,
+) -> AttributeOutcomesResponse:
+    """Attribute outcomes to pending decisions.
+
+    Currently implements PR stability check:
+    - If decision has PR and is older than stability_days, mark as success.
+
+    Args:
+        request: The attribution request.
+        decisions_path: Override for decisions directory.
+
+    Returns:
+        Attribution response with results.
+    """
+    now = datetime.now(UTC)
+
+    # Find pending decisions for project
+    pending = await find_pending_decisions(
+        project=request.project,
+        since=request.since,
+        decisions_path=decisions_path,
+    )
+
+    results: list[AttributionResult] = []
+    counts = {"stable": 0, "skipped": 0}
+
+    for path, data in pending:
+        decision_id = data.get("id", "unknown")
+        pr_number = data.get("pr")
+        decision_date = data.get("date", "")
+
+        # Skip if no PR associated
+        if pr_number is None:
+            counts["skipped"] += 1
+            continue
+
+        # Check PR stability
+        if is_pr_stable(pr_number, request.project, request.stability_days, decision_date):
+            reason = f"PR #{pr_number} stable for {request.stability_days} days"
+
+            updated = await update_decision_outcome(
+                path=path,
+                outcome="success",
+                reason=reason,
+                dry_run=request.dry_run,
+            )
+
+            results.append(
+                AttributionResult(
+                    id=decision_id,
+                    outcome="success",
+                    reason=reason,
+                    path=str(path),
+                    updated=updated,
+                )
+            )
+            counts["stable"] += 1
+        else:
+            counts["skipped"] += 1
+
+    return AttributeOutcomesResponse(
+        processed=len(pending),
+        attributed=counts,
+        decisions=results,
+        query_time=now.isoformat(),
+    )

--- a/a2a/cstp/dispatcher.py
+++ b/a2a/cstp/dispatcher.py
@@ -15,6 +15,10 @@ from ..models.jsonrpc import (
     JsonRpcRequest,
     JsonRpcResponse,
 )
+from .attribution_service import (
+    AttributeOutcomesRequest,
+    attribute_outcomes,
+)
 from .calibration_service import (
     GetCalibrationRequest,
     get_calibration,
@@ -45,6 +49,7 @@ QUERY_FAILED = -32003
 RATE_LIMITED = -32002
 GUARDRAIL_EVAL_FAILED = -32004
 RECORD_FAILED = -32005
+ATTRIBUTION_FAILED = -32008
 REVIEW_FAILED = -32006
 DECISION_NOT_FOUND = -32007
 
@@ -276,6 +281,7 @@ def register_methods(dispatcher: CstpDispatcher) -> None:
     dispatcher.register("cstp.recordDecision", _handle_record_decision)
     dispatcher.register("cstp.reviewDecision", _handle_review_decision)
     dispatcher.register("cstp.getCalibration", _handle_get_calibration)
+    dispatcher.register("cstp.attributeOutcomes", _handle_attribute_outcomes)
 
 
 async def _handle_record_decision(params: dict[str, Any], agent_id: str) -> dict[str, Any]:
@@ -350,4 +356,22 @@ async def _handle_get_calibration(params: dict[str, Any], agent_id: str) -> dict
     """
     request = GetCalibrationRequest.from_dict(params)
     response = await get_calibration(request)
+    return response.to_dict()
+
+
+async def _handle_attribute_outcomes(params: dict[str, Any], agent_id: str) -> dict[str, Any]:
+    """Handle cstp.attributeOutcomes method.
+
+    Args:
+        params: JSON-RPC params.
+        agent_id: Authenticated agent ID.
+
+    Returns:
+        Attribution results as dict.
+
+    Raises:
+        ValueError: If validation fails.
+    """
+    request = AttributeOutcomesRequest.from_dict(params)
+    response = await attribute_outcomes(request)
     return response.to_dict()

--- a/tests/test_attribution_service.py
+++ b/tests/test_attribution_service.py
@@ -1,0 +1,281 @@
+"""Unit tests for attribution_service.py."""
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+import yaml
+
+from a2a.cstp.attribution_service import (
+    AttributeOutcomesRequest,
+    attribute_outcomes,
+    find_pending_decisions,
+    is_pr_stable,
+    update_decision_outcome,
+)
+
+
+def create_pending_decision(
+    tmp_path: Path,
+    decision_id: str,
+    project: str,
+    pr: int | None = None,
+    days_old: int = 0,
+) -> Path:
+    """Helper to create a pending decision file."""
+    year_dir = tmp_path / "2026" / "02"
+    year_dir.mkdir(parents=True, exist_ok=True)
+
+    decision_date = datetime.now(UTC) - timedelta(days=days_old)
+
+    data = {
+        "id": decision_id,
+        "summary": f"Test decision {decision_id}",
+        "category": "code-review",
+        "confidence": 0.85,
+        "status": "pending",
+        "date": decision_date.isoformat(),
+        "project": project,
+    }
+
+    if pr is not None:
+        data["pr"] = pr
+
+    file_path = year_dir / f"2026-02-05-decision-{decision_id}.yaml"
+    with open(file_path, "w") as f:
+        yaml.dump(data, f)
+
+    return file_path
+
+
+class TestAttributeOutcomesRequest:
+    """Tests for AttributeOutcomesRequest."""
+
+    def test_from_dict_valid(self) -> None:
+        """Parses valid request."""
+        data = {
+            "project": "owner/repo",
+            "since": "2026-01-01",
+            "stabilityDays": 7,
+            "dryRun": True,
+        }
+        req = AttributeOutcomesRequest.from_dict(data)
+
+        assert req.project == "owner/repo"
+        assert req.since == "2026-01-01"
+        assert req.stability_days == 7
+        assert req.dry_run is True
+
+    def test_from_dict_missing_project_raises(self) -> None:
+        """Missing project raises ValueError."""
+        with pytest.raises(ValueError, match="project is required"):
+            AttributeOutcomesRequest.from_dict({})
+
+    def test_defaults(self) -> None:
+        """Default values are applied."""
+        data = {"project": "owner/repo"}
+        req = AttributeOutcomesRequest.from_dict(data)
+
+        assert req.stability_days == 14
+        assert req.dry_run is False
+        assert req.since is None
+
+
+class TestFindPendingDecisions:
+    """Tests for find_pending_decisions."""
+
+    @pytest.mark.asyncio
+    async def test_finds_pending_for_project(self, tmp_path: Path) -> None:
+        """Finds pending decisions for project."""
+        create_pending_decision(tmp_path, "dec1", "owner/repo", pr=1)
+        create_pending_decision(tmp_path, "dec2", "owner/repo", pr=2)
+        create_pending_decision(tmp_path, "dec3", "other/repo", pr=3)
+
+        results = await find_pending_decisions(
+            project="owner/repo",
+            decisions_path=str(tmp_path),
+        )
+
+        assert len(results) == 2
+        ids = [data["id"] for _, data in results]
+        assert "dec1" in ids
+        assert "dec2" in ids
+        assert "dec3" not in ids
+
+    @pytest.mark.asyncio
+    async def test_skips_reviewed(self, tmp_path: Path) -> None:
+        """Skips reviewed decisions."""
+        path = create_pending_decision(tmp_path, "dec1", "owner/repo", pr=1)
+
+        # Mark as reviewed
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        data["status"] = "reviewed"
+        with open(path, "w") as f:
+            yaml.dump(data, f)
+
+        results = await find_pending_decisions(
+            project="owner/repo",
+            decisions_path=str(tmp_path),
+        )
+
+        assert len(results) == 0
+
+    @pytest.mark.asyncio
+    async def test_empty_when_no_match(self, tmp_path: Path) -> None:
+        """Returns empty when no matching project."""
+        create_pending_decision(tmp_path, "dec1", "other/repo", pr=1)
+
+        results = await find_pending_decisions(
+            project="owner/repo",
+            decisions_path=str(tmp_path),
+        )
+
+        assert len(results) == 0
+
+
+class TestIsPrStable:
+    """Tests for is_pr_stable."""
+
+    def test_stable_when_old_enough(self) -> None:
+        """Returns True when decision is old enough."""
+        old_date = (datetime.now(UTC) - timedelta(days=20)).isoformat()
+
+        result = is_pr_stable(
+            pr_number=1,
+            project="owner/repo",
+            stability_days=14,
+            decision_date=old_date,
+        )
+
+        assert result is True
+
+    def test_not_stable_when_too_recent(self) -> None:
+        """Returns False when decision is too recent."""
+        recent_date = (datetime.now(UTC) - timedelta(days=5)).isoformat()
+
+        result = is_pr_stable(
+            pr_number=1,
+            project="owner/repo",
+            stability_days=14,
+            decision_date=recent_date,
+        )
+
+        assert result is False
+
+    def test_handles_date_only_format(self) -> None:
+        """Handles YYYY-MM-DD format."""
+        old_date = (datetime.now(UTC) - timedelta(days=20)).strftime("%Y-%m-%d")
+
+        result = is_pr_stable(
+            pr_number=1,
+            project="owner/repo",
+            stability_days=14,
+            decision_date=old_date,
+        )
+
+        assert result is True
+
+
+class TestUpdateDecisionOutcome:
+    """Tests for update_decision_outcome."""
+
+    @pytest.mark.asyncio
+    async def test_updates_decision_file(self, tmp_path: Path) -> None:
+        """Updates decision file with outcome."""
+        path = create_pending_decision(tmp_path, "dec1", "owner/repo", pr=1)
+
+        result = await update_decision_outcome(
+            path=path,
+            outcome="success",
+            reason="PR stable",
+            dry_run=False,
+        )
+
+        assert result is True
+
+        # Verify file was updated
+        with open(path) as f:
+            data = yaml.safe_load(f)
+
+        assert data["status"] == "reviewed"
+        assert data["outcome"] == "success"
+        assert data["auto_attributed"] is True
+        assert data["attribution_reason"] == "PR stable"
+
+    @pytest.mark.asyncio
+    async def test_dry_run_doesnt_write(self, tmp_path: Path) -> None:
+        """Dry run doesn't modify file."""
+        path = create_pending_decision(tmp_path, "dec1", "owner/repo", pr=1)
+
+        result = await update_decision_outcome(
+            path=path,
+            outcome="success",
+            reason="PR stable",
+            dry_run=True,
+        )
+
+        assert result is True
+
+        # Verify file was NOT updated
+        with open(path) as f:
+            data = yaml.safe_load(f)
+
+        assert data["status"] == "pending"
+        assert "outcome" not in data
+
+
+class TestAttributeOutcomes:
+    """Integration tests for attribute_outcomes."""
+
+    @pytest.mark.asyncio
+    async def test_attributes_stable_prs(self, tmp_path: Path) -> None:
+        """Attributes success to stable PRs."""
+        # Old decision (should be attributed)
+        create_pending_decision(tmp_path, "old1", "owner/repo", pr=1, days_old=20)
+        # Recent decision (should be skipped)
+        create_pending_decision(tmp_path, "new1", "owner/repo", pr=2, days_old=5)
+
+        request = AttributeOutcomesRequest(
+            project="owner/repo",
+            stability_days=14,
+        )
+        response = await attribute_outcomes(request, decisions_path=str(tmp_path))
+
+        assert response.processed == 2
+        assert response.attributed["stable"] == 1
+        assert response.attributed["skipped"] == 1
+        assert len(response.decisions) == 1
+        assert response.decisions[0].id == "old1"
+        assert response.decisions[0].outcome == "success"
+
+    @pytest.mark.asyncio
+    async def test_skips_decisions_without_pr(self, tmp_path: Path) -> None:
+        """Skips decisions without PR number."""
+        create_pending_decision(tmp_path, "no-pr", "owner/repo", pr=None, days_old=20)
+
+        request = AttributeOutcomesRequest(project="owner/repo")
+        response = await attribute_outcomes(request, decisions_path=str(tmp_path))
+
+        assert response.processed == 1
+        assert response.attributed["skipped"] == 1
+        assert len(response.decisions) == 0
+
+    @pytest.mark.asyncio
+    async def test_dry_run_doesnt_modify(self, tmp_path: Path) -> None:
+        """Dry run reports but doesn't modify."""
+        path = create_pending_decision(tmp_path, "dec1", "owner/repo", pr=1, days_old=20)
+
+        request = AttributeOutcomesRequest(
+            project="owner/repo",
+            dry_run=True,
+        )
+        response = await attribute_outcomes(request, decisions_path=str(tmp_path))
+
+        assert response.attributed["stable"] == 1
+        assert len(response.decisions) == 1
+
+        # Verify file was NOT modified
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        assert data["status"] == "pending"


### PR DESCRIPTION
## Summary

Phase 4 of F010: Implements `cstp.attributeOutcomes` for automatic outcome linking.

## How It Works

1. Find pending decisions for a project
2. For each decision with a PR:
   - Check if PR age > stabilityDays (default 14)
   - If stable, mark as success
3. Returns attribution results

## API

```json
{
  "method": "cstp.attributeOutcomes",
  "params": {
    "project": "owner/repo",
    "stabilityDays": 14,
    "dryRun": false
  }
}
```

## Response

```json
{
  "processed": 10,
  "attributed": {
    "stable": 7,
    "skipped": 3
  },
  "decisions": [
    {
      "id": "abc123",
      "outcome": "success",
      "reason": "PR #8 stable for 14 days"
    }
  ]
}
```

## Changes

- `a2a/cstp/attribution_service.py` — Core service
- `a2a/cstp/dispatcher.py` — Method registration
- `tests/test_attribution_service.py` — Comprehensive tests