### PR TITLE
fix: extract title from decision/summary and date from timestamp

### DIFF
--- a/a2a/cstp/reindex_service.py
+++ b/a2a/cstp/reindex_service.py
@@ -269,7 +269,20 @@ async def reindex_decisions() -> ReindexResult:
             continue
 
         # Build metadata
+        # Extract title from title, decision, or summary fields (fallback chain)
+        title = (
+            decision.get("title")
+            or decision.get("decision")
+            or decision.get("summary")
+            or ""
+        )
+        # Extract date from date or timestamp fields (YYYY-MM-DD format)
+        date_raw = decision.get("date") or decision.get("timestamp") or ""
+        date_str = str(date_raw)[:10] if date_raw else ""
+
         metadata = {
+            "title": title[:500] if title else "",
+            "date": date_str,
             "category": decision.get("category", ""),
             "stakes": decision.get("stakes", ""),
             "confidence": float(decision.get("confidence", 0.5)),


### PR DESCRIPTION
## Summary

Fixes #31 - CSTP query was returning `Untitled` and empty date for all decisions.

## Root Cause

The `reindex_service.py` metadata extraction only looked for `title` and `date` fields, but decision YAMLs use:
- `decision` or `summary` for the title
- `timestamp` for the date

## Changes

- Add fallback chain: `title` ← `decision` ← `summary`
- Add fallback: `date` ← `timestamp` (extract YYYY-MM-DD)
- Truncate title to 500 chars for ChromaDB metadata limit

## Testing

After deploying, run `cstp.reindex` and verify `queryDecisions` returns proper titles and dates.

---

*⚡ Emerson*