### PR TITLE
docs: update ProductDocumentation to v0.9.0 with MCP integration

### DIFF
--- a/ProductDocumentation/02-Architecture.md
+++ b/ProductDocumentation/02-Architecture.md
@@ -2,90 +2,109 @@
 
 ## High-Level Architecture
 
-```
-┌─────────────────────────────────────────────────────────────────────┐
-│                         AI AGENTS                                   │
-│        (LangChain, AutoGen, CrewAI, Custom Python Agents)           │
-└──────────────┬────────────────────────────────────┬─────────────────┘
-               │  JSON-RPC 2.0 over HTTP            │  CLI
-               │  (Bearer Token Auth)                │
-               ▼                                     ▼
-┌──────────────────────────────────┐    ┌────────────────────────────┐
-│          A2A LAYER               │    │        CLI LAYER           │
-│   ┌─────────────────────────┐    │    │   bin/cognition            │
-│   │   FastAPI Server        │    │    │   ├── index <dir>          │
-│   │   (a2a/server.py)       │    │    │   ├── query <context>      │
-│   │   ├── POST /cstp        │    │    │   ├── check --stakes high  │
-│   │   ├── GET  /health      │    │    │   ├── patterns calibration │
-│   │   └── GET  /.well-known │    │    │   ├── guardrails           │
-│   │          /agent.json    │    │    │   └── count                │
-│   └────────────┬────────────┘    │    └────────────────────────────┘
-│                │                 │
-│   ┌────────────▼────────────┐    │
-│   │  CSTP Dispatcher        │    │    ┌────────────────────────────┐
-│   │  (a2a/cstp/dispatcher)  │    │    │      WEB DASHBOARD         │
-│   │                         │    │    │  (dashboard/app.py)        │
-│   │  Methods:               │    │    │  Flask + Jinja2            │
-│   │  ├── queryDecisions     │    │    │  ├── /decisions            │
-│   │  ├── checkGuardrails    │    │    │  ├── /decisions/<id>       │
-│   │  ├── listGuardrails     │    │    │  ├── /decisions/<id>/review│
-│   │  ├── recordDecision     │    │    │  ├── /calibration          │
-│   │  ├── reviewDecision     │    │    │  └── /health               │
-│   │  ├── getCalibration     │    │    └────────────────────────────┘
-│   │  ├── attributeOutcomes  │    │
-│   │  ├── checkDrift         │    │
-│   │  └── reindex            │    │
-│   └────────────┬────────────┘    │
-└────────────────┼─────────────────┘
-                 │
-    ┌────────────▼──────────────────────────────────────────┐
-    │                    CSTP SERVICES                       │
-    │  ┌──────────────┐  ┌───────────────┐  ┌────────────┐  │
-    │  │query_service  │  │decision_svc   │  │calibration │  │
-    │  │(semantic +    │  │(record + YAML │  │_service    │  │
-    │  │ BM25 hybrid)  │  │ + ChromaDB)   │  │(Brier +    │  │
-    │  └──────────────┘  └───────────────┘  │ buckets)   │  │
-    │  ┌──────────────┐  ┌───────────────┐  └────────────┘  │
-    │  │guardrails_svc│  │attribution    │  ┌────────────┐  │
-    │  │(YAML-based   │  │_service       │  │drift_svc   │  │
-    │  │ evaluation)  │  │(PR stability) │  │(30d vs 90d)│  │
-    │  └──────────────┘  └───────────────┘  └────────────┘  │
-    │  ┌──────────────┐  ┌───────────────┐                  │
-    │  │reindex_svc   │  │bm25_index     │                  │
-    │  │(full rebuild)│  │(keyword search│                  │
-    │  └──────────────┘  └───────────────┘                  │
-    └───────────────────────┬───────────────────────────────┘
-                            │
-    ┌───────────────────────▼───────────────────────────────┐
-    │                  CORE ENGINES                          │
-    │  (src/cognition_engines/)                              │
-    │                                                        │
-    │  ┌─────────────────────────────────────────────────┐   │
-    │  │ ACCELERATORS                                     │   │
-    │  │ ├── SemanticIndex (ChromaDB + Gemini embeddings) │   │
-    │  │ └── PatternDetector (calibration, anti-patterns) │   │
-    │  └─────────────────────────────────────────────────┘   │
-    │  ┌─────────────────────────────────────────────────┐   │
-    │  │ GUARDRAILS                                       │   │
-    │  │ ├── GuardrailEngine (YAML loader + evaluator)    │   │
-    │  │ ├── Evaluators (field, semantic, temporal,        │   │
-    │  │ │               aggregate, compound)              │   │
-    │  │ └── AuditLog (JSON-based audit trail)             │   │
-    │  └─────────────────────────────────────────────────┘   │
-    └───────────────────────┬───────────────────────────────┘
-                            │
-    ┌───────────────────────▼───────────────────────────────┐
-    │                  STORAGE LAYER                         │
-    │  ┌────────────────┐  ┌─────────────────────────────┐   │
-    │  │   ChromaDB     │  │   YAML Decision Files       │   │
-    │  │   (vectors +   │  │   decisions/YYYY/MM/         │   │
-    │  │    metadata)   │  │   YYYY-MM-DD-decision-*.yaml │   │
-    │  └────────────────┘  └─────────────────────────────┘   │
-    │  ┌────────────────┐  ┌─────────────────────────────┐   │
-    │  │  Guardrail     │  │   Audit Trail               │   │
-    │  │  YAML Files    │  │   audit/*.json               │   │
-    │  └────────────────┘  └─────────────────────────────┘   │
-    └───────────────────────────────────────────────────────┘
+```mermaid
+graph TB
+    subgraph Agents["AI AGENTS"]
+        direction LR
+        LC["LangChain"]
+        AG["AutoGen"]
+        CR["CrewAI"]
+        CD["Claude Desktop"]
+        OC["OpenClaw"]
+        CP["Custom Python"]
+    end
+
+    subgraph A2A["A2A LAYER"]
+        direction TB
+        FS["FastAPI Server<br/>(a2a/server.py)"]
+        CSTP_EP["POST /cstp<br/>JSON-RPC 2.0"]
+        MCP_EP["POST|GET /mcp<br/>Streamable HTTP"]
+        HEALTH["GET /health"]
+        AGENT_CARD["GET /.well-known/agent.json"]
+        FS --- CSTP_EP
+        FS --- MCP_EP
+        FS --- HEALTH
+        FS --- AGENT_CARD
+    end
+
+    subgraph MCP_LAYER["MCP LAYER"]
+        direction TB
+        MCP_SRV["MCP Server<br/>(a2a/mcp_server.py)"]
+        MCP_SCH["MCP Schemas<br/>(a2a/mcp_schemas.py)"]
+        STDIO["stdio transport<br/>python -m a2a.mcp_server"]
+        SHTTP["StreamableHTTPSessionManager"]
+        MCP_SRV --- MCP_SCH
+        MCP_EP --> SHTTP --> MCP_SRV
+        STDIO --> MCP_SRV
+    end
+
+    subgraph DISPATCH["CSTP DISPATCHER"]
+        direction TB
+        DISP["dispatcher.py"]
+        QD["queryDecisions"]
+        CG["checkGuardrails"]
+        LG["listGuardrails"]
+        RD["recordDecision"]
+        RV["reviewDecision"]
+        GC["getCalibration"]
+        AO["attributeOutcomes"]
+        CDR["checkDrift"]
+        RI["reindex"]
+        DISP --- QD & CG & LG & RD & RV & GC & AO & CDR & RI
+    end
+
+    subgraph CLI_LAYER["CLI LAYER"]
+        direction TB
+        CLI["bin/cognition"]
+        CLI_INDEX["index <dir>"]
+        CLI_QUERY["query <context>"]
+        CLI_CHECK["check --stakes"]
+        CLI --- CLI_INDEX & CLI_QUERY & CLI_CHECK
+    end
+
+    subgraph DASHBOARD["WEB DASHBOARD"]
+        FLASK["Flask + Jinja2<br/>(dashboard/app.py)"]
+    end
+
+    subgraph SERVICES["CSTP SERVICES"]
+        direction TB
+        QS["query_service<br/>(semantic + BM25 hybrid)"]
+        DS["decision_service<br/>(record + YAML + ChromaDB)"]
+        CS["calibration_service<br/>(Brier + buckets)"]
+        GS["guardrails_service<br/>(YAML-based evaluation)"]
+        AS["attribution_service<br/>(PR stability)"]
+        DRS["drift_service<br/>(30d vs 90d)"]
+        RS["reindex_service<br/>(full rebuild)"]
+        BM["bm25_index<br/>(keyword search)"]
+    end
+
+    subgraph CORE["CORE ENGINES (src/cognition_engines/)"]
+        direction TB
+        SI["SemanticIndex<br/>(ChromaDB + Gemini)"]
+        PD["PatternDetector<br/>(calibration, anti-patterns)"]
+        GE["GuardrailEngine<br/>(YAML loader + evaluator)"]
+        AL["AuditLog<br/>(JSON audit trail)"]
+    end
+
+    subgraph STORAGE["STORAGE LAYER"]
+        direction LR
+        CHROMA["ChromaDB<br/>(vectors + metadata)"]
+        YAML["YAML Decision Files<br/>decisions/YYYY/MM/"]
+        GUARD["Guardrail YAML Files"]
+        AUDIT["Audit Trail<br/>audit/*.json"]
+    end
+
+    Agents -->|"JSON-RPC 2.0 / Bearer Token"| CSTP_EP
+    Agents -->|"MCP / Streamable HTTP"| MCP_EP
+    Agents -->|"MCP / stdio"| STDIO
+    CLI_LAYER -->|"direct import"| CORE
+    DASHBOARD -->|"HTTP client"| CSTP_EP
+    CSTP_EP --> DISP
+    MCP_SRV -->|"direct function calls"| SERVICES
+    DISP --> SERVICES
+    SERVICES --> CORE
+    CORE --> STORAGE
+end
 ```
 
 ---
@@ -98,14 +117,17 @@ The **Agent-to-Agent** layer is the network-facing surface of Cognition Engines.
 
 | File | Purpose |
 |------|---------|
-| `server.py` | FastAPI application with lifespan management, CORS, and route registration |
+| `server.py` | FastAPI application with lifespan management, CORS, route registration, and MCP mount at `/mcp` |
 | `config.py` | Multi-source configuration: YAML file → environment variables → defaults |
 | `auth.py` | Bearer token authentication with constant-time comparison (`secrets.compare_digest`) |
+| `mcp_server.py` | MCP Server with 5 tool handlers; exposes `mcp_app` Server instance for mounting |
+| `mcp_schemas.py` | Pydantic input schemas for MCP tool definitions (auto-generates JSON Schema for tool discovery) |
 | `__init__.py` | Package exports |
 
 **Endpoints:**
 
 - `POST /cstp` — JSON-RPC 2.0 dispatch (authenticated)
+- `POST|GET /mcp` — MCP Streamable HTTP transport (tool calls + event streams)
 - `GET /health` — Health check with uptime (unauthenticated)
 - `GET /.well-known/agent.json` — A2A agent card for discovery (unauthenticated)
 
@@ -117,9 +139,10 @@ Each JSON-RPC method is backed by a dedicated service module:
 |---------|--------|-------------|
 | `query_service.py` | `cstp.queryDecisions` | Semantic search over ChromaDB with optional BM25 hybrid |
 | `decision_service.py` | `cstp.recordDecision` | Record new decisions as YAML + ChromaDB index |
+| `decision_service.py` | `cstp.reviewDecision` | Record outcome of a past decision for calibration |
 | `guardrails_service.py` | `cstp.checkGuardrails` | Evaluate context against all loaded guardrails |
 | `guardrails_service.py` | `cstp.listGuardrails` | List active guardrail definitions |
-| `calibration_service.py` | `cstp.getCalibration` | Compute Brier scores and confidence buckets |
+| `calibration_service.py` | `cstp.getCalibration` | Compute Brier scores, confidence buckets, and variance |
 | `attribution_service.py` | `cstp.attributeOutcomes` | Auto-attribute outcomes via PR stability |
 | `drift_service.py` | `cstp.checkDrift` | Compare 30-day vs. 90-day+ calibration |
 | `reindex_service.py` | `cstp.reindex` | Delete and rebuild ChromaDB collection |
@@ -127,7 +150,34 @@ Each JSON-RPC method is backed by a dedicated service module:
 | `models.py` | (shared) | Pydantic-style dataclasses for request/response objects |
 | `bm25_index.py` | (internal) | BM25Okapi keyword index with caching and score merging |
 
-### 3. Core Engines (`src/cognition_engines/`)
+### 3. MCP Layer (`a2a/mcp_server.py` + `a2a/mcp_schemas.py`)
+
+The MCP layer provides **Model Context Protocol** access to CSTP capabilities. It is a thin bridge — Pydantic schemas validate inputs, then tool handlers delegate directly to CSTP service functions.
+
+| Component | File | Description |
+|-----------|------|-------------|
+| `mcp_app` | `mcp_server.py` | `Server("cstp-decisions")` instance — importable for ASGI mounting |
+| `list_tools()` | `mcp_server.py` | Returns 5 `Tool` definitions with JSON Schema from Pydantic models |
+| `call_tool()` | `mcp_server.py` | Dispatches tool calls to `_handle_*` functions |
+| `run_stdio()` | `mcp_server.py` | Runs the MCP server with stdio transport |
+| `StreamableHTTPSessionManager` | `server.py` | Manages Streamable HTTP sessions; mounted at `/mcp` via lifespan |
+| `QueryDecisionsInput` | `mcp_schemas.py` | Schema for `query_decisions` tool |
+| `CheckActionInput` | `mcp_schemas.py` | Schema for `check_action` tool |
+| `LogDecisionInput` | `mcp_schemas.py` | Schema for `log_decision` tool |
+| `ReviewOutcomeInput` | `mcp_schemas.py` | Schema for `review_outcome` tool |
+| `GetStatsInput` | `mcp_schemas.py` | Schema for `get_stats` tool |
+
+**MCP tools → CSTP method mapping:**
+
+| MCP Tool | CSTP Method | Service |
+|----------|-------------|---------|
+| `query_decisions` | `cstp.queryDecisions` | `query_service.py` |
+| `check_action` | `cstp.checkGuardrails` | `guardrails_service.py` |
+| `log_decision` | `cstp.recordDecision` | `decision_service.py` |
+| `review_outcome` | `cstp.reviewDecision` | `decision_service.py` |
+| `get_stats` | `cstp.getCalibration` | `calibration_service.py` |
+
+### 4. Core Engines (`src/cognition_engines/`)
 
 The library-level logic, usable independently of the HTTP server.
 
@@ -162,7 +212,7 @@ The library-level logic, usable independently of the HTTP server.
 | `CalibrationBucket` | `detector.py` | Confidence bucket with Brier score computation |
 | `AntiPattern` | `detector.py` | Detected anti-pattern (e.g., overcalibration, flip-flopping) |
 
-### 4. Web Dashboard (`dashboard/`)
+### 5. Web Dashboard (`dashboard/`)
 
 A Flask-based web UI for human-friendly decision browsing and outcome review.
 
@@ -176,7 +226,7 @@ A Flask-based web UI for human-friendly decision browsing and outcome review.
 | `templates/` | Jinja2 HTML templates (base, decisions, decision, review, calibration) |
 | `static/` | CSS/JS assets |
 
-### 5. Guardrail Definitions (`guardrails/`)
+### 6. Guardrail Definitions (`guardrails/`)
 
 | File | Description |
 |------|-------------|
@@ -184,7 +234,7 @@ A Flask-based web UI for human-friendly decision browsing and outcome review.
 | `templates/financial.yaml` | Template for financial/trading projects (risk assessment, position limits, audit trail) |
 | `templates/production-safety.yaml` | Template for production deployments (code review, CI, rollback, no-Friday deploys) |
 
-### 6. CLI (`bin/cognition`)
+### 7. CLI (`bin/cognition`)
 
 A standalone Python CLI providing all core operations without the HTTP server.
 
@@ -194,64 +244,133 @@ A standalone Python CLI providing all core operations without the HTTP server.
 
 ### Query Flow
 
-```
-Agent → POST /cstp → Dispatcher → query_service
-                                      ├── Generate embedding (Gemini API)
-                                      ├── Query ChromaDB (semantic)
-                                      ├── Optionally build BM25 index (keyword)
-                                      ├── Merge and rank results
-                                      └── Return JSON-RPC response
+```mermaid
+sequenceDiagram
+    participant Agent
+    participant FastAPI as POST /cstp
+    participant Dispatcher
+    participant QuerySvc as query_service
+    participant Gemini as Gemini API
+    participant Chroma as ChromaDB
+    participant BM25 as BM25 Index
+
+    Agent->>FastAPI: JSON-RPC queryDecisions
+    FastAPI->>Dispatcher: dispatch
+    Dispatcher->>QuerySvc: query_decisions()
+    QuerySvc->>Gemini: generate embedding
+    Gemini-->>QuerySvc: 768-dim vector
+    QuerySvc->>Chroma: semantic search
+    Chroma-->>QuerySvc: ranked results
+    opt hybrid mode
+        QuerySvc->>BM25: keyword search
+        BM25-->>QuerySvc: BM25 scores
+        QuerySvc->>QuerySvc: merge & rank
+    end
+    QuerySvc-->>Agent: JSON-RPC response
 ```
 
 ### Record Flow
 
