### PR TITLE
feat(F016): Confidence variance tracking

### DIFF
--- a/a2a/cstp/tests/test_confidence_variance.py
+++ b/a2a/cstp/tests/test_confidence_variance.py
@@ -1,0 +1,183 @@
+"""Tests for confidence variance tracking (F016)."""
+import pytest
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from a2a.cstp.calibration_service import (
+    ConfidenceStats,
+    calculate_confidence_stats,
+    generate_variance_recommendations,
+    CalibrationRecommendation,
+)
+
+
+class TestCalculateConfidenceStats:
+    """Tests for calculate_confidence_stats function."""
+
+    def test_basic_stats(self) -> None:
+        """Test basic stats calculation."""
+        decisions = [
+            {"confidence": 0.80},
+            {"confidence": 0.85},
+            {"confidence": 0.90},
+        ]
+        stats = calculate_confidence_stats(decisions)
+        
+        assert stats is not None
+        assert stats.count == 3
+        assert stats.mean == pytest.approx(0.85, abs=0.01)
+        assert stats.min_conf == 0.80
+        assert stats.max_conf == 0.90
+
+    def test_bucket_counts(self) -> None:
+        """Test bucket distribution."""
+        decisions = [
+            {"confidence": 0.55},  # 0.5-0.6
+            {"confidence": 0.65},  # 0.6-0.7
+            {"confidence": 0.75},  # 0.7-0.8
+            {"confidence": 0.85},  # 0.8-0.9
+            {"confidence": 0.85},  # 0.8-0.9
+            {"confidence": 0.95},  # 0.9-1.0
+        ]
+        stats = calculate_confidence_stats(decisions)
+        
+        assert stats is not None
+        assert stats.bucket_counts["0.5-0.6"] == 1
+        assert stats.bucket_counts["0.6-0.7"] == 1
+        assert stats.bucket_counts["0.7-0.8"] == 1
+        assert stats.bucket_counts["0.8-0.9"] == 2
+        assert stats.bucket_counts["0.9-1.0"] == 1
+
+    def test_std_dev_calculation(self) -> None:
+        """Test standard deviation calculation."""
+        # All same value - std_dev should be 0
+        decisions = [{"confidence": 0.85} for _ in range(10)]
+        stats = calculate_confidence_stats(decisions)
+        
+        assert stats is not None
+        assert stats.std_dev == 0.0
+
+    def test_varied_std_dev(self) -> None:
+        """Test std dev with varied values."""
+        decisions = [
+            {"confidence": 0.50},
+            {"confidence": 0.75},
+            {"confidence": 1.00},
+        ]
+        stats = calculate_confidence_stats(decisions)
+        
+        assert stats is not None
+        assert stats.std_dev > 0.15  # Should have significant variance
+
+    def test_empty_decisions(self) -> None:
+        """Test with no decisions."""
+        stats = calculate_confidence_stats([])
+        assert stats is None
+
+    def test_no_confidence_field(self) -> None:
+        """Test decisions without confidence field."""
+        decisions = [{"summary": "test"}]
+        stats = calculate_confidence_stats(decisions)
+        assert stats is None
+
+
+class TestGenerateVarianceRecommendations:
+    """Tests for generate_variance_recommendations function."""
+
+    def test_low_variance_recommendation(self) -> None:
+        """Test low variance generates recommendation."""
+        stats = ConfidenceStats(
+            mean=0.85,
+            std_dev=0.02,  # Very low variance
+            min_conf=0.82,
+            max_conf=0.88,
+            count=20,
+            bucket_counts={
+                "0.5-0.6": 0,
+                "0.6-0.7": 0,
+                "0.7-0.8": 0,
+                "0.8-0.9": 20,  # All in one bucket
+                "0.9-1.0": 0,
+            },
+        )
+        recs = generate_variance_recommendations(stats)
+        
+        assert len(recs) >= 1
+        assert any(r.type == "low_variance" for r in recs)
+
+    def test_overconfident_habit(self) -> None:
+        """Test overconfident habit detection."""
+        stats = ConfidenceStats(
+            mean=0.90,
+            std_dev=0.05,
+            min_conf=0.80,  # All high
+            max_conf=0.98,
+            count=15,
+            bucket_counts={
+                "0.5-0.6": 0,
+                "0.6-0.7": 0,
+                "0.7-0.8": 0,
+                "0.8-0.9": 5,
+                "0.9-1.0": 10,
+            },
+        )
+        recs = generate_variance_recommendations(stats)
+        
+        assert any(r.type == "overconfident_habit" for r in recs)
+
+    def test_no_recommendation_good_variance(self) -> None:
+        """Test no recommendations with good variance."""
+        stats = ConfidenceStats(
+            mean=0.75,
+            std_dev=0.15,  # Good variance
+            min_conf=0.50,
+            max_conf=0.95,
+            count=20,
+            bucket_counts={
+                "0.5-0.6": 4,
+                "0.6-0.7": 4,
+                "0.7-0.8": 4,
+                "0.8-0.9": 4,
+                "0.9-1.0": 4,
+            },
+        )
+        recs = generate_variance_recommendations(stats)
+        
+        # Should have no variance warnings
+        assert not any(r.type in ("low_variance", "overconfident_habit") for r in recs)
+
+    def test_insufficient_decisions(self) -> None:
+        """Test no recommendations with few decisions."""
+        stats = ConfidenceStats(
+            mean=0.85,
+            std_dev=0.01,  # Would trigger low_variance
+            min_conf=0.84,
+            max_conf=0.86,
+            count=5,  # Too few
+            bucket_counts={"0.8-0.9": 5},
+        )
+        recs = generate_variance_recommendations(stats)
+        
+        assert len(recs) == 0  # Not enough data
+
+    def test_underconfident_habit(self) -> None:
+        """Test underconfident habit detection."""
+        stats = ConfidenceStats(
+            mean=0.55,
+            std_dev=0.05,
+            min_conf=0.50,
+            max_conf=0.65,  # All low
+            count=15,
+            bucket_counts={
+                "0.5-0.6": 10,
+                "0.6-0.7": 5,
+                "0.7-0.8": 0,
+                "0.8-0.9": 0,
+                "0.9-1.0": 0,
+            },
+        )
+        recs = generate_variance_recommendations(stats)
+        
+        assert any(r.type == "underconfident_habit" for r in recs)

