### PR TITLE
fix(dashboard): handle date field from list mode response

### DIFF
--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -83,17 +83,20 @@ class Decision:
             if len(created_str) == 10:
                 created_at = datetime.fromisoformat(created_str + "T00:00:00+00:00")
             else:
-                created_at = datetime.fromisoformat(
-                    created_str.replace("Z", "+00:00")
-                )
+                # Ensure timezone-aware: replace Z with +00:00, add +00:00 if missing
+                ts = created_str.replace("Z", "+00:00")
+                if "+" not in ts and ts.count("-") <= 2:
+                    ts = ts + "+00:00"
+                created_at = datetime.fromisoformat(ts)
         else:
             created_at = datetime.now(UTC)
         
         reviewed_at: datetime | None = None
         if data.get("reviewed_at"):
-            reviewed_at = datetime.fromisoformat(
-                data["reviewed_at"].replace("Z", "+00:00")
-            )
+            ts = data["reviewed_at"].replace("Z", "+00:00")
+            if "+" not in ts and ts.count("-") <= 2:
+                ts = ts + "+00:00"
+            reviewed_at = datetime.fromisoformat(ts)
         
         return cls(
             id=data["id"],


### PR DESCRIPTION
## Summary

Fixes KeyError when dashboard receives list mode response.

## Problem

Server list mode returns `date` field (YYYY-MM-DD format) but dashboard expected `created_at` (full ISO format).

## Solution

- Accept both `created_at` and `date` field names
- Handle date-only format vs full ISO timestamp
- Default to now() if neither present