+```mermaid
+sequenceDiagram
+    participant Agent
+    participant FastAPI as POST /cstp
+    participant Dispatcher
+    participant DecSvc as decision_service
+    participant Guard as guardrails_service
+    participant Gemini as Gemini API
+    participant Chroma as ChromaDB
+    participant Disk as YAML File
+
+    Agent->>FastAPI: JSON-RPC recordDecision
+    FastAPI->>Dispatcher: dispatch
+    Dispatcher->>DecSvc: record_decision()
+    DecSvc->>Guard: check guardrails
+    Guard-->>DecSvc: pass/fail
+    DecSvc->>DecSvc: build YAML structure
+    DecSvc->>Disk: write YAML file
+    DecSvc->>Gemini: generate embedding
+    Gemini-->>DecSvc: 768-dim vector
+    DecSvc->>Chroma: index decision
+    DecSvc-->>Agent: decision ID + path
 ```
-Agent → POST /cstp → Dispatcher → decision_service
-                                      ├── Validate request
-                                      ├── Check guardrails (pre-decision protocol)
-                                      ├── Build YAML structure
-                                      ├── Write YAML file to disk
-                                      ├── Generate embedding (Gemini API)
-                                      ├── Index in ChromaDB
-                                      └── Return decision ID + path
+
+### MCP Data Flow
+
+```mermaid
+sequenceDiagram
+    participant Client as MCP Client
+    participant Transport as Transport Layer
+    participant MCPSrv as MCP Server (mcp_app)
+    participant Services as CSTP Services
+    participant Storage as ChromaDB + YAML
+
+    alt Streamable HTTP
+        Client->>Transport: POST /mcp (HTTP)
+        Transport->>MCPSrv: StreamableHTTPSessionManager
+    else stdio
+        Client->>Transport: stdin/stdout
+        Transport->>MCPSrv: stdio_server
+    end
+
+    MCPSrv->>MCPSrv: validate via Pydantic schemas
+    MCPSrv->>Services: direct function call
+    Services->>Storage: read/write
+    Storage-->>Services: result
+    Services-->>MCPSrv: response dict
+    MCPSrv-->>Client: TextContent (JSON)
 ```
 
 ### Guardrail Flow
 