--- a/dashboard/templates/calibration.html
+++ b/dashboard/templates/calibration.html
@@ -54,6 +54,46 @@
     </article>
 </div>
 
+{% if stats.confidence_stats %}
+<h2>Confidence Distribution</h2>
+<div class="grid">
+    <article>
+        <header>Mean</header>
+        <p class="stat-number">{{ stats.confidence_stats.mean_pct }}%</p>
+    </article>
+    <article>
+        <header>Std Dev</header>
+        <p class="stat-number">{{ "%.2f"|format(stats.confidence_stats.std_dev) }}</p>
+    </article>
+    <article>
+        <header>Range</header>
+        <p class="stat-number">{{ (stats.confidence_stats.min_conf * 100)|int }}-{{ (stats.confidence_stats.max_conf * 100)|int }}%</p>
+    </article>
+</div>
+
+<details>
+    <summary>Distribution by Bucket</summary>
+    <table>
+        <thead>
+            <tr>
+                <th>Confidence Range</th>
+                <th>Count</th>
+                <th>Percentage</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for bucket, count in stats.confidence_stats.bucket_counts.items() %}
+            <tr>
+                <td>{{ bucket }}</td>
+                <td>{{ count }}</td>
+                <td>{% if stats.confidence_stats.count > 0 %}{{ (count / stats.confidence_stats.count * 100)|round|int }}%{% else %}--{% endif %}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</details>
+{% endif %}
+
 {% if stats.by_category %}
 <h2>By Category</h2>
 <figure>

