### PR TITLE
fix: use Gemini v1 API for text-embedding-004

### DIFF
--- a/a2a/cstp/decision_service.py
+++ b/a2a/cstp/decision_service.py
@@ -367,7 +367,7 @@ async def generate_embedding(text: str) -> list[float] | None:
     if not GEMINI_API_KEY:
         return None
 
-    url = f"https://generativelanguage.googleapis.com/v1beta/models/{EMBEDDING_MODEL}:embedContent"
+    url = f"https://generativelanguage.googleapis.com/v1/models/{EMBEDDING_MODEL}:embedContent"
 
     async with httpx.AsyncClient(timeout=30.0) as client:
         try:

--- a/a2a/cstp/query_service.py
+++ b/a2a/cstp/query_service.py
@@ -129,7 +129,7 @@ async def _generate_embedding(text: str) -> list[float]:
     if len(text) > 8000:
         text = text[:8000]
 
-    url = "https://generativelanguage.googleapis.com/v1beta/models/text-embedding-004:embedContent"
+    url = "https://generativelanguage.googleapis.com/v1/models/text-embedding-004:embedContent"
     headers = {
         "Content-Type": "application/json",
         "x-goog-api-key": api_key,


### PR DESCRIPTION
## Summary

Fixes embedding API error when viewing decision details.

## Problem

`v1beta` API version doesnt support `text-embedding-004` model.

## Solution

Change API endpoint from `v1beta` to `v1` in both:
- decision_service.py
- query_service.py