-```
-Agent → POST /cstp → Dispatcher → guardrails_service
-                                      ├── Load guardrails from YAML (cached 5 min)
-                                      ├── Match conditions against context
-                                      ├── Evaluate requirements
-                                      ├── Collect violations + warnings
-                                      ├── Log audit trail
-                                      └── Return allowed/blocked + details
+```mermaid
+sequenceDiagram
+    participant Agent
+    participant FastAPI as POST /cstp
+    participant Dispatcher
+    participant GuardSvc as guardrails_service
+    participant Engine as GuardrailEngine
+    participant Audit as AuditLog
+
+    Agent->>FastAPI: JSON-RPC checkGuardrails
+    FastAPI->>Dispatcher: dispatch
+    Dispatcher->>GuardSvc: evaluate_guardrails()
+    GuardSvc->>Engine: load YAML (cached 5 min)
+    Engine->>Engine: match conditions
+    Engine->>Engine: evaluate requirements
+    Engine-->>GuardSvc: violations + warnings
+    GuardSvc->>Audit: log audit trail
+    GuardSvc-->>Agent: allowed/blocked + details
 ```
 
 ---
 
 ## Deployment Architecture
 
-```
-┌────────────────────────────────────────────────────────────┐
-│                   Docker Compose                            │
-│                                                             │
-│  ┌──────────────────┐         ┌─────────────────────┐      │
-│  │   cstp-server     │         │     chromadb         │      │
-│  │   (Python 3.11)   │ ──────▶ │   (chromadb/chroma)  │      │
-│  │   Port: 8100      │  HTTP   │   Port: 8000         │      │
-│  │                    │         │                      │      │
-│  │   Volumes:         │         │   Volume:            │      │
-│  │   ├── config/ (ro) │         │   └── chroma_data    │      │
-│  │   ├── guardrails/  │         │                      │      │
-│  │   └── decisions/   │         │   Health:            │      │
-│  │                    │         │   /api/v1/heartbeat   │      │
-│  │   Health:          │         └─────────────────────┘      │
-│  │   /health          │                                      │
-│  └──────────────────┘                                       │
-│                                                             │
-│  Network: cstp-network (bridge)                             │
-└────────────────────────────────────────────────────────────┘
+```mermaid
+graph TB
+    subgraph Docker["Docker Compose"]
+        subgraph CSTP["cstp-server (Python 3.11)"]
+            PORT_8100["Port: 8100"]
+            EP_CSTP["/cstp — JSON-RPC 2.0"]
+            EP_MCP["/mcp — MCP Streamable HTTP"]
+            EP_HEALTH["/health"]
+            VOL_CONFIG["config/ (ro)"]
+            VOL_GUARD["guardrails/"]
+            VOL_DEC["decisions/"]
+        end
+
+        subgraph CHROMA["chromadb (chromadb/chroma)"]
+            PORT_8000["Port: 8000"]
+            VOL_CHROMA["chroma_data"]
+            HB["/api/v1/heartbeat"]
+        end
+
+        CSTP -->|HTTP| CHROMA
+    end
+
+    NET["Network: cstp-network (bridge)"]
+    Docker --- NET
 ```
 
 **Docker Image:** Multi-stage build (`python:3.11-slim`)
