### PR TITLE
feat: add cstp.reindex endpoint

### DIFF
--- a/a2a/cstp/dispatcher.py
+++ b/a2a/cstp/dispatcher.py
@@ -44,6 +44,7 @@ from .models import (
     QueryDecisionsResponse,
 )
 from .query_service import query_decisions, load_all_decisions
+from .reindex_service import reindex_decisions
 
 
 # Type alias for method handlers
@@ -473,6 +474,24 @@ def register_methods(dispatcher: CstpDispatcher) -> None:
     dispatcher.register("cstp.getCalibration", _handle_get_calibration)
     dispatcher.register("cstp.attributeOutcomes", _handle_attribute_outcomes)
     dispatcher.register("cstp.checkDrift", _handle_check_drift)
+    dispatcher.register("cstp.reindex", _handle_reindex)
+
+
+async def _handle_reindex(params: dict[str, Any], agent_id: str) -> dict[str, Any]:
+    """Handle cstp.reindex method.
+
+    Reindexes all decisions with fresh embeddings.
+    This will delete and recreate the ChromaDB collection.
+
+    Args:
+        params: JSON-RPC params (unused).
+        agent_id: Authenticated agent ID.
+
+    Returns:
+        Reindex result as dict.
+    """
+    result = await reindex_decisions()
+    return result.to_dict()
 
 
 async def _handle_record_decision(params: dict[str, Any], agent_id: str) -> dict[str, Any]:

