### PR TITLE
fix: align collection names across services

### DIFF
--- a/a2a/cstp/query_service.py
+++ b/a2a/cstp/query_service.py
@@ -16,7 +16,7 @@ CHROMA_URL = os.getenv("CHROMA_URL", "http://chromadb:8000")
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "")
 TENANT = "default_tenant"
 DATABASE = "default_database"
-COLLECTION_NAME = "cognition_decisions"
+COLLECTION_NAME = os.getenv("CHROMA_COLLECTION", "decisions_gemini")
 
 # Configurable secrets paths (can be overridden via env)
 SECRETS_PATHS = os.getenv(


### PR DESCRIPTION
query_service was using hardcoded `cognition_decisions`, decision_service uses `decisions_gemini`.

Now both use CHROMA_COLLECTION env var (default: decisions_gemini).