@@ -259,6 +378,7 @@ Agent → POST /cstp → Dispatcher → guardrails_service
 - **Builder stage:** Installs `uv` and Python dependencies from `pyproject.toml`
 - **Runtime stage:** Copies installed packages, app code, creates non-root user
 - **Security:** Runs as `appuser` (non-root), read-only config mounts
+- **MCP:** Both `/cstp` (JSON-RPC) and `/mcp` (MCP Streamable HTTP) are served on port 8100
 
 ---
 
@@ -269,6 +389,7 @@ Agent → POST /cstp → Dispatcher → guardrails_service
 | **Transport** | HTTPS (reverse proxy recommended for production) |
 | **Authentication** | Bearer token per agent, validated with `secrets.compare_digest` |
 | **Authorization** | Agent ID embedded in each request; audit trail records who did what |
+| **MCP Auth** | MCP Streamable HTTP inherits FastAPI bearer token middleware |
 | **Secrets** | Environment variables or `${VAR}` expansion in YAML config |
 | **Container** | Non-root user, minimal base image, no-cache pip installs |
 | **CORS** | Configurable allowed origins (defaults to `*`) |

--- a/ProductDocumentation/06-Installation-Guide.md
+++ b/ProductDocumentation/06-Installation-Guide.md
@@ -143,15 +143,19 @@ source .venv/bin/activate
 # Install with pip (including A2A server dependencies)
 python -m pip install -e ".[a2a,dev]"
 
