### PR TITLE
fix: use gemini-embedding-001 model on v1beta API

### DIFF
--- a/a2a/cstp/decision_service.py
+++ b/a2a/cstp/decision_service.py
@@ -21,7 +21,7 @@ CHROMA_COLLECTION = os.getenv("CHROMA_COLLECTION", "decisions_gemini")
 CHROMA_TENANT = os.getenv("CHROMA_TENANT", "default_tenant")
 CHROMA_DATABASE = os.getenv("CHROMA_DATABASE", "default_database")
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "")
-EMBEDDING_MODEL = "text-embedding-004"
+EMBEDDING_MODEL = "gemini-embedding-001"
 
 logger = logging.getLogger(__name__)
 
@@ -367,7 +367,7 @@ async def generate_embedding(text: str) -> list[float] | None:
     if not GEMINI_API_KEY:
         return None
 
-    url = f"https://generativelanguage.googleapis.com/v1/models/{EMBEDDING_MODEL}:embedContent"
+    url = f"https://generativelanguage.googleapis.com/v1beta/models/{EMBEDDING_MODEL}:embedContent"
 
     async with httpx.AsyncClient(timeout=30.0) as client:
         try:

--- a/a2a/cstp/query_service.py
+++ b/a2a/cstp/query_service.py
@@ -129,7 +129,7 @@ async def _generate_embedding(text: str) -> list[float]:
     if len(text) > 8000:
         text = text[:8000]
 
-    url = "https://generativelanguage.googleapis.com/v1/models/text-embedding-004:embedContent"
+    url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-001:embedContent"
     headers = {
         "Content-Type": "application/json",
         "x-goog-api-key": api_key,


### PR DESCRIPTION
## Summary

Fixes embedding API 404 error.

## Root Cause

`text-embedding-004` model doesnt exist. PR #25 was wrong fix.

## Correct Fix

- Model: `gemini-embedding-001` (verified via ListModels API)
- API Version: `v1beta` (only version that supports this model)

## Verification

```bash
curl "https://generativelanguage.googleapis.com/v1beta/models?key=..."
# Returns: models/gemini-embedding-001 with embedContent support
```