--- a/docs/F016-IMPLEMENTATION-PLAN.md
+++ b/docs/F016-IMPLEMENTATION-PLAN.md
@@ -1,0 +1,225 @@
+# F016 Implementation Plan: Confidence Variance Tracking
+
+**Spec:** `docs/specs/V0.9.0-FEATURES.md`  
+**Skill:** python-pro  
+**Complexity:** Low (~1 hour)
+
+---
+
+## Overview
+
+Track confidence distribution to detect habituation — when agents always use the same confidence (e.g., always 85%) instead of varying based on actual uncertainty.
+
+---
+
+## API Changes
+
+### Enhanced `cstp.getCalibration` Response
+
+Add `confidenceStats` to the response:
+
+```json
+{
+  "overall": { ... },
+  "confidenceStats": {
+    "mean": 0.82,
+    "stdDev": 0.08,
+    "min": 0.60,
+    "max": 0.95,
+    "count": 45,
+    "bucketCounts": {
+      "0.5-0.6": 5,
+      "0.6-0.7": 12,
+      "0.7-0.8": 8,
+      "0.8-0.9": 15,
+      "0.9-1.0": 5
+    }
+  },
+  "recommendations": [
+    {
+      "type": "low_variance",
+      "message": "80% of decisions use 80-90% confidence. Consider varying more based on actual uncertainty.",
+      "severity": "info"
+    }
+  ]
+}
+```
+
+---
+
+## Implementation Steps
+
+### Phase 1: Backend (30 min)
+
+#### Step 1.1: Add ConfidenceStats dataclass (10 min)
+
+**File:** `a2a/cstp/calibration_service.py`
+
+```python
+@dataclass
+class ConfidenceStats:
+    """Statistics about confidence distribution."""
+    
+    mean: float
+    std_dev: float
+    min_conf: float
+    max_conf: float
+    count: int
+    bucket_counts: dict[str, int]
+    
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "mean": round(self.mean, 3),
+            "stdDev": round(self.std_dev, 3),
+            "min": round(self.min_conf, 2),
+            "max": round(self.max_conf, 2),
+            "count": self.count,
+            "bucketCounts": self.bucket_counts,
+        }
+```
+
+#### Step 1.2: Add calculate_confidence_stats function (15 min)
+
+```python
+def calculate_confidence_stats(decisions: list[dict[str, Any]]) -> ConfidenceStats | None:
+    """Calculate confidence distribution statistics.
+    
+    Args:
+        decisions: List of decision data with 'confidence' field.
+        
+    Returns:
+        ConfidenceStats or None if no decisions.
+    """
+    confidences = [d.get("confidence", 0.5) for d in decisions if "confidence" in d]
+    
+    if not confidences:
+        return None
+    
+    n = len(confidences)
+    mean = sum(confidences) / n
+    variance = sum((c - mean) ** 2 for c in confidences) / n
+    std_dev = variance ** 0.5
+    
+    # Bucket counts
+    buckets = {"0.5-0.6": 0, "0.6-0.7": 0, "0.7-0.8": 0, "0.8-0.9": 0, "0.9-1.0": 0}
+    for c in confidences:
+        if c < 0.6:
+            buckets["0.5-0.6"] += 1
+        elif c < 0.7:
+            buckets["0.6-0.7"] += 1
+        elif c < 0.8:
+            buckets["0.7-0.8"] += 1
+        elif c < 0.9:
+            buckets["0.8-0.9"] += 1
+        else:
+            buckets["0.9-1.0"] += 1
+    
+    return ConfidenceStats(
+        mean=mean,
+        std_dev=std_dev,
+        min_conf=min(confidences),
+        max_conf=max(confidences),
+        count=n,
+        bucket_counts=buckets,
+    )
+```
+
+#### Step 1.3: Add variance recommendations (5 min)
+
+```python
+def generate_variance_recommendations(stats: ConfidenceStats) -> list[CalibrationRecommendation]:
+    """Generate recommendations based on confidence variance."""
+    recs = []
+    
+    # Low variance warning
+    if stats.std_dev < 0.05 and stats.count >= 10:
+        # Find dominant bucket
+        max_bucket = max(stats.bucket_counts, key=stats.bucket_counts.get)
+        max_pct = stats.bucket_counts[max_bucket] / stats.count * 100
+        
+        if max_pct > 70:
+            recs.append(CalibrationRecommendation(
+                type="low_variance",
+                message=f"{max_pct:.0f}% of decisions use {max_bucket} confidence. Consider varying more based on actual uncertainty.",
+                severity="info",
+            ))
+    
+    # Always high confidence
+    if stats.mean > 0.85 and stats.min_conf > 0.75:
+        recs.append(CalibrationRecommendation(
+            type="overconfident_habit",
+            message="All decisions have high confidence (>75%). Are you calibrating to actual uncertainty?",
+            severity="warning",
+        ))
+    
+    return recs
+```
+
+#### Step 1.4: Integrate into get_calibration (5 min)
+
+Update `GetCalibrationResponse` and `get_calibration()` to include confidence stats.
+
+---
+
+### Phase 2: Dashboard (15 min)
+
+#### Step 2.1: Update models.py
+
+Add `confidence_stats` field to `CalibrationStats`.
+
+#### Step 2.2: Update calibration.html
+
+Display confidence distribution as a simple bar chart or table.
+
+---
+
+### Phase 3: Tests (15 min)
+
+```python
+def test_calculate_confidence_stats():
+    """Test confidence stats calculation."""
+    decisions = [
+        {"confidence": 0.85},
+        {"confidence": 0.80},
+        {"confidence": 0.90},
+    ]
+    stats = calculate_confidence_stats(decisions)
+    assert stats.mean == pytest.approx(0.85, 0.01)
+    assert stats.count == 3
+
+def test_low_variance_recommendation():
+    """Test low variance generates recommendation."""
+    # All decisions at 0.85
+    stats = ConfidenceStats(
+        mean=0.85, std_dev=0.02, min_conf=0.82, max_conf=0.88,
+        count=20, bucket_counts={"0.8-0.9": 20, ...}
+    )
+    recs = generate_variance_recommendations(stats)
+    assert any(r.type == "low_variance" for r in recs)
+```
+
+---
+
+## Checklist
+
+| # | Task | Est. | Status |
+|---|------|------|--------|
+| 1 | Add ConfidenceStats dataclass | 10m | ⬜ |
+| 2 | Add calculate_confidence_stats() | 15m | ⬜ |
+| 3 | Add generate_variance_recommendations() | 5m | ⬜ |
+| 4 | Integrate into get_calibration | 5m | ⬜ |
+| 5 | Update dashboard models | 5m | ⬜ |
+| 6 | Update calibration template | 10m | ⬜ |
+| 7 | Add tests | 10m | ⬜ |
+| 8 | Create PR + review | 15m | ⬜ |
+
+**Total:** ~1 hour
+
+---
+
+## Detection Thresholds
+
+| Condition | Alert |
+|-----------|-------|
+| std_dev < 0.05 AND >70% in one bucket | "low_variance" info |
+| mean > 0.85 AND min > 0.75 | "overconfident_habit" warning |


### PR DESCRIPTION
## Summary

Track confidence distribution to detect habituation patterns.

## New Response Field: `confidenceStats`

Added to `cstp.getCalibration` response:

```json
{
  "confidenceStats": {
    "mean": 0.82,
    "stdDev": 0.08,
    "min": 0.60,
    "max": 0.95,
    "count": 45,
    "bucketCounts": {"0.5-0.6": 5, "0.6-0.7": 12, ...}
  }
}
```

## Detection Patterns

| Pattern | Condition | Alert |
|---------|-----------|-------|
| Low variance | std_dev < 0.05, >70% in one bucket | info |
| Overconfident habit | mean > 0.85, min > 0.75 | warning |
| Underconfident habit | mean < 0.65, max < 0.75 | info |

## Changes

- `calibration_service.py`: ConfidenceStats, calculate/generate functions
- `dashboard/models.py`: ConfidenceDistribution model
- `calibration.html`: Distribution display with bucket table
- Tests: comprehensive unit tests