+# Install with MCP support
+python -m pip install -e ".[a2a,mcp,dev]"
+
 # Or with uv (faster)
 pip install uv
-uv pip install -e ".[a2a,dev]"
+uv pip install -e ".[a2a,mcp,dev]"
 ```
 
 **Dependency groups:**
 
 - **Core:** `pyyaml`, `chromadb`, `rank-bm25`
 - **`[a2a]`:** `fastapi`, `uvicorn`, `httpx`, `python-multipart`
+- **`[mcp]`:** `mcp` (Model Context Protocol SDK)
 - **`[dev]`:** `pytest`, `pytest-asyncio`, `pytest-cov`, `mypy`, `ruff`
 
 ### Step 3: Start ChromaDB
@@ -287,6 +291,55 @@ cp -r skills/openclaw/cognition_skill.py /path/to/openclaw/skills/
 ```
 
 The skill provides `query_decisions` and `check_guardrails` tools to any OpenClaw agent.
+
+---
+
+## Method 5: MCP Quick Start
+
+Connect any MCP-compliant agent to CSTP decision intelligence. The MCP server exposes 5 tools (`query_decisions`, `check_action`, `log_decision`, `review_outcome`, `get_stats`) via two transports.
+
+### Streamable HTTP (Remote)
+
+The CSTP server exposes MCP at `/mcp` on the same port (8100):
+
+```bash
+# Claude Code
+claude mcp add --transport http cstp-decisions http://your-server:8100/mcp
+
+# Any MCP client — point to:
+http://your-server:8100/mcp
+```
+
+### stdio (Local / Docker)
+
+```bash
+# Via Docker (recommended — container has all deps)
+docker exec -i cstp python -m a2a.mcp_server
+
+# Local development
+pip install -e ".[mcp]"
+export CHROMA_URL=http://localhost:8000
+export GEMINI_API_KEY=your-key
+python -m a2a.mcp_server
+```
+
+### Claude Desktop
+
+Add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "cstp": {
+      "command": "docker",
+      "args": ["exec", "-i", "cstp", "python", "-m", "a2a.mcp_server"],
+      "env": {}
+    }
+  }
+}
+```
+
+> See [MCP Integration Guide](10-MCP-Integration.md) for full details, schemas, and examples.
 
 ---
 

--- a/ProductDocumentation/07-Configuration-Guide.md
+++ b/ProductDocumentation/07-Configuration-Guide.md
@@ -47,7 +47,7 @@ Cognition Engines supports configuration through three sources (in order of prec
 |----------|---------|-------------|
 | `CSTP_AGENT_NAME` | `cognition-engines` | Agent name in discovery card |
 | `CSTP_AGENT_DESCRIPTION` | `Decision Intelligence Service` | Agent description |
-| `CSTP_AGENT_VERSION` | `0.7.0` | Reported version |
+| `CSTP_AGENT_VERSION` | `0.9.0` | Reported version |
 | `CSTP_AGENT_URL` | — | Public URL for agent card |
 | `CSTP_AGENT_CONTACT` | — | Contact email |
 
@@ -70,7 +70,7 @@ cors_origins:
 agent:
   name: cognition-engines
   description: Decision Intelligence Service - Semantic search and guardrail evaluation
-  version: 0.7.0
+  version: 0.9.0
   url: https://your-domain.com
   contact: admin@your-domain.com
 
@@ -139,6 +139,12 @@ auth:
 ```
 
 > **Warning:** Never disable auth in production.