--- a/a2a/cstp/reindex_service.py
+++ b/a2a/cstp/reindex_service.py
@@ -1,0 +1,222 @@
+"""Reindex service for CSTP.
+
+Provides functionality to recreate the ChromaDB collection with fresh embeddings.
+"""
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from .query_service import (
+    CHROMA_URL,
+    COLLECTION_NAME,
+    DATABASE,
+    TENANT,
+    _generate_embedding,
+    load_all_decisions,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ReindexResult:
+    """Result of reindex operation."""
+
+    success: bool
+    decisions_indexed: int
+    errors: int
+    duration_ms: int
+    message: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dict for JSON response."""
+        return {
+            "success": self.success,
+            "decisionsIndexed": self.decisions_indexed,
+            "errors": self.errors,
+            "durationMs": self.duration_ms,
+            "message": self.message,
+        }
+
+
+async def _delete_collection() -> bool:
+    """Delete the existing collection if it exists."""
+    base = f"{CHROMA_URL}/api/v2/tenants/{TENANT}/databases/{DATABASE}"
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        # List collections to find our collection
+        resp = await client.get(f"{base}/collections")
+        if resp.status_code != 200:
+            logger.warning("Failed to list collections: %s", resp.text)
+            return False
+
+        collections = resp.json()
+        coll_id = None
+        for c in collections:
+            if c.get("name") == COLLECTION_NAME:
+                coll_id = c["id"]
+                break
+
+        if not coll_id:
+            logger.info("Collection %s does not exist, nothing to delete", COLLECTION_NAME)
+            return True
+
+        # Delete the collection
+        resp = await client.delete(f"{base}/collections/{coll_id}")
+        if resp.status_code not in (200, 204):
+            logger.error("Failed to delete collection: %s", resp.text)
+            return False
+
+        logger.info("Deleted collection %s", COLLECTION_NAME)
+        return True
+
+
+async def _create_collection() -> str | None:
+    """Create a new collection and return its ID."""
+    base = f"{CHROMA_URL}/api/v2/tenants/{TENANT}/databases/{DATABASE}"
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        # Create collection with cosine distance
+        payload = {
+            "name": COLLECTION_NAME,
+            "metadata": {
+                "hnsw:space": "cosine",
+            },
+        }
+        resp = await client.post(f"{base}/collections", json=payload)
+        if resp.status_code not in (200, 201):
+            logger.error("Failed to create collection: %s", resp.text)
+            return None
+
+        data = resp.json()
+        coll_id = data.get("id")
+        logger.info("Created collection %s with id %s", COLLECTION_NAME, coll_id)
+        return coll_id
+
+
+async def _add_to_collection(
+    coll_id: str,
+    doc_id: str,
+    embedding: list[float],
+    metadata: dict[str, Any],
+    document: str,
+) -> bool:
+    """Add a single document to the collection."""
+    base = f"{CHROMA_URL}/api/v2/tenants/{TENANT}/databases/{DATABASE}"
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        payload = {
+            "ids": [doc_id],
+            "embeddings": [embedding],
+            "metadatas": [metadata],
+            "documents": [document],
+        }
+        resp = await client.post(f"{base}/collections/{coll_id}/add", json=payload)
+        if resp.status_code not in (200, 201):
+            logger.error("Failed to add document %s: %s", doc_id, resp.text)
+            return False
+        return True
+
+
+async def reindex_decisions() -> ReindexResult:
+    """Reindex all decisions with fresh embeddings.
+
+    This will:
+    1. Delete the existing collection
+    2. Create a new collection
+    3. Load all decisions from YAML files
+    4. Generate embeddings for each
+    5. Add to the new collection
+
+    Returns:
+        ReindexResult with operation status.
+    """
+    start_time = time.time()
+
+    # Step 1: Delete existing collection
+    if not await _delete_collection():
+        return ReindexResult(
+            success=False,
+            decisions_indexed=0,
+            errors=0,
+            duration_ms=int((time.time() - start_time) * 1000),
+            message="Failed to delete existing collection",
+        )
+
+    # Step 2: Create new collection
+    coll_id = await _create_collection()
+    if not coll_id:
+        return ReindexResult(
+            success=False,
+            decisions_indexed=0,
+            errors=0,
+            duration_ms=int((time.time() - start_time) * 1000),
+            message="Failed to create new collection",
+        )
+
+    # Step 3: Load all decisions
+    decisions = await load_all_decisions()
+    if not decisions:
+        return ReindexResult(
+            success=True,
+            decisions_indexed=0,
+            errors=0,
+            duration_ms=int((time.time() - start_time) * 1000),
+            message="No decisions found to index",
+        )
+
+    # Step 4 & 5: Generate embeddings and add to collection
+    indexed = 0
+    errors = 0
+
+    for decision in decisions:
+        doc_id = decision.get("id", "")
+        if not doc_id:
+            errors += 1
+            continue
+
+        # Build text for embedding
+        summary = decision.get("summary", decision.get("decision", ""))
+        context = decision.get("context", "")
+        category = decision.get("category", "")
+
+        text = f"{summary}\n{context}\nCategory: {category}"
+
+        try:
+            embedding = await _generate_embedding(text)
+        except Exception as e:
+            logger.error("Failed to generate embedding for %s: %s", doc_id, e)
+            errors += 1
+            continue
+
+        # Build metadata
+        metadata = {
+            "category": decision.get("category", ""),
+            "stakes": decision.get("stakes", ""),
+            "confidence": float(decision.get("confidence", 0.5)),
+            "status": decision.get("status", "pending"),
+            "created_at": decision.get("created_at", ""),
+        }
+
+        # Filter None values (ChromaDB doesn't like them)
+        metadata = {k: v for k, v in metadata.items() if v is not None and v != ""}
+
+        # Add to collection
+        if await _add_to_collection(coll_id, doc_id, embedding, metadata, text):
+            indexed += 1
+        else:
+            errors += 1
+
+    duration_ms = int((time.time() - start_time) * 1000)
+
+    return ReindexResult(
+        success=True,
+        decisions_indexed=indexed,
+        errors=errors,
+        duration_ms=duration_ms,
+        message=f"Indexed {indexed} decisions with {errors} errors in {duration_ms}ms",
+    )


### PR DESCRIPTION
## Summary

Adds `cstp.reindex` endpoint to rebuild ChromaDB collection with fresh embeddings.

## Problem

Embedding dimension mismatch: collection has 768-dim embeddings but new model produces 3072-dim.

## Solution

New endpoint that:
1. Deletes existing collection
2. Creates new collection
3. Loads all decisions from YAML
4. Generates embeddings with current model
5. Adds to new collection

## Usage

```json
{"jsonrpc":"2.0","method":"cstp.reindex","params":{},"id":1}
```

## Response

```json
{"success": true, "decisionsIndexed": 50, "errors": 0, "durationMs": 5000}
```