### PR TITLE
fix(dashboard): use absolute imports for gunicorn compatibility

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,14 +1,15 @@
 """CSTP Dashboard Flask application."""
 import asyncio
+import contextlib
 from typing import Any
 
 from flask import Flask, Response, flash, redirect, render_template, request, url_for
 from flask_wtf import CSRFProtect
 from flask_wtf.csrf import CSRFError
 
-from .auth import requires_auth
-from .config import config
-from .cstp_client import CSTPClient, CSTPError
+from auth import requires_auth
+from config import config
+from cstp_client import CSTPClient, CSTPError
 
 # Initialize Flask app
 app = Flask(__name__)
@@ -203,10 +204,8 @@ def calibration() -> str:
     
     # Check for drift (only if not filtering by window)
     if not window:
-        try:
+        with contextlib.suppress(CSTPError):
             drift = run_async(cstp.check_drift(project=project))
-        except CSTPError:
-            pass  # Drift check is optional, don't show error
     
     return render_template(
         "calibration.html",

--- a/dashboard/auth.py
+++ b/dashboard/auth.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from flask import Response, request
 
-from .config import Config
+from config import Config
 
 
 def check_auth(username: str, password: str, config: Config) -> bool:

--- a/dashboard/cstp_client.py
+++ b/dashboard/cstp_client.py
@@ -3,7 +3,7 @@ from typing import Any
 
 import httpx
 
-from .models import CalibrationStats, Decision
+from models import CalibrationStats, Decision
 
 
 class CSTPError(Exception):

--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -217,9 +217,15 @@ class CalibrationStats:
             conf_stats = ConfidenceDistribution.from_dict(cs_data)
         
         return cls(
-            total_decisions=overall.get("total_decisions", overall.get("totalDecisions", 0)),
-            reviewed_decisions=overall.get("reviewed_decisions", overall.get("reviewedDecisions", 0)),
-            brier_score=float(overall.get("brier_score", overall.get("brierScore", 0.0))),
+            total_decisions=overall.get(
+                "total_decisions", overall.get("totalDecisions", 0)
+            ),
+            reviewed_decisions=overall.get(
+                "reviewed_decisions", overall.get("reviewedDecisions", 0)
+            ),
+            brier_score=float(
+                overall.get("brier_score", overall.get("brierScore", 0.0))
+            ),
             accuracy=float(overall.get("accuracy", 0.0)),
             interpretation=overall.get("interpretation", "unknown"),
             by_category=by_category,

--- a/dashboard/tests/test_app.py
+++ b/dashboard/tests/test_app.py
@@ -32,7 +32,9 @@ def test_decisions_requires_auth(client: FlaskClient) -> None:
     assert response.status_code == 401
 
 
-def test_decisions_list(client: FlaskClient, auth_headers: dict[str, str], mock_cstp: AsyncMock) -> None:
+def test_decisions_list(
+    client: FlaskClient, auth_headers: dict[str, str], mock_cstp: AsyncMock
+) -> None:
     """Test decisions list renders."""
     mock_cstp.list_decisions = AsyncMock(return_value=([], 0))
     response = client.get("/decisions", headers=auth_headers)
@@ -40,7 +42,9 @@ def test_decisions_list(client: FlaskClient, auth_headers: dict[str, str], mock_
     assert b"Decisions" in response.data
 
 
-def test_calibration_page(client: FlaskClient, auth_headers: dict[str, str], mock_cstp: AsyncMock) -> None:
+def test_calibration_page(
+    client: FlaskClient, auth_headers: dict[str, str], mock_cstp: AsyncMock
+) -> None:
     """Test calibration page renders with stats."""
     response = client.get("/calibration", headers=auth_headers)
     assert response.status_code == 200

--- a/dashboard/tests/test_cstp_client.py
+++ b/dashboard/tests/test_cstp_client.py
@@ -1,7 +1,7 @@
 """Tests for CSTP client."""
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
-from dashboard.models import CalibrationStats, CategoryStats, Decision, Reason
+from dashboard.models import CalibrationStats, Decision
 
 
 def test_decision_from_dict() -> None:
@@ -38,7 +38,7 @@ def test_decision_outcome_icons() -> None:
         category="test",
         stakes="low",
         confidence=0.5,
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
     )
     
     assert decision.outcome_icon == "⏳"


### PR DESCRIPTION
## Summary

Fixes dashboard container startup failure.

## Problem

Relative imports (`from .auth import`) fail when gunicorn loads `app:app` because the app is not loaded as a package.

## Solution

- Change all relative imports to absolute imports
- `from .auth` → `from auth`
- `from .config` → `from config`
- etc.

## Also Fixed

- Line length issues in models.py and test_app.py
- SIM105: Use contextlib.suppress instead of try/except/pass

## Tested

- `python3 -m py_compile` passes
- `ruff check dashboard/` passes