### PR TITLE
fix: resolve ruff lint errors

### DIFF
--- a/a2a/cstp/drift_service.py
+++ b/a2a/cstp/drift_service.py
@@ -122,14 +122,14 @@ def detect_drift_alerts(
         List of drift alerts.
     """
     alerts: list[DriftAlert] = []
-    
+
     # Minimum absolute difference to avoid false positives on small values
-    MIN_BRIER_DIFF = 0.03  # At least 0.03 absolute difference required
-    MIN_ACCURACY_DIFF = 0.05  # At least 5% absolute accuracy drop required
+    min_brier_diff = 0.03  # At least 0.03 absolute difference required
+    min_accuracy_diff = 0.05  # At least 5% absolute accuracy drop required
 
     # Check Brier score degradation (higher is worse)
     brier_diff = recent.brier_score - historical.brier_score
-    if historical.brier_score > 0.001 and brier_diff >= MIN_BRIER_DIFF:
+    if historical.brier_score > 0.001 and brier_diff >= min_brier_diff:
         brier_change = brier_diff / historical.brier_score
         if brier_change > threshold_brier:
             severity = "error" if brier_change > 0.5 else "warning"
@@ -146,7 +146,7 @@ def detect_drift_alerts(
 
     # Check accuracy drop (lower is worse)
     accuracy_diff = historical.accuracy - recent.accuracy
-    if historical.accuracy > 0.001 and accuracy_diff >= MIN_ACCURACY_DIFF:
+    if historical.accuracy > 0.001 and accuracy_diff >= min_accuracy_diff:
         accuracy_change = accuracy_diff / historical.accuracy
         if accuracy_change > threshold_accuracy:
             severity = "error" if accuracy_change > 0.25 else "warning"

--- a/a2a/cstp/tests/test_calibration.py
+++ b/a2a/cstp/tests/test_calibration.py
@@ -1,7 +1,6 @@
 """Tests for calibration service."""
-from datetime import datetime, timedelta, UTC
+from datetime import datetime, UTC
 
-import pytest
 
 # Import from parent package
 import sys
@@ -19,11 +18,11 @@ class TestWindowToDates:
         since, until = window_to_dates("30d")
         assert since is not None
         assert until is not None
-        
+
         # Verify format
         datetime.strptime(since, "%Y-%m-%d")
         datetime.strptime(until, "%Y-%m-%d")
-        
+
         # Verify range is approximately 30 days
         since_dt = datetime.strptime(since, "%Y-%m-%d")
         until_dt = datetime.strptime(until, "%Y-%m-%d")
@@ -35,7 +34,7 @@ class TestWindowToDates:
         since, until = window_to_dates("60d")
         assert since is not None
         assert until is not None
-        
+
         since_dt = datetime.strptime(since, "%Y-%m-%d")
         until_dt = datetime.strptime(until, "%Y-%m-%d")
         delta = until_dt - since_dt
@@ -46,7 +45,7 @@ class TestWindowToDates:
         since, until = window_to_dates("90d")
         assert since is not None
         assert until is not None
-        
+
         since_dt = datetime.strptime(since, "%Y-%m-%d")
         until_dt = datetime.strptime(until, "%Y-%m-%d")
         delta = until_dt - since_dt

--- a/a2a/cstp/tests/test_confidence_variance.py
+++ b/a2a/cstp/tests/test_confidence_variance.py
@@ -9,7 +9,6 @@ from a2a.cstp.calibration_service import (
     ConfidenceStats,
     calculate_confidence_stats,
     generate_variance_recommendations,
-    CalibrationRecommendation,
 )
 
 
@@ -24,7 +23,7 @@ class TestCalculateConfidenceStats:
             {"confidence": 0.90},
         ]
         stats = calculate_confidence_stats(decisions)
-        
+
         assert stats is not None
         assert stats.count == 3
         assert stats.mean == pytest.approx(0.85, abs=0.01)
@@ -42,7 +41,7 @@ class TestCalculateConfidenceStats:
             {"confidence": 0.95},  # 0.9-1.0
         ]
         stats = calculate_confidence_stats(decisions)
-        
+
         assert stats is not None
         assert stats.bucket_counts["0.5-0.6"] == 1
         assert stats.bucket_counts["0.6-0.7"] == 1
@@ -55,7 +54,7 @@ class TestCalculateConfidenceStats:
         # All same value - std_dev should be 0
         decisions = [{"confidence": 0.85} for _ in range(10)]
         stats = calculate_confidence_stats(decisions)
-        
+
         assert stats is not None
         assert stats.std_dev == 0.0
 
@@ -67,7 +66,7 @@ class TestCalculateConfidenceStats:
             {"confidence": 1.00},
         ]
         stats = calculate_confidence_stats(decisions)
-        
+
         assert stats is not None
         assert stats.std_dev > 0.15  # Should have significant variance
 
@@ -103,7 +102,7 @@ class TestGenerateVarianceRecommendations:
             },
         )
         recs = generate_variance_recommendations(stats)
-        
+
         assert len(recs) >= 1
         assert any(r.type == "low_variance" for r in recs)
 
@@ -124,7 +123,7 @@ class TestGenerateVarianceRecommendations:
             },
         )
         recs = generate_variance_recommendations(stats)
-        
+
         assert any(r.type == "overconfident_habit" for r in recs)
 
     def test_no_recommendation_good_variance(self) -> None:
@@ -144,7 +143,7 @@ class TestGenerateVarianceRecommendations:
             },
         )
         recs = generate_variance_recommendations(stats)
-        
+
         # Should have no variance warnings
         assert not any(r.type in ("low_variance", "overconfident_habit") for r in recs)
 
@@ -159,7 +158,7 @@ class TestGenerateVarianceRecommendations:
             bucket_counts={"0.8-0.9": 5},
         )
         recs = generate_variance_recommendations(stats)
-        
+
         assert len(recs) == 0  # Not enough data
 
     def test_underconfident_habit(self) -> None:
@@ -179,5 +178,5 @@ class TestGenerateVarianceRecommendations:
             },
         )
         recs = generate_variance_recommendations(stats)
-        
+
         assert any(r.type == "underconfident_habit" for r in recs)

--- a/a2a/cstp/tests/test_drift.py
+++ b/a2a/cstp/tests/test_drift.py
@@ -1,5 +1,4 @@
 """Tests for drift detection service."""
-import pytest
 
 import sys
 from pathlib import Path
@@ -15,7 +14,7 @@ from a2a.cstp.drift_service import (
 
 class MockCalibrationResult:
     """Mock CalibrationResult for testing."""
-    
+
     def __init__(self, brier_score: float, accuracy: float) -> None:
         self.brier_score = brier_score
         self.accuracy = accuracy
@@ -28,7 +27,7 @@ class TestDetectDriftAlerts:
         """Test Brier score degradation is detected."""
         recent = MockCalibrationResult(brier_score=0.15, accuracy=0.85)
         historical = MockCalibrationResult(brier_score=0.08, accuracy=0.88)
-        
+
         alerts = detect_drift_alerts(
             recent=recent,  # type: ignore
             historical=historical,  # type: ignore
@@ -36,7 +35,7 @@ class TestDetectDriftAlerts:
             threshold_accuracy=0.15,
             category=None,
         )
-        
+
         assert len(alerts) >= 1
         brier_alert = next((a for a in alerts if a.type == "brier_degradation"), None)
         assert brier_alert is not None
@@ -48,7 +47,7 @@ class TestDetectDriftAlerts:
         """Test accuracy drop is detected."""
         recent = MockCalibrationResult(brier_score=0.10, accuracy=0.70)
         historical = MockCalibrationResult(brier_score=0.10, accuracy=0.90)
-        
+
         alerts = detect_drift_alerts(
             recent=recent,  # type: ignore
             historical=historical,  # type: ignore
@@ -56,7 +55,7 @@ class TestDetectDriftAlerts:
             threshold_accuracy=0.15,
             category="architecture",
         )
-        
+
         assert len(alerts) >= 1
         accuracy_alert = next((a for a in alerts if a.type == "accuracy_drop"), None)
         assert accuracy_alert is not None
@@ -68,7 +67,7 @@ class TestDetectDriftAlerts:
         """Test no alerts when metrics are stable."""
         recent = MockCalibrationResult(brier_score=0.10, accuracy=0.85)
         historical = MockCalibrationResult(brier_score=0.09, accuracy=0.87)
-        
+
         alerts = detect_drift_alerts(
             recent=recent,  # type: ignore
             historical=historical,  # type: ignore
@@ -76,14 +75,14 @@ class TestDetectDriftAlerts:
             threshold_accuracy=0.15,
             category=None,
         )
-        
+
         assert len(alerts) == 0
 
     def test_no_alerts_when_improving(self) -> None:
         """Test no alerts when calibration is improving."""
         recent = MockCalibrationResult(brier_score=0.05, accuracy=0.95)
         historical = MockCalibrationResult(brier_score=0.10, accuracy=0.85)
-        
+
         alerts = detect_drift_alerts(
             recent=recent,  # type: ignore
             historical=historical,  # type: ignore
@@ -91,14 +90,14 @@ class TestDetectDriftAlerts:
             threshold_accuracy=0.15,
             category=None,
         )
-        
+
         assert len(alerts) == 0
 
     def test_severity_warning_for_moderate_drift(self) -> None:
         """Test warning severity for moderate drift."""
         recent = MockCalibrationResult(brier_score=0.12, accuracy=0.80)
         historical = MockCalibrationResult(brier_score=0.08, accuracy=0.88)
-        
+
         alerts = detect_drift_alerts(
             recent=recent,  # type: ignore
             historical=historical,  # type: ignore
@@ -106,7 +105,7 @@ class TestDetectDriftAlerts:
             threshold_accuracy=0.05,
             category=None,
         )
-        
+
         for alert in alerts:
             assert alert.severity in ("warning", "error")
 
@@ -114,7 +113,7 @@ class TestDetectDriftAlerts:
         """Test no division by zero with zero historical values."""
         recent = MockCalibrationResult(brier_score=0.10, accuracy=0.80)
         historical = MockCalibrationResult(brier_score=0.0, accuracy=0.0)
-        
+
         # Should not raise
         alerts = detect_drift_alerts(
             recent=recent,  # type: ignore
@@ -123,7 +122,7 @@ class TestDetectDriftAlerts:
             threshold_accuracy=0.15,
             category=None,
         )
-        
+
         assert isinstance(alerts, list)
 
 
@@ -143,9 +142,9 @@ class TestGenerateDriftRecommendations:
                 message="Test",
             )
         ]
-        
+
         recs = generate_drift_recommendations(alerts)
-        
+
         assert len(recs) == 1
         assert recs[0]["type"] == "recalibrate"
         assert "confidence" in recs[0]["message"].lower()
@@ -163,9 +162,9 @@ class TestGenerateDriftRecommendations:
                 message="Test",
             )
         ]
-        
+
         recs = generate_drift_recommendations(alerts)
-        
+
         assert len(recs) == 1
         assert recs[0]["type"] == "review_process"
 
@@ -177,9 +176,9 @@ class TestGenerateDriftRecommendations:
             DriftAlert(type="brier_degradation", category="b", recent_value=0.2,
                       historical_value=0.1, change_pct=100, severity="warning", message="2"),
         ]
-        
+
         recs = generate_drift_recommendations(alerts)
-        
+
         # Should only have one recalibrate recommendation
         recalibrate_recs = [r for r in recs if r["type"] == "recalibrate"]
         assert len(recalibrate_recs) == 1
@@ -191,7 +190,7 @@ class TestCheckDriftRequest:
     def test_from_dict_defaults(self) -> None:
         """Test default values."""
         request = CheckDriftRequest.from_dict({})
-        
+
         assert request.threshold_brier == 0.20
         assert request.threshold_accuracy == 0.15
         assert request.category is None
@@ -205,7 +204,7 @@ class TestCheckDriftRequest:
             "category": "architecture",
             "minDecisions": 10,
         })
-        
+
         assert request.threshold_brier == 0.30
         assert request.threshold_accuracy == 0.10
         assert request.category == "architecture"


### PR DESCRIPTION
## Summary

Fix lint errors that broke CI on PRs #17, #18, #19.

## Changes

- `drift_service.py`: Rename `MIN_BRIER_DIFF` → `min_brier_diff` (N806)
- Various files: Remove trailing whitespace (W293)

## Lesson Learned

Always verify CI status (tests AND lint) before merging.