+
+### MCP Authentication
+
+The MCP Streamable HTTP transport at `/mcp` inherits authentication from the FastAPI bearer token middleware. The same `CSTP_AUTH_TOKENS` configuration applies to both the JSON-RPC `/cstp` endpoint and the MCP `/mcp` endpoint.
+
+The stdio transport (`python -m a2a.mcp_server`) does not use bearer tokens — it relies on the process-level security of the hosting environment (e.g., Docker container isolation).
 
 ---
 

--- a/ProductDocumentation/10-MCP-Integration.md
+++ b/ProductDocumentation/10-MCP-Integration.md
@@ -1,0 +1,366 @@
+# MCP Integration Guide
+
+> **Since:** v0.9.0  
+> **Protocol:** [Model Context Protocol](https://modelcontextprotocol.io/) (MCP)
+
+This guide covers connecting MCP-compliant agents to CSTP decision intelligence. The MCP layer exposes the same capabilities as the JSON-RPC API through a standardized tool interface.
+
+---
+
+## Architecture
+
+The MCP server is a **thin bridge** over the existing CSTP dispatcher. Each MCP tool maps 1:1 to a CSTP service method — there is zero business logic duplication.
+
+```mermaid
+graph TB
+    subgraph Clients["MCP Clients"]
+        CC["Claude Code"]
+        CD["Claude Desktop"]
+        OC["OpenClaw"]
+        GEN["Generic MCP Client"]
+    end
+
+    subgraph Transport["Transport Layer"]
+        HTTP["Streamable HTTP<br/>POST/GET :8100/mcp"]
+        STDIO["stdio<br/>python -m a2a.mcp_server"]
+    end
+
+    subgraph MCP["MCP Server"]
+        APP["mcp_app<br/>Server('cstp-decisions')"]
+        SCHEMAS["Pydantic Schemas<br/>(mcp_schemas.py)"]
+        TOOLS["5 Tool Handlers"]
+    end
+
+    subgraph Services["CSTP Services"]
+        QS["query_service"]
+        GS["guardrails_service"]
+        DS["decision_service"]
+        CS["calibration_service"]
+    end
+
+    subgraph Storage["Storage"]
+        CHROMA["ChromaDB"]
+        YAML["YAML Files"]
+    end
+
+    Clients -->|"Streamable HTTP"| HTTP
+    Clients -->|"stdio"| STDIO
+    HTTP --> APP
+    STDIO --> APP
+    APP --> SCHEMAS
+    APP --> TOOLS
+    TOOLS -->|"direct function calls"| Services
+    Services --> Storage
+```
+
+Key design principles:
+
+- **Bridge pattern** — MCP tools validate inputs via Pydantic, then delegate to CSTP services
+- **Shared server instance** — Both stdio and Streamable HTTP use the same `mcp_app` and tool handlers
+- **Zero duplication** — No business logic in the MCP layer; all logic lives in CSTP services
+
+---
+
+## Connection Methods
+
+### Streamable HTTP (Remote)
+
+The CSTP FastAPI server mounts the MCP handler at `/mcp` on port 8100. The endpoint handles both `POST` (tool calls) and `GET` (event streams) on the same path.
+
+```
+http://your-server:8100/mcp
+```
+
+**Requirements:** The CSTP server must be running (Docker or local).
+
+### stdio (Local / Docker)
+
+The MCP server can run as a standalone process communicating over stdin/stdout:
+
+```bash
+# Direct (requires Python env with dependencies)
+python -m a2a.mcp_server
+
+# Via Docker (recommended)
+docker exec -i cstp python -m a2a.mcp_server
+```
+
+**Requirements:** The container/environment must have `CHROMA_URL`, `GEMINI_API_KEY`, and `DECISIONS_PATH` configured.
+
+---
+
+## Client Setup
+
+### Claude Code
+
+```bash
+claude mcp add --transport http cstp-decisions http://your-server:8100/mcp
+```
+
+After adding, CSTP tools appear in Claude Code's tool list automatically.
+
+### Claude Desktop
+
+Add to your Claude Desktop configuration file (`claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "cstp": {
+      "command": "docker",
+      "args": ["exec", "-i", "cstp", "python", "-m", "a2a.mcp_server"],
+      "env": {}
+    }
+  }
+}
+```
+
+> **Note:** The CSTP container must be running. The MCP server inherits all environment variables (`CHROMA_URL`, `GEMINI_API_KEY`, etc.) from the container.
+
+### OpenClaw
+
+Point OpenClaw's MCP client configuration to the Streamable HTTP endpoint:
+
+```
+http://your-server:8100/mcp
+```
+
+Or configure stdio transport to launch the MCP server process directly.
+
+### Generic MCP Client
+
+Any client implementing the [MCP specification](https://modelcontextprotocol.io/) can connect via either transport. The server advertises itself as `cstp-decisions` and exposes 5 tools via the standard `tools/list` method.
+
+---
+
+## Available Tools
+
+### `query_decisions`
+
+Search similar past decisions using semantic search, keyword matching, or hybrid retrieval. Returns matching decisions with confidence scores, categories, and outcomes.
+
+**Use before making new decisions to learn from history.**
+
+```json
+{
+  "query": "database migration strategy",
+  "limit": 5,
+  "retrieval_mode": "hybrid",
+  "filters": {
+    "category": "architecture",
+    "project": "owner/repo"
+  }
+}
+```
+
+**Input Schema:**
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `query` | string | ✅ | — | Natural language query (min 1 char) |
+| `limit` | int | ❌ | 5 | Maximum results (1–50) |
+| `retrieval_mode` | `"semantic"` \| `"keyword"` \| `"hybrid"` | ❌ | `"hybrid"` | Search mode |
+| `filters` | object | ❌ | — | See below |
+
+**Filters:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `category` | string | `architecture`, `process`, `integration`, `tooling`, `security` |
+| `stakes` | string[] | `low`, `medium`, `high`, `critical` |
+| `project` | string | Project in `owner/repo` format |
+| `has_outcome` | bool | Filter to decisions with/without recorded outcomes |
+
+**Output:** List of matching decisions with IDs, titles, confidence scores, categories, stakes, dates, and similarity distances.
+
+---
+
+### `check_action`
+
+Validate an intended action against safety guardrails and policies. Returns whether the action is allowed, any blocking violations, and warnings.
+
+**Always check before high-stakes actions.**
+
+```json
+{
+  "description": "Deploy to production without tests",
+  "stakes": "high",
+  "confidence": 0.6
+}
+```
+
+**Input Schema:**
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `description` | string | ✅ | — | Action you intend to take (min 1 char) |
+| `category` | string | ❌ | — | Action category |
+| `stakes` | `"low"` \| `"medium"` \| `"high"` \| `"critical"` | ❌ | `"medium"` | Stakes level |
+| `confidence` | float | ❌ | — | Your confidence (0.0–1.0) |
+
+**Output:** `allowed` boolean, list of violations (blocking), list of warnings, count of evaluated guardrails.
+
+---
+
+### `log_decision`
+
+Record a decision to the immutable decision log. Include what you decided, your confidence level, category, and supporting reasons.
+
+**Use after making a decision to build calibration history.**
+
+```json
+{
+  "decision": "Use PostgreSQL for the new service",
+  "confidence": 0.85,
+  "category": "architecture",
+  "stakes": "high",
+  "context": "Evaluated PostgreSQL vs MongoDB for the analytics service",
+  "reasons": [
+    {"type": "analysis", "text": "Need ACID transactions for financial data"},
+    {"type": "pattern", "text": "Team has strong PostgreSQL expertise"}
+  ],
+  "project": "owner/repo",
+  "pr": 42
+}
+```
+
+**Input Schema:**
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `decision` | string | ✅ | — | What you decided — state the choice |
+| `confidence` | float | ✅ | — | Confidence (0.0–1.0) |
+| `category` | `"architecture"` \| `"process"` \| `"integration"` \| `"tooling"` \| `"security"` | ✅ | — | Decision category |
+| `stakes` | `"low"` \| `"medium"` \| `"high"` \| `"critical"` | ❌ | `"medium"` | Stakes level |
+| `context` | string | ❌ | — | Situation context |
+| `reasons` | array | ❌ | — | Supporting reasons (see below) |
+| `tags` | string[] | ❌ | — | Tags for categorization |
+| `project` | string | ❌ | — | Project in `owner/repo` format |
+| `feature` | string | ❌ | — | Feature or epic name |
+| `pr` | int | ❌ | — | Pull request number (≥ 1) |
+
+**Reason object:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `"authority"` \| `"analogy"` \| `"analysis"` \| `"pattern"` \| `"intuition"` | Reasoning type |
+| `text` | string | Explanation |
+
+**Output:** Decision ID, file path, indexed status, and timestamp.
+
+---
+
+### `review_outcome`
+
+Record the outcome of a past decision. Provide the decision ID, whether it succeeded or failed, what actually happened, and lessons learned.
+
+**Builds calibration data over time.**
+
+```json
+{
+  "id": "a1b2c3d4",
+  "outcome": "success",
+  "actual_result": "PostgreSQL handled the load well, no issues",
+  "lessons": "ACID transactions were indeed critical for data integrity"
+}
+```
+
+**Input Schema:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | ✅ | Decision ID (8-char hex) |
+| `outcome` | `"success"` \| `"partial"` \| `"failure"` \| `"abandoned"` | ✅ | Outcome of the decision |
+| `actual_result` | string | ❌ | What actually happened |
+| `lessons` | string | ❌ | Lessons learned |
+| `notes` | string | ❌ | Additional review notes |
+
+**Output:** Review status, updated path, and reindex confirmation.
+
+---
+
+### `get_stats`
+
+Get calibration statistics: Brier score, accuracy, confidence distribution, and decision counts. Optionally filter by category, project, or time window.
+
+**Use to check decision-making quality.**
+
+```json
+{
+  "category": "architecture",
+  "window": "90d"
+}
+```
+
+**Input Schema:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `category` | string | ❌ | Filter by category |
+| `project` | string | ❌ | Filter by project (`owner/repo`) |
+| `window` | `"30d"` \| `"60d"` \| `"90d"` \| `"all"` | ❌ | Rolling time window |
+
+**Output:** Brier score, accuracy, confidence distribution, decision counts, and confidence variance metrics.
+
+---
+
+## Error Handling
+
+All MCP tool errors are returned as `TextContent` containing a JSON object:
+
+```json
+{
+  "error": "validation_error",
+  "message": "1 validation error for QueryDecisionsInput\nquery\n  Field required [type=missing, ...]"
+}
+```
+
+| Error Type | Cause |
+|------------|-------|
+| `validation_error` | Invalid input — Pydantic schema validation failed |
+| `internal_error` | Unexpected server error — check server logs |
+
+The MCP server logs to stderr (stdout is reserved for the MCP protocol). Check container logs for debugging:
+
+```bash
+docker logs cstp 2>&1 | grep "cstp-mcp"
+```
+
+---
+
+## Authentication
+
+- **Streamable HTTP** — Inherits authentication from the FastAPI bearer token middleware. The same `CSTP_AUTH_TOKENS` apply.
+- **stdio** — No bearer token authentication. Security relies on process-level isolation (e.g., Docker container, local access).
+
+---
+
+## Local Development
+
+```bash
+# 1. Install with MCP support
+pip install -e ".[a2a,mcp,dev]"
+
+# 2. Set required environment variables
+export CHROMA_URL=http://localhost:8000
+export GEMINI_API_KEY=your-key
+export DECISIONS_PATH=./decisions
+
+# 3. Run MCP server (stdio)
+python -m a2a.mcp_server
+
+# 4. Or start the full server (includes /mcp endpoint)
+python -m uvicorn a2a.server:app --host 0.0.0.0 --port 8100
+```
+
+---
+
+## Tool-to-Method Mapping
+
+| MCP Tool | CSTP JSON-RPC Method | Service Module |
+|----------|----------------------|----------------|
+| `query_decisions` | `cstp.queryDecisions` | `a2a/cstp/query_service.py` |
+| `check_action` | `cstp.checkGuardrails` | `a2a/cstp/guardrails_service.py` |
+| `log_decision` | `cstp.recordDecision` | `a2a/cstp/decision_service.py` |
+| `review_outcome` | `cstp.reviewDecision` | `a2a/cstp/decision_service.py` |
+| `get_stats` | `cstp.getCalibration` | `a2a/cstp/calibration_service.py` |

--- a/ProductDocumentation/README.md
+++ b/ProductDocumentation/README.md
@@ -1,6 +1,6 @@
 # Cognition Engines — Product Documentation
 
-> **Version:** 0.7.0  
+> **Version:** 0.9.0  
 > **License:** Apache 2.0  
 > **Python:** ≥ 3.11
 
@@ -19,6 +19,7 @@
 | [Configuration Guide](07-Configuration-Guide.md) | Environment variables, YAML config, and guardrail authoring |
 | [Dashboard Guide](08-Dashboard-Guide.md) | Web dashboard setup, features, and usage |
 | [Guardrails Authoring](09-Guardrails-Authoring.md) | Writing custom guardrail rules and using templates |
+| [MCP Integration](10-MCP-Integration.md) | Model Context Protocol integration guide — tools, transports, and client setup |
 
 ---
 


### PR DESCRIPTION
Updates all ProductDocumentation files from v0.7.0 to v0.9.0.

## Changes
- 7 files modified, 1 new file created
- MCP added as 3rd pillar alongside Accelerators and Guardrails
- Feature table updated (v0.8.0 feedback loop, v0.9.0 calibration/drift/hybrid/MCP)
- ASCII diagrams replaced with Mermaid
- New `10-MCP-Integration.md` dedicated guide
- All version references updated to 0.9.0

+913 / -170 lines (docs only, no code changes)