### PR TITLE
feat: add VitePress documentation website

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,0 +1,58 @@
+name: Deploy Website
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'website/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - name: Install dependencies
+        run: cd website && npm ci
+
+      - name: Build
+        run: cd website && npm run docs:build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: website/.vitepress/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,6 @@ rad.json
 TestResults.xml__pycache__/
 **/pycache__/
 *.pyc
-.env
+.envwebsite/node_modules/
+website/.vitepress/dist/
+website/.vitepress/cache/

--- a/website/.vitepress/config.mjs
+++ b/website/.vitepress/config.mjs
@@ -1,0 +1,106 @@
+import { defineConfig } from 'vitepress'
+
+export default defineConfig({
+  title: 'Cognition Engines',
+  description: 'Decision Intelligence for AI Agents',
+  base: '/cognition-agent-decisions/',
+
+  head: [
+    ['meta', { name: 'theme-color', content: '#6366f1' }],
+    ['meta', { property: 'og:type', content: 'website' }],
+    ['meta', { property: 'og:title', content: 'Cognition Engines' }],
+    ['meta', { property: 'og:description', content: 'Decision Intelligence for AI Agents - Query, Check, Record, Learn' }],
+  ],
+
+  themeConfig: {
+    logo: '/logo.svg',
+    siteTitle: 'Cognition Engines',
+
+    nav: [
+      { text: 'Guide', link: '/guide/what-is-cognition-engines' },
+      { text: 'Reference', link: '/reference/api' },
+      { text: 'Specs', link: '/specs/' },
+      {
+        text: 'v0.10.0',
+        items: [
+          { text: 'Changelog', link: '/changelog' },
+          { text: 'GitHub', link: 'https://github.com/tfatykhov/cognition-agent-decisions' }
+        ]
+      }
+    ],
+
+    sidebar: {
+      '/guide/': [
+        {
+          text: 'Introduction',
+          items: [
+            { text: 'What is Cognition Engines?', link: '/guide/what-is-cognition-engines' },
+            { text: 'Getting Started', link: '/guide/getting-started' },
+            { text: 'Agent Quick Start', link: '/guide/agent-quickstart' },
+          ]
+        },
+        {
+          text: 'Core Concepts',
+          items: [
+            { text: 'Decision Protocol', link: '/guide/decision-protocol' },
+            { text: 'Deliberation Traces', link: '/guide/deliberation-traces' },
+            { text: 'Bridge-Definitions', link: '/guide/bridge-definitions' },
+            { text: 'Related Decisions', link: '/guide/related-decisions' },
+            { text: 'Guardrails', link: '/guide/guardrails' },
+          ]
+        },
+        {
+          text: 'Integration',
+          items: [
+            { text: 'MCP Integration', link: '/guide/mcp-integration' },
+            { text: 'Dashboard', link: '/guide/dashboard' },
+          ]
+        }
+      ],
+      '/reference/': [
+        {
+          text: 'Reference',
+          items: [
+            { text: 'API Reference', link: '/reference/api' },
+            { text: 'CLI Reference', link: '/reference/cli' },
+            { text: 'Architecture', link: '/reference/architecture' },
+            { text: 'Module Reference', link: '/reference/modules' },
+            { text: 'Configuration', link: '/reference/configuration' },
+            { text: 'Installation', link: '/reference/installation' },
+          ]
+        }
+      ],
+      '/specs/': [
+        {
+          text: 'Feature Specs',
+          items: [
+            { text: 'Overview', link: '/specs/' },
+            { text: 'F022 - MCP Server', link: '/specs/f022-mcp-server' },
+            { text: 'F023 - Deliberation Traces', link: '/specs/f023-deliberation-traces' },
+            { text: 'F024 - Bridge-Definitions', link: '/specs/f024-bridge-definitions' },
+            { text: 'F027 - Censor Layer', link: '/specs/f027-censor-layer' },
+            { text: 'F028 - Decomposed Confidence', link: '/specs/f028-decomposed-confidence' },
+          ]
+        }
+      ]
+    },
+
+    socialLinks: [
+      { icon: 'github', link: 'https://github.com/tfatykhov/cognition-agent-decisions' }
+    ],
+
+    search: {
+      provider: 'local'
+    },
+
+    editLink: {
+      pattern: 'https://github.com/tfatykhov/cognition-agent-decisions/edit/main/website/:path',
+      text: 'Edit this page on GitHub'
+    },
+
+    footer: {
+      message: 'Released under the Apache 2.0 License.',
+      copyright: 'Built with Minsky\'s Society of Mind'
+    }
+  }
+})

--- a/website/changelog.md
+++ b/website/changelog.md
@@ -1,0 +1,26 @@
+# Changelog
+
+## v0.10.0 - Decision Intelligence with Auto-Capture
+*February 8, 2026*
+
+Every decision now automatically captures its full cognitive context - deliberation traces, bridge-definitions, and related decision links - with zero client changes.
+
+### Features
+- **F022: MCP Server** - 7 native MCP tools at `/mcp`
+- **F023: Deliberation Traces** - auto-capture query/check as structured inputs
+- **F024: Bridge-Definitions** - structure/function dual descriptions with directional search
+- **F025: Related Decisions** - auto-populated graph edges from query results
+- `cstp.getDecision` - full decision details by ID
+- `cstp.getReasonStats` - reason-type calibration analytics
+- Agent Quick Start Guide for onboarding other agents
+
+### No Breaking Changes
+All features are additive and backward-compatible.
+
+## v0.8.0 - Decision Intelligence Platform
+*February 5, 2026*
+
+- CSTP server with JSON-RPC 2.0 API
+- Hybrid retrieval (BM25 + semantic)
+- Drift alerts and confidence variance monitoring
+- Docker deployment with dashboard

--- a/website/guide/agent-quickstart.md
+++ b/website/guide/agent-quickstart.md
@@ -1,0 +1,148 @@
+# Agent Quick Start Guide
+
+> **Version:** v0.10.0
+> **Protocol:** JSON-RPC 2.0 over HTTP (`/cstp`) or MCP (`/mcp`)
+
+## What This Is
+
+A decision intelligence server. You query it before making decisions, and it helps you:
+- Find what approaches worked (or failed) for similar problems
+- Check if guardrails allow your planned action
+- Record decisions with structured reasoning for future reference
+- Build calibration data so your confidence estimates improve over time
+
+## Quick Start
+
+### 1. Connect
+
+**JSON-RPC:**
+```
+POST http://<server>:9991/cstp
+Authorization: Bearer <your-token>
+Content-Type: application/json
+```
+
+**MCP:** Connect to `http://<server>:9991/mcp` with any MCP-compliant client.
+
+### 2. Before Deciding: Query + Check
+
+```json
+// Step 1: What solved problems like this?
+{"jsonrpc":"2.0","method":"cstp.queryDecisions","params":{
+  "query":"handling transient API failures",
+  "bridgeSide":"function",
+  "limit":5
+},"id":1}
+
+// Step 2: Am I allowed to do this?
+{"jsonrpc":"2.0","method":"cstp.checkGuardrails","params":{
+  "action":{
+    "description":"Add retry logic to payment API",
+    "category":"architecture",
+    "stakes":"high",
+    "confidence":0.85
+  }
+},"id":2}
+```
+
+### 3. After Deciding: Record
+
+```json
+{"jsonrpc":"2.0","method":"cstp.recordDecision","params":{
+  "decision":"Added exponential backoff with jitter to payment API",
+  "confidence":0.85,
+  "category":"architecture",
+  "stakes":"high",
+  "context":"Payment API returning 503s during peak. Needed resilience without circuit breaker complexity.",
+  "reasons":[
+    {"type":"analysis","text":"Backoff handles transient failures; jitter prevents thundering herd"},
+    {"type":"empirical","text":"Similar pattern succeeded in order-service (decision abc123)"}
+  ]
+},"id":3}
+```
+
+### 4. What You Get Back
+
+The server automatically attaches:
+- **Deliberation trace**: Your Step 1-2 queries linked to this decision
+- **Bridge-definition**: Structure (what it looks like) + function (what it solves) extracted from your text
+- **Related decisions**: The decisions found in Step 1, linked with distance scores
+
+```json
+{
+  "result":{
+    "id":"def456",
+    "indexed":true,
+    "deliberation_auto":true,
+    "deliberation_inputs_count":2,
+    "bridge_auto":true,
+    "related_count":5
+  }
+}
+```
+
+## Adding to Your Agent's System Prompt
+
+Paste this into your agent's AGENTS.md or system prompt:
+
+```markdown
+## Decision Protocol
+
+Before making significant decisions (architecture, tooling, process):
+
+1. **Query**: Search past decisions for similar context
+   POST /cstp {"method":"cstp.queryDecisions","params":{"query":"your context"}}
+
+2. **Check**: Validate against guardrails
+   POST /cstp {"method":"cstp.checkGuardrails","params":{"action":{"description":"what you want to do","stakes":"medium"}}}
+
+3. **Record**: Log the decision with reasons
+   POST /cstp {"method":"cstp.recordDecision","params":{"decision":"what you chose","confidence":0.85,"category":"architecture","reasons":[{"type":"analysis","text":"why"}]}}
+
+The server auto-captures your query and check as deliberation inputs.
+Use at least 2 different reason types for robustness.
+```
+
+## Tips
+
+- **Use 2+ reason types** for robustness: `analysis`, `empirical`, `pattern`, `authority`, `constraint`, `analogy`, `intuition`, `elimination`
+- **bridgeSide search**: Use `"function"` to find what solved similar problems, `"structure"` to find where a pattern was used before
+- **Confidence honestly**: Rate your actual uncertainty, not optimism. The calibration data is more valuable than a clean record.
+- **Review outcomes**: Call `cstp.reviewDecision` when you know the result. This builds calibration data.
+
+## What to Log
+
+- Architecture and design choices
+- Tool or library selections
+- Process changes
+- Bug fix approaches
+- Any choice that could be wrong and worth reviewing
+
+## What NOT to Log
+
+- Routine operations (backups, deploys)
+- Trivial formatting choices
+- Decisions already made by someone else
+
+## Available Methods
+
+| Method | Purpose |
+|--------|---------|
+| `cstp.queryDecisions` | Search past decisions (semantic, keyword, or hybrid) |
+| `cstp.checkGuardrails` | Validate an action against policy rules |
+| `cstp.recordDecision` | Log a new decision with reasoning |
+| `cstp.reviewDecision` | Record the outcome of a past decision |
+| `cstp.getDecision` | Get full decision details by ID |
+| `cstp.getCalibration` | Calibration stats (Brier score, accuracy) |
+| `cstp.getReasonStats` | Which reason types predict success |
+| `cstp.listGuardrails` | List active guardrail rules |
+| `cstp.checkDrift` | Detect calibration drift over time |
+| `cstp.attributeOutcomes` | Bulk outcome attribution by project |
+
+## Categories
+
+`architecture`, `process`, `integration`, `tooling`, `security`
+
+## Stakes
+
+`low`, `medium`, `high`, `critical`

--- a/website/guide/bridge-definitions.md
+++ b/website/guide/bridge-definitions.md
@@ -1,0 +1,58 @@
+# Bridge-Definitions
+
+> **Feature:** F024 | **Status:** Shipped in v0.10.0 | **Source:** Minsky Ch 12
+
+Bridge-definitions describe each decision from two angles: **structure** (what it looks like) and **function** (what problem it solves). This enables directional search.
+
+## The Idea
+
+From Minsky's *Society of Mind* Chapter 12 - "Learning Meaning":
+
+> The best ideas connect recognizable patterns to their purposes.
+
+A decision that only knows *what it is* can't help you find it when you need *what it does*, and vice versa. Bridge-definitions connect both.
+
+## Example
+
+```yaml
+decision: "Added exponential backoff with jitter to payment API"
+bridge:
+  structure: "Exponential backoff with jitter, max 3 retries, 100ms base"
+  function: "Handle transient API failures without cascading or thundering herd"
+```
+
+## Directional Search
+
+Search by purpose or by pattern:
+
+```bash
+# "What solved problems like this?" (search by function)
+cstp.py query "handle transient failures" --bridge-side function
+
+# "Where did we use this pattern?" (search by structure)
+cstp.py query "exponential backoff" --bridge-side structure
+```
+
+These return different results because they search different aspects of the same decisions.
+
+## Auto-Extraction
+
+If you don't provide an explicit bridge, the server extracts one automatically:
+
+- **Structure** is derived from implementation-oriented language in the decision text
+- **Function** is derived from the strongest reason text (purpose-oriented)
+
+The response includes `bridge_auto: true` when auto-extracted.
+
+## Optional Operators
+
+From Minsky Ch 12.3 (Uniframes), bridges can include operators:
+
+```yaml
+bridge:
+  structure: "Rate limiter with token bucket"
+  function: "Prevent API abuse without blocking legitimate traffic"
+  tolerance: "Allows burst of 10 requests before limiting"
+  enforcement: "Returns 429 with Retry-After header"
+  prevention: "Stops cascading failures to downstream services"
+```

--- a/website/guide/dashboard.md
+++ b/website/guide/dashboard.md
@@ -1,0 +1,20 @@
+# Dashboard
+
+The Cognition Engines dashboard provides a visual interface for exploring decisions, calibration data, and patterns.
+
+## Access
+
+```
+http://your-server:8080
+```
+
+## Features
+
+- **Decision Browser** - search, filter, and inspect decisions
+- **Calibration View** - Brier scores, accuracy, confidence distribution
+- **Timeline** - decisions plotted over time with outcomes
+- **Guardrail Status** - active rules and recent evaluations
+
+## Deployment
+
+The dashboard is included in the Docker deployment. See the [Installation Guide](/reference/installation) for setup instructions.

--- a/website/guide/decision-protocol.md
+++ b/website/guide/decision-protocol.md
@@ -1,0 +1,77 @@
+# Decision Protocol
+
+The core workflow that every agent follows. The server auto-captures everything.
+
+## The Three Steps
+
+### Step 1: Query Similar Decisions
+
+Before making a decision, search the corpus for similar past choices.
+
+```bash
+# Semantic search
+cstp.py query "handling transient API failures" --top 5
+
+# Directional search (Minsky Ch 12)
+cstp.py query "the problem" --bridge-side function --top 5   # What solved this?
+cstp.py query "the pattern" --bridge-side structure --top 5  # Where was this used?
+```
+
+### Step 2: Check Guardrails
+
+Validate your planned action against policy rules.
+
+```bash
+cstp.py check -d "deploy retry logic to production" -s high -f 0.85
+```
+
+If blocked, the response tells you why and what to fix.
+
+### Step 3: Record the Decision
+
+Log what you decided, why, and with what confidence.
+
+```bash
+cstp.py record \
+  -d "Added exponential backoff with jitter" \
+  -f 0.85 \
+  -c architecture \
+  -s medium \
+  -r "analysis:Backoff handles transient failures" \
+  -r "empirical:Similar pattern succeeded in order-service"
+```
+
+## What Happens Automatically
+
+When you follow query -> check -> record, three features fire:
+
+| Feature | What It Does | Response Field |
+|---------|-------------|----------------|
+| **Deliberation Traces** | Links your queries and checks to the decision | `deliberation_auto: true` |
+| **Bridge-Definitions** | Extracts structure/function from your text | `bridge_auto: true` |
+| **Related Decisions** | Links decisions found in queries | `related_count: N` |
+
+## Reason Types
+
+Use at least 2 different types for robustness (Minsky Ch 18 - parallel bundles):
+
+| Type | When to Use |
+|------|------------|
+| `analysis` | Logical reasoning about the problem |
+| `empirical` | Based on observed data or past results |
+| `pattern` | Matches a known successful pattern |
+| `authority` | Expert or documentation says so |
+| `constraint` | Required by technical/policy limits |
+| `analogy` | Similar to another domain's solution |
+| `intuition` | Gut feeling (use sparingly, be honest) |
+| `elimination` | Other options ruled out |
+
+## Review Outcomes
+
+Later, when you know the result:
+
+```bash
+cstp.py review --id abc123 --outcome success --result "Retry logic reduced 503s by 95%"
+```
+
+This builds calibration data. Your Brier score improves as you review more decisions.

--- a/website/guide/deliberation-traces.md
+++ b/website/guide/deliberation-traces.md
@@ -1,0 +1,54 @@
+# Deliberation Traces
+
+> **Feature:** F023 | **Status:** Shipped in v0.10.0
+
+Deliberation traces capture the chain-of-thought behind every decision - which past decisions you queried, which guardrails you checked, and how long the process took.
+
+## How It Works
+
+The CSTP server tracks your queries and checks per `agent_id`. When you record a decision, it automatically attaches the trace.
+
+```
+Agent queries "retry patterns"     → Tracker stores input
+Agent checks guardrails            → Tracker stores input
+Agent records decision             → Tracker builds trace, attaches it, clears
+```
+
+**Zero client changes needed.** The server handles everything.
+
+## What Gets Captured
+
+Each deliberation trace contains:
+
+- **Inputs** - queries and guardrail checks that preceded the decision
+- **Steps** - timestamped processing events
+- **Timing** - total deliberation duration in milliseconds
+- **Convergence** - whether multiple search paths pointed to the same answer
+
+## Example
+
+```yaml
+deliberation:
+  inputs:
+    - id: q-a1b2c3
+      type: query
+      text: "Queried 'retry patterns': 3 results"
+    - id: g-d4e5f6
+      type: guardrail
+      text: "Checked 'deploy retry logic': Allowed"
+  steps:
+    - timestamp: "2026-02-08T21:30:00Z"
+      action: "query_executed"
+    - timestamp: "2026-02-08T21:30:01Z"
+      action: "guardrail_checked"
+    - timestamp: "2026-02-08T21:30:05Z"
+      action: "decision_recorded"
+  timing_ms: 5000
+```
+
+## Why It Matters
+
+- **Provenance** - see exactly what influenced each decision
+- **Compliance** - prove the full workflow was followed
+- **Learning** - identify when skipped steps correlate with failures
+- **Debugging** - when a decision goes wrong, trace back to what was considered

--- a/website/guide/getting-started.md
+++ b/website/guide/getting-started.md
@@ -1,0 +1,373 @@
+# Installation Guide
+
+This guide covers three installation methods: Docker (recommended for production), local development, and integration as a skill.
+
+---
+
+## Prerequisites
+
+| Requirement | Version | Purpose |
+|-------------|---------|---------|
+| Python | ≥ 3.11 | Core runtime |
+| Docker + Docker Compose | Latest | Container deployment |
+| Gemini API Key | — | Text embeddings (`text-embedding-004`) |
+| ChromaDB | ≥ 0.4 | Vector database |
+
+### Obtaining a Gemini API Key
+
+1. Visit [Google AI Studio](https://makersuite.google.com/app/apikey)
+2. Create a new API key
+3. Save it — you'll need it for configuration
+
+---
+
+## Method 1: Docker (Recommended)
+
+### Quick Start
+
+```bash
+# 1. Clone the repository
+git clone https://github.com/tfatykhov/cognition-agent-decisions.git
+cd cognition-agent-decisions
+
+# 2. Create environment file
+cp .env.example .env
+
+# 3. Edit .env with your settings
+#    At minimum, set:
+#    - GEMINI_API_KEY=your_key_here
+#    - CSTP_AUTH_TOKENS=myagent:mysecrettoken
+
+# 4. Start services
+docker compose up -d
+
+# 5. Verify
+curl http://localhost:8100/health
+```
+
+### What Gets Started
+
+| Service | Port | Description |
+|---------|------|-------------|
+| `cstp-server` | 8100 | CSTP API server |
+| `chromadb` | 8000 | ChromaDB vector database |
+
+### Docker Compose Details
+
+```yaml
+services:
+  cstp-server:
+    build: .
+    ports:
+      - "8100:8100"
+    environment:
+      - GEMINI_API_KEY=${GEMINI_API_KEY}
+      - CSTP_AUTH_TOKENS=${CSTP_AUTH_TOKENS}
+      - CHROMA_URL=http://chromadb:8000
+    volumes:
+      - ./config:/app/config:ro
+      - ./guardrails:/app/guardrails:ro
+      - decisions_data:/app/decisions
+    depends_on:
+      chromadb:
+        condition: service_healthy
+
+  chromadb:
+    image: chromadb/chroma:latest
+    ports:
+      - "8000:8000"
+    volumes:
+      - chroma_data:/chroma/chroma
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/api/v1/heartbeat"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+```
+
+### Persistent Volumes
+
+| Volume | Purpose |
+|--------|---------|
+| `decisions_data` | Recorded decision YAML files |
+| `chroma_data` | ChromaDB index data |
+
+### Custom Guardrails
+
+Mount your guardrail YAML files:
+
+```yaml
+volumes:
+  - ./my-guardrails:/app/custom-guardrails:ro
+environment:
+  - GUARDRAILS_PATHS=/app/guardrails:/app/custom-guardrails
+```
+
+### Rebuilding
+
+```bash
+# Rebuild after code changes
+docker compose build --no-cache cstp-server
+
+# Restart services
+docker compose up -d
+
+# View logs
+docker compose logs -f cstp-server
+```
+
+---
+
+## Method 2: Local Development
+
+### Step 1: Clone and Set Up Environment
+
+```bash
+# Clone
+git clone https://github.com/tfatykhov/cognition-agent-decisions.git
+cd cognition-agent-decisions
+
+# Create virtual environment
+python -m venv .venv
+
+# Activate (Windows PowerShell)
+.\.venv\Scripts\Activate
+
+# Activate (Linux/macOS)
+source .venv/bin/activate
+```
+
+### Step 2: Install Dependencies
+
+```bash
+# Install with pip (including A2A server dependencies)
+python -m pip install -e ".[a2a,dev]"
+
+# Install with MCP support
+python -m pip install -e ".[a2a,mcp,dev]"
+
+# Or with uv (faster)
+pip install uv
+uv pip install -e ".[a2a,mcp,dev]"
+```
+
+**Dependency groups:**
+
+- **Core:** `pyyaml`, `chromadb`, `rank-bm25`
+- **`[a2a]`:** `fastapi`, `uvicorn`, `httpx`, `python-multipart`
+- **`[mcp]`:** `mcp` (Model Context Protocol SDK)
+- **`[dev]`:** `pytest`, `pytest-asyncio`, `pytest-cov`, `mypy`, `ruff`
+
+### Step 3: Start ChromaDB
+
+You need ChromaDB running independently:
+
+```bash
+# Option A: Docker
+docker run -d --name chromadb -p 8000:8000 chromadb/chroma:latest
+
+# Option B: Python (in-process)
+pip install chromadb
+chroma run --host 0.0.0.0 --port 8000
+```
+
+### Step 4: Configure Environment
+
+```bash
+# Create .env file
+cp .env.example .env
+
+# Set required variables
+$env:GEMINI_API_KEY = "your_gemini_api_key"
+$env:CSTP_AUTH_TOKENS = "myagent:mysecrettoken"
+$env:CHROMA_URL = "http://localhost:8000"
+```
+
+### Step 5: Start the CSTP Server
+
+```bash
+# Using the package script
+cstp-server --config config/server.yaml
+
+# Or directly with Python
+python -m uvicorn a2a.server:app --host 0.0.0.0 --port 8100
+
+# Or with the entry point
+python a2a/server.py --config config/server.yaml --port 8100
+```
+
+### Step 6: Verify
+
+```bash
+# Health check
+curl http://localhost:8100/health
+
+# Agent card
+curl http://localhost:8100/.well-known/agent.json
+
+# Query decisions (requires auth)
+curl -X POST http://localhost:8100/cstp `
+  -H "Authorization: Bearer myagent:mysecrettoken" `
+  -H "Content-Type: application/json" `
+  -d '{"jsonrpc":"2.0","method":"cstp.queryDecisions","params":{"query":"test"},"id":"1"}'
+```
+
+### Step 7: Run Tests
+
+```bash
+# Run all tests
+python -m pytest tests/ -v
+
+# Run with coverage
+python -m pytest tests/ --cov=src/cognition_engines --cov=a2a --cov-report=term-missing
+
+# Run specific test module
+python -m pytest tests/test_guardrails.py -v
+
+# Type checking
+python -m mypy src/ a2a/ --ignore-missing-imports
+
+# Linting
+python -m ruff check src/ a2a/
+```
+
+---
+
+## Method 3: Integration as Library
+
+Use Cognition Engines directly in your Python agent without the HTTP server.
+
+### Install
+
+```bash
+pip install cognition-engines
+# Or from source:
+pip install -e /path/to/cognition-agent-decisions
+```
+
+### Usage
+
+```python
+from cognition_engines.accelerators.semantic_index import get_index
+from cognition_engines.guardrails.engine import get_engine, load_default_guardrails
+from cognition_engines.patterns.detector import PatternDetector
+
+# --- Semantic Index ---
+index = get_index()
+index.index_decisions([{
+    "title": "Use Redis for caching",
+    "category": "architecture",
+    "confidence": 0.85,
+    "decision": "Chose Redis over Memcached for caching layer",
+}])
+
+results = index.query("caching solution", n_results=5)
+
+# --- Guardrails ---
+load_default_guardrails()
+engine = get_engine()
+allowed, results = engine.check({
+    "category": "deployment",
+    "stakes": "high",
+    "affects_production": True,
+    "code_review_completed": True,
+})
+
+# --- Pattern Detection ---
+detector = PatternDetector()
+detector.load_from_directory("decisions/")
+report = detector.full_report()
+```
+
+---
+
+## Method 4: OpenClaw Skill
+
+If using the [OpenClaw](https://github.com/tfatykhov/openclaw) agent framework:
+
+```bash
+# Copy the skill definition
+cp -r skills/openclaw/cognition_skill.py /path/to/openclaw/skills/
+```
+
+The skill provides `query_decisions` and `check_guardrails` tools to any OpenClaw agent.
+
+---
+
+## Method 5: MCP Quick Start
+
+Connect any MCP-compliant agent to CSTP decision intelligence. The MCP server exposes 5 tools (`query_decisions`, `check_action`, `log_decision`, `review_outcome`, `get_stats`) via two transports.
+
+### Streamable HTTP (Remote)
+
+The CSTP server exposes MCP at `/mcp` on the same port (8100):
+
+```bash
+# Claude Code
+claude mcp add --transport http cstp-decisions http://your-server:8100/mcp
+
+# Any MCP client — point to:
+http://your-server:8100/mcp
+```
+
+### stdio (Local / Docker)
+
+```bash
+# Via Docker (recommended — container has all deps)
+docker exec -i cstp python -m a2a.mcp_server
+
+# Local development
+pip install -e ".[mcp]"
+export CHROMA_URL=http://localhost:8000
+export GEMINI_API_KEY=your-key
+python -m a2a.mcp_server
+```
+
+### Claude Desktop
+
+Add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "cstp": {
+      "command": "docker",
+      "args": ["exec", "-i", "cstp", "python", "-m", "a2a.mcp_server"],
+      "env": {}
+    }
+  }
+}
+```
+
+> See [MCP Integration Guide](/guide/mcp-integration) for full details, schemas, and examples.
+
+---
+
+## Troubleshooting
+
+### Common Issues
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| `GEMINI_API_KEY not found` | Missing API key | Set `GEMINI_API_KEY` in `.env` or environment |
+| `ChromaDB connection refused` | ChromaDB not running | Start ChromaDB with Docker or `chroma run` |
+| `401 Unauthorized` | Invalid or missing token | Check `CSTP_AUTH_TOKENS` format: `agent:token` |
+| `ModuleNotFoundError: cognition_engines` | Package not installed | Run `pip install -e .` |
+| `Docker build fails at uv` | Build tools missing | The Dockerfile includes `gcc`/`g++` — ensure Docker build doesn't cache stale layers |
+
+### Port Conflicts
+
+Default ports:
+
+| Service | Default Port | Environment Variable |
+|---------|-------------|---------------------|
+| CSTP Server | 8100 | `CSTP_PORT` |
+| ChromaDB | 8000 | `CHROMA_URL` (full URL) |
+| Dashboard | 5001 | `DASHBOARD_PORT` |
+
+Override with environment variables:
+
+```bash
+$env:CSTP_PORT = "9100"
+$env:CHROMA_URL = "http://localhost:9000"
+```

--- a/website/guide/guardrails.md
+++ b/website/guide/guardrails.md
@@ -1,0 +1,70 @@
+# Guardrails
+
+Guardrails are policy rules that prevent agents from making decisions that violate established constraints. They act as **suppressors** - blocking actions at the moment they'd execute.
+
+## Built-in Rules
+
+### no-high-stakes-low-confidence
+Blocks high-stakes decisions when confidence is below 50%.
+
+```yaml
+- id: no-high-stakes-low-confidence
+  condition_stakes: high
+  condition_confidence: "< 0.5"
+  action: block
+  message: High-stakes decisions require 50% confidence or more
+```
+
+### no-production-without-review
+Blocks production changes that haven't been code reviewed.
+
+```yaml
+- id: no-production-without-review
+  condition_affects_production: true
+  requires_code_review: true
+  action: block
+  message: Production changes require completed code review
+```
+
+## Checking Guardrails
+
+```bash
+cstp.py check -d "deploy to production without review" -s high -f 0.85
+```
+
+Response when blocked:
+```json
+{
+  "allowed": false,
+  "violations": [
+    {
+      "guardrail_id": "no-production-without-review",
+      "message": "Production changes require completed code review"
+    }
+  ]
+}
+```
+
+## Custom Guardrails
+
+Add custom rules in `guardrails/` YAML files:
+
+```yaml
+- id: no-trading-without-backtest
+  description: Trading strategy changes need backtesting
+  scope: CryptoTrader
+  condition_affects_trading: true
+  requires_backtest: true
+  action: block
+  message: Run backtest before changing trading strategy
+```
+
+## Templates
+
+Pre-built guardrail templates are available in `guardrails/templates/`:
+- `financial.yaml` - Rules for financial/trading systems
+- `production-safety.yaml` - Rules for production deployments
+
+## Future: Censors (F027)
+
+Current guardrails are reactive (block at action time). A future **censor layer** will proactively warn when query results surface failed decisions with similar patterns - intercepting *before* the bad decision forms. See [F027 spec](/specs/f027-censor-layer).

--- a/website/guide/mcp-integration.md
+++ b/website/guide/mcp-integration.md
@@ -1,0 +1,74 @@
+# MCP Integration
+
+> **Feature:** F022 | **Status:** Shipped in v0.10.0
+
+Cognition Engines exposes 7 tools via the [Model Context Protocol](https://modelcontextprotocol.io/) for integration with Claude Desktop, OpenClaw, and any MCP-compliant agent.
+
+## Endpoint
+
+```
+http://your-server:9991/mcp
+```
+
+Streamable HTTP - handles both POST (tool calls) and GET (SSE events).
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `query_decisions` | Search past decisions with optional `bridge_side` |
+| `check_action` | Validate against guardrails |
+| `log_decision` | Record a new decision with reasoning |
+| `review_outcome` | Record what actually happened |
+| `get_stats` | Calibration statistics |
+| `get_decision` | Full decision details by ID |
+| `get_reason_stats` | Which reason types predict success |
+
+## Claude Desktop Configuration
+
+Add to your Claude Desktop MCP config:
+
+```json
+{
+  "mcpServers": {
+    "cognition-engines": {
+      "url": "http://your-server:9991/mcp",
+      "headers": {
+        "Authorization": "Bearer your-token"
+      }
+    }
+  }
+}
+```
+
+## OpenClaw Configuration
+
+Add to your OpenClaw gateway config:
+
+```yaml
+mcp:
+  servers:
+    cognition-engines:
+      url: http://your-server:9991/mcp
+      headers:
+        Authorization: "Bearer your-token"
+```
+
+## Example: Query Tool
+
+```json
+{
+  "name": "query_decisions",
+  "arguments": {
+    "query": "handling API rate limits",
+    "bridge_side": "function",
+    "limit": 5
+  }
+}
+```
+
+Returns matching decisions with summaries, confidence scores, outcomes, and distances.
+
+## vs JSON-RPC
+
+MCP adds session management overhead. For stateless workflows, the [JSON-RPC API](/reference/api) via `cstp.py` is simpler. Use MCP when your agent platform expects it.

--- a/website/guide/related-decisions.md
+++ b/website/guide/related-decisions.md
@@ -1,0 +1,44 @@
+# Related Decisions
+
+> **Feature:** F025 | **Status:** Shipped in v0.10.0
+
+Related decisions are lightweight graph edges that automatically link each new decision to its predecessors - the past decisions that were consulted during the decision-making process.
+
+## How It Works
+
+When you query similar decisions (Step 1 of the protocol), the server remembers those results. When you record a decision (Step 3), it automatically links the query results as `related_to`.
+
+```
+Query "retry patterns" → finds decisions A, B, C
+Record new decision D  → D.related_to = [A, B, C] with distances
+```
+
+## What Gets Stored
+
+Each related decision includes:
+
+```yaml
+related_to:
+  - id: abc123
+    summary: "Used circuit breaker for payment API"
+    distance: 0.265
+  - id: def456
+    summary: "Added retry with backoff to order service"
+    distance: 0.324
+```
+
+- **id** - the related decision's identifier
+- **summary** - first 100 chars of the decision text
+- **distance** - semantic distance (lower = more similar)
+
+## Why Not a Graph Database?
+
+We considered adding a full graph database (Neo4j, etc.) but deferred it:
+
+- ~50 decisions is too few for graph traversal to outperform semantic search
+- Related-to edges give us 90% of the graph benefit with zero infrastructure
+- Revisit at 200+ decisions if traversal patterns emerge
+
+## Deduplication
+
+If the same decision appears in multiple pre-decision queries, only the closest distance is kept. This prevents inflated link counts.

--- a/website/guide/what-is-cognition-engines.md
+++ b/website/guide/what-is-cognition-engines.md
@@ -1,0 +1,51 @@
+# What is Cognition Engines?
+
+Cognition Engines is a decision intelligence platform for AI agents. It helps agents make better decisions by learning from past choices.
+
+## The Problem
+
+AI agents make hundreds of decisions per session - architecture choices, tool selections, process changes, bug fix approaches. But they:
+
+- **Don't learn from past decisions** - each session starts fresh
+- **Can't search their history** - "what worked last time?" has no answer
+- **Lack guardrails** - nothing prevents repeating known mistakes
+- **Have no calibration** - confidence estimates are unchecked guesses
+
+## The Solution
+
+Cognition Engines provides three capabilities:
+
+### 1. Accelerators
+Cross-agent learning via semantic decision search. Before making a new decision, query the corpus to find similar past decisions and their outcomes.
+
+```bash
+cstp.py query "handling transient API failures" --bridge-side function --top 5
+```
+
+### 2. Guardrails
+Policy enforcement that prevents violations before they occur. Define rules like "no production changes without code review" and the system enforces them automatically.
+
+```bash
+cstp.py check -d "deploy to production" -s high -f 0.85
+```
+
+### 3. Auto-Capture
+Every decision automatically gets:
+- **Deliberation traces** - which queries and checks preceded this decision
+- **Bridge-definitions** - structure (what it looks like) + function (what it solves)
+- **Related decisions** - linked predecessors from pre-decision queries
+
+## Theoretical Foundation
+
+Cognition Engines is inspired by Marvin Minsky's *Society of Mind*:
+
+- **Ch 12 - Bridge-Definitions:** Describe concepts by both form and purpose
+- **Ch 18 - Parallel Bundles:** Seek multiple independent reasons, not one serial chain
+- **Ch 27 - Censors:** Proactive warnings that intercept before mistakes, not just reactive blocks
+- **Ch 28 - Mental Currencies:** Confidence scores that preserve reasoning structure
+
+## What It's Not
+
+- **Not a database** - it's an intelligence layer on top of storage
+- **Not an LLM** - it doesn't generate decisions, it helps agents make better ones
+- **Not a logging system** - decisions are indexed, searchable, and connected

--- a/website/index.md
+++ b/website/index.md
@@ -1,0 +1,69 @@
+---
+layout: home
+
+hero:
+  name: Cognition Engines
+  text: Decision Intelligence for AI Agents
+  tagline: Every decision automatically captures its full cognitive context - deliberation traces, bridge-definitions, and related decision links.
+  actions:
+    - theme: brand
+      text: Get Started
+      link: /guide/what-is-cognition-engines
+    - theme: alt
+      text: Agent Quick Start
+      link: /guide/agent-quickstart
+    - theme: alt
+      text: View on GitHub
+      link: https://github.com/tfatykhov/cognition-agent-decisions
+
+features:
+  - icon: 🔍
+    title: Query Before Deciding
+    details: Semantic search across past decisions. Find what worked, what failed, and why. Directional search by structure ("where did we use this pattern?") or function ("what solved this problem?").
+  - icon: 🛡️
+    title: Guardrails
+    details: Policy enforcement that prevents violations before they occur. Block high-stakes decisions with low confidence. Require code review for production changes.
+  - icon: 🧠
+    title: Deliberation Traces
+    details: Every query and guardrail check automatically linked to the resulting decision. Full provenance of how each choice was made - zero client changes needed.
+  - icon: 🌉
+    title: Bridge-Definitions
+    details: Describe decisions by both structure (what it looks like) and function (what it solves). Inspired by Minsky's Society of Mind Ch 12 - connecting patterns to purposes.
+  - icon: 🔗
+    title: Related Decisions
+    details: Pre-decision query results automatically linked as lightweight graph edges. See which past decisions influenced each new choice, with semantic distance scores.
+  - icon: 📊
+    title: Calibration & Analytics
+    details: Track Brier scores, success rates, and confidence calibration over time. Reason-type analytics show which reasoning patterns predict success.
+  - icon: 🔌
+    title: MCP Integration
+    details: 7 native MCP tools for Claude Desktop, OpenClaw, and any MCP-compliant agent. Streamable HTTP at /mcp - plug into any AI agent system.
+  - icon: ⚡
+    title: JSON-RPC API
+    details: CSTP protocol over HTTP. Query, check, record, review - all via simple JSON-RPC 2.0 calls. Built on FastAPI with ChromaDB for semantic search.
+---
+
+## How It Works
+
+Every significant decision follows a simple protocol. The server handles the rest automatically.
+
+```
+1. Query  →  "What solved problems like this?"
+2. Check  →  "Am I allowed to do this?"
+3. Record →  "Here's what I decided and why"
+```
+
+The server auto-captures:
+- **Deliberation trace** from your queries and checks
+- **Bridge-definition** extracted from your decision text
+- **Related decisions** linked from your query results
+
+```json
+{
+  "id": "abc123",
+  "deliberation_auto": true,
+  "deliberation_inputs_count": 2,
+  "bridge_auto": true,
+  "related_count": 5
+}
+```

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,0 +1,2514 @@
+{
+  "name": "website",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "website",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "vitepress": "^1.6.4"
+      }
+    },
+    "node_modules/@algolia/abtesting": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.14.0.tgz",
+      "integrity": "sha512-cZfj+1Z1dgrk3YPtNQNt0H9Rr67P8b4M79JjUKGS0d7/EbFbGxGgSu6zby5f22KXo3LT0LZa4O2c6VVbupJuDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.48.0",
+        "@algolia/requester-browser-xhr": "5.48.0",
+        "@algolia/requester-fetch": "5.48.0",
+        "@algolia/requester-node-http": "5.48.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/autocomplete-core": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
+      "integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
+        "@algolia/autocomplete-shared": "1.17.7"
+      }
+    },
+    "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
+      "integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "search-insights": ">= 1 < 3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
+      "integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-shared": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
+      "integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/client-abtesting": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.48.0.tgz",
+      "integrity": "sha512-n17WSJ7vazmM6yDkWBAjY12J8ERkW9toOqNgQ1GEZu/Kc4dJDJod1iy+QP5T/UlR3WICgZDi/7a/VX5TY5LAPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.48.0",
+        "@algolia/requester-browser-xhr": "5.48.0",
+        "@algolia/requester-fetch": "5.48.0",
+        "@algolia/requester-node-http": "5.48.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-analytics": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.48.0.tgz",
+      "integrity": "sha512-v5bMZMEqW9U2l40/tTAaRyn4AKrYLio7KcRuHmLaJtxuJAhvZiE7Y62XIsF070juz4MN3eyvfQmI+y5+OVbZuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.48.0",
+        "@algolia/requester-browser-xhr": "5.48.0",
+        "@algolia/requester-fetch": "5.48.0",
+        "@algolia/requester-node-http": "5.48.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-common": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.48.0.tgz",
+      "integrity": "sha512-7H3DgRyi7UByScc0wz7EMrhgNl7fKPDjKX9OcWixLwCj7yrRXDSIzwunykuYUUO7V7HD4s319e15FlJ9CQIIFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-insights": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.48.0.tgz",
+      "integrity": "sha512-tXmkB6qrIGAXrtRYHQNpfW0ekru/qymV02bjT0w5QGaGw0W91yT+53WB6dTtRRsIrgS30Al6efBvyaEosjZ5uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.48.0",
+        "@algolia/requester-browser-xhr": "5.48.0",
+        "@algolia/requester-fetch": "5.48.0",
+        "@algolia/requester-node-http": "5.48.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-personalization": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.48.0.tgz",
+      "integrity": "sha512-4tXEsrdtcBZbDF73u14Kb3otN+xUdTVGop1tBjict+Rc/FhsJQVIwJIcTrOJqmvhtBfc56Bu65FiVOnpAZCxcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.48.0",
+        "@algolia/requester-browser-xhr": "5.48.0",
+        "@algolia/requester-fetch": "5.48.0",
+        "@algolia/requester-node-http": "5.48.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-query-suggestions": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.48.0.tgz",
+      "integrity": "sha512-unzSUwWFpsDrO8935RhMAlyK0Ttua/5XveVIwzfjs5w+GVBsHgIkbOe8VbBJccMU/z1LCwvu1AY3kffuSLAR5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.48.0",
+        "@algolia/requester-browser-xhr": "5.48.0",
+        "@algolia/requester-fetch": "5.48.0",
+        "@algolia/requester-node-http": "5.48.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-search": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.48.0.tgz",
+      "integrity": "sha512-RB9bKgYTVUiOcEb5bOcZ169jiiVW811dCsJoLT19DcbbFmU4QaK0ghSTssij35QBQ3SCOitXOUrHcGgNVwS7sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.48.0",
+        "@algolia/requester-browser-xhr": "5.48.0",
+        "@algolia/requester-fetch": "5.48.0",
+        "@algolia/requester-node-http": "5.48.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/ingestion": {
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.48.0.tgz",
+      "integrity": "sha512-rhoSoPu+TDzDpvpk3cY/pYgbeWXr23DxnAIH/AkN0dUC+GCnVIeNSQkLaJ+CL4NZ51cjLIjksrzb4KC5Xu+ktw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.48.0",
+        "@algolia/requester-browser-xhr": "5.48.0",
+        "@algolia/requester-fetch": "5.48.0",
+        "@algolia/requester-node-http": "5.48.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/monitoring": {
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.48.0.tgz",
+      "integrity": "sha512-aSe6jKvWt+8VdjOaq2ERtsXp9+qMXNJ3mTyTc1VMhNfgPl7ArOhRMRSQ8QBnY8ZL4yV5Xpezb7lAg8pdGrrulg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.48.0",
+        "@algolia/requester-browser-xhr": "5.48.0",
+        "@algolia/requester-fetch": "5.48.0",
+        "@algolia/requester-node-http": "5.48.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/recommend": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.48.0.tgz",
+      "integrity": "sha512-p9tfI1bimAaZrdiVExL/dDyGUZ8gyiSHsktP1ZWGzt5hXpM3nhv4tSjyHtXjEKtA0UvsaHKwSfFE8aAAm1eIQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.48.0",
+        "@algolia/requester-browser-xhr": "5.48.0",
+        "@algolia/requester-fetch": "5.48.0",
+        "@algolia/requester-node-http": "5.48.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.48.0.tgz",
+      "integrity": "sha512-XshyfpsQB7BLnHseMinp3fVHOGlTv6uEHOzNK/3XrEF9mjxoZAcdVfY1OCXObfwRWX5qXZOq8FnrndFd44iVsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.48.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-fetch": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.48.0.tgz",
+      "integrity": "sha512-Q4XNSVQU89bKNAPuvzSYqTH9AcbOOiIo6AeYMQTxgSJ2+uvT78CLPMG89RIIloYuAtSfE07s40OLV50++l1Bbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.48.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-node-http": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.48.0.tgz",
+      "integrity": "sha512-ZgxV2+5qt3NLeUYBTsi6PLyHcENQWC0iFppFZekHSEDA2wcLdTUjnaJzimTEULHIvJuLRCkUs4JABdhuJktEag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.48.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@docsearch/css": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.2.tgz",
+      "integrity": "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@docsearch/js": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.8.2.tgz",
+      "integrity": "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/react": "3.8.2",
+        "preact": "^10.0.0"
+      }
+    },
+    "node_modules/@docsearch/react": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.2.tgz",
+      "integrity": "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.17.7",
+        "@algolia/autocomplete-preset-algolia": "1.17.7",
+        "@docsearch/css": "3.8.2",
+        "algoliasearch": "^5.14.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 19.0.0",
+        "react": ">= 16.8.0 < 19.0.0",
+        "react-dom": ">= 16.8.0 < 19.0.0",
+        "search-insights": ">= 1 < 3"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "search-insights": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@iconify-json/simple-icons": {
+      "version": "1.2.70",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.70.tgz",
+      "integrity": "sha512-CYNRCgN6nBTjN4dNkrBCjHXNR2e4hQihdsZUs/afUNFOWLSYjfihca4EFN05rRvDk4Xoy2n8tym6IxBZmcn+Qg==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@shikijs/core": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.4"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-2.5.0.tgz",
+      "integrity": "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^3.1.0"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-2.5.0.tgz",
+      "integrity": "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-2.5.0.tgz",
+      "integrity": "sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-2.5.0.tgz",
+      "integrity": "sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-2.5.0.tgz",
+      "integrity": "sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-2.5.0.tgz",
+      "integrity": "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.27.tgz",
+      "integrity": "sha512-gnSBQjZA+//qDZen+6a2EdHqJ68Z7uybrMf3SPjEGgG4dicklwDVmMC1AeIHxtLVPT7sn6sH1KOO+tS6gwOUeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.5",
+        "@vue/shared": "3.5.27",
+        "entities": "^7.0.0",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.27.tgz",
+      "integrity": "sha512-oAFea8dZgCtVVVTEC7fv3T5CbZW9BxpFzGGxC79xakTr6ooeEqmRuvQydIiDAkglZEAd09LgVf1RoDnL54fu5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.27",
+        "@vue/shared": "3.5.27"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.27.tgz",
+      "integrity": "sha512-sHZu9QyDPeDmN/MRoshhggVOWE5WlGFStKFwu8G52swATgSny27hJRWteKDSUUzUH+wp+bmeNbhJnEAel/auUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.5",
+        "@vue/compiler-core": "3.5.27",
+        "@vue/compiler-dom": "3.5.27",
+        "@vue/compiler-ssr": "3.5.27",
+        "@vue/shared": "3.5.27",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.6",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.27.tgz",
+      "integrity": "sha512-Sj7h+JHt512fV1cTxKlYhg7qxBvack+BGncSpH+8vnN+KN95iPIcqB5rsbblX40XorP+ilO7VIKlkuu3Xq2vjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.27",
+        "@vue/shared": "3.5.27"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
+      "integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.9"
+      }
+    },
+    "node_modules/@vue/devtools-kit": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
+      "integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.9",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
+      "integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rfdc": "^1.4.1"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.27.tgz",
+      "integrity": "sha512-vvorxn2KXfJ0nBEnj4GYshSgsyMNFnIQah/wczXlsNXt+ijhugmW+PpJ2cNPe4V6jpnBcs0MhCODKllWG+nvoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.27"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.27.tgz",
+      "integrity": "sha512-fxVuX/fzgzeMPn/CLQecWeDIFNt3gQVhxM0rW02Tvp/YmZfXQgcTXlakq7IMutuZ/+Ogbn+K0oct9J3JZfyk3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.27",
+        "@vue/shared": "3.5.27"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.27.tgz",
+      "integrity": "sha512-/QnLslQgYqSJ5aUmb5F0z0caZPGHRB8LEAQ1s81vHFM5CBfnun63rxhvE/scVb/j3TbBuoZwkJyiLCkBluMpeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.27",
+        "@vue/runtime-core": "3.5.27",
+        "@vue/shared": "3.5.27",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.27.tgz",
+      "integrity": "sha512-qOz/5thjeP1vAFc4+BY3Nr6wxyLhpeQgAE/8dDtKo6a6xdk+L4W46HDZgNmLOBUDEkFXV3G7pRiUqxjX0/2zWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.27",
+        "@vue/shared": "3.5.27"
+      },
+      "peerDependencies": {
+        "vue": "3.5.27"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.27.tgz",
+      "integrity": "sha512-dXr/3CgqXsJkZ0n9F3I4elY8wM9jMJpP3pvRG52r6m0tu/MsAFIe6JpXVGeNMd/D9F4hQynWT8Rfuj0bdm9kFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vueuse/core": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.8.2.tgz",
+      "integrity": "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/integrations": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-12.8.2.tgz",
+      "integrity": "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vueuse/core": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "async-validator": "^4",
+        "axios": "^1",
+        "change-case": "^5",
+        "drauu": "^0.4",
+        "focus-trap": "^7",
+        "fuse.js": "^7",
+        "idb-keyval": "^6",
+        "jwt-decode": "^4",
+        "nprogress": "^0.2",
+        "qrcode": "^1.5",
+        "sortablejs": "^1",
+        "universal-cookie": "^7"
+      },
+      "peerDependenciesMeta": {
+        "async-validator": {
+          "optional": true
+        },
+        "axios": {
+          "optional": true
+        },
+        "change-case": {
+          "optional": true
+        },
+        "drauu": {
+          "optional": true
+        },
+        "focus-trap": {
+          "optional": true
+        },
+        "fuse.js": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "jwt-decode": {
+          "optional": true
+        },
+        "nprogress": {
+          "optional": true
+        },
+        "qrcode": {
+          "optional": true
+        },
+        "sortablejs": {
+          "optional": true
+        },
+        "universal-cookie": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.8.2.tgz",
+      "integrity": "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.8.2.tgz",
+      "integrity": "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/algoliasearch": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.48.0.tgz",
+      "integrity": "sha512-aD8EQC6KEman6/S79FtPdQmB7D4af/etcRL/KwiKFKgAE62iU8c5PeEQvpvIcBPurC3O/4Lj78nOl7ZcoazqSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/abtesting": "1.14.0",
+        "@algolia/client-abtesting": "5.48.0",
+        "@algolia/client-analytics": "5.48.0",
+        "@algolia/client-common": "5.48.0",
+        "@algolia/client-insights": "5.48.0",
+        "@algolia/client-personalization": "5.48.0",
+        "@algolia/client-query-suggestions": "5.48.0",
+        "@algolia/client-search": "5.48.0",
+        "@algolia/ingestion": "1.48.0",
+        "@algolia/monitoring": "1.48.0",
+        "@algolia/recommend": "5.48.0",
+        "@algolia/requester-browser-xhr": "5.48.0",
+        "@algolia/requester-fetch": "5.48.0",
+        "@algolia/requester-node-http": "5.48.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/copy-anything": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/focus-trap": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
+      "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.4.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
+      "integrity": "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex-xs": "^1.0.0",
+        "regex": "^6.0.1",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.28.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.3.tgz",
+      "integrity": "sha512-tCmoRkPQLpBeWzpmbhryairGnhW9tKV6c6gr/w+RhoRoKEJwsjzipwp//1oCpGPOchvSLaAPlpcJi9MwMmoPyA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
+      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.57.1",
+        "@rollup/rollup-android-arm64": "4.57.1",
+        "@rollup/rollup-darwin-arm64": "4.57.1",
+        "@rollup/rollup-darwin-x64": "4.57.1",
+        "@rollup/rollup-freebsd-arm64": "4.57.1",
+        "@rollup/rollup-freebsd-x64": "4.57.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
+        "@rollup/rollup-linux-arm64-musl": "4.57.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
+        "@rollup/rollup-linux-loong64-musl": "4.57.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-musl": "4.57.1",
+        "@rollup/rollup-openbsd-x64": "4.57.1",
+        "@rollup/rollup-openharmony-arm64": "4.57.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
+        "@rollup/rollup-win32-x64-gnu": "4.57.1",
+        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/search-insights": {
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
+      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/shiki": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-2.5.0.tgz",
+      "integrity": "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/langs": "2.5.0",
+        "@shikijs/themes": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitepress": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.4.tgz",
+      "integrity": "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/css": "3.8.2",
+        "@docsearch/js": "3.8.2",
+        "@iconify-json/simple-icons": "^1.2.21",
+        "@shikijs/core": "^2.1.0",
+        "@shikijs/transformers": "^2.1.0",
+        "@shikijs/types": "^2.1.0",
+        "@types/markdown-it": "^14.1.2",
+        "@vitejs/plugin-vue": "^5.2.1",
+        "@vue/devtools-api": "^7.7.0",
+        "@vue/shared": "^3.5.13",
+        "@vueuse/core": "^12.4.0",
+        "@vueuse/integrations": "^12.4.0",
+        "focus-trap": "^7.6.4",
+        "mark.js": "8.11.1",
+        "minisearch": "^7.1.1",
+        "shiki": "^2.1.0",
+        "vite": "^5.4.14",
+        "vue": "^3.5.13"
+      },
+      "bin": {
+        "vitepress": "bin/vitepress.js"
+      },
+      "peerDependencies": {
+        "markdown-it-mathjax3": "^4",
+        "postcss": "^8"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it-mathjax3": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.27.tgz",
+      "integrity": "sha512-aJ/UtoEyFySPBGarREmN4z6qNKpbEguYHMmXSiOGk69czc+zhs0NF6tEFrY8TZKAl8N/LYAkd4JHVd5E/AsSmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.27",
+        "@vue/compiler-sfc": "3.5.27",
+        "@vue/runtime-dom": "3.5.27",
+        "@vue/server-renderer": "3.5.27",
+        "@vue/shared": "3.5.27"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/website/package.json
+++ b/website/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "website",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "docs:dev": "vitepress dev",
+    "docs:build": "vitepress build",
+    "docs:preview": "vitepress preview"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "vitepress": "^1.6.4"
+  }
+}

--- a/website/public/logo.svg
+++ b/website/public/logo.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <circle cx="16" cy="16" r="14" fill="#6366f1" opacity="0.15"/>
+  <circle cx="16" cy="16" r="10" fill="#6366f1" opacity="0.3"/>
+  <circle cx="16" cy="16" r="6" fill="#6366f1"/>
+  <path d="M16 6 L18 14 L16 12 L14 14 Z" fill="#a5b4fc"/>
+  <path d="M16 26 L14 18 L16 20 L18 18 Z" fill="#a5b4fc"/>
+  <path d="M6 16 L14 14 L12 16 L14 18 Z" fill="#a5b4fc"/>
+  <path d="M26 16 L18 18 L20 16 L18 14 Z" fill="#a5b4fc"/>
+</svg>

--- a/website/reference/api.md
+++ b/website/reference/api.md
@@ -1,0 +1,777 @@
+# CSTP API Reference
+
+The **Cognition State Transfer Protocol** (CSTP) is a JSON-RPC 2.0 API exposed over HTTP. All method calls use `POST /cstp` with a bearer token in the `Authorization` header.
+
+---
+
+## Protocol Basics
+
+### Request Format
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "cstp.<methodName>",
+  "params": { ... },
+  "id": "unique-request-id"
+}
+```
+
+### Response Format — Success
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": { ... },
+  "id": "unique-request-id"
+}
+```
+
+### Response Format — Error
+
+```json
+{
+  "jsonrpc": "2.0",
+  "error": {
+    "code": -32003,
+    "message": "Query failed: ..."
+  },
+  "id": "unique-request-id"
+}
+```
+
+### Authentication
+
+All requests must include a bearer token:
+
+```
+Authorization: Bearer <agent>:<token>
+```
+
+The agent name is extracted from the token pair and included in audit trails.
+
+### Error Codes
+
+| Code | Name | Description |
+|------|------|-------------|
+| -32700 | Parse Error | Malformed JSON |
+| -32600 | Invalid Request | Missing required fields |
+| -32601 | Method Not Found | Unknown CSTP method |
+| -32602 | Invalid Params | Parameter validation failed |
+| -32603 | Internal Error | Unexpected server error |
+| -32002 | Rate Limited | Too many requests |
+| -32003 | Query Failed | Error during decision query |
+| -32004 | Guardrail Eval Failed | Error evaluating guardrails |
+| -32005 | Record Failed | Error recording decision |
+| -32006 | Review Failed | Error reviewing decision |
+| -32007 | Decision Not Found | Decision ID not found |
+| -32008 | Attribution Failed | Error attributing outcomes |
+
+---
+
+## Non-Authenticated Endpoints
+
+### `GET /health`
+
+Health check with uptime tracking.
+
+**Response:**
+
+```json
+{
+  "status": "ok",
+  "version": "0.9.0",
+  "agent": "cognition-engines",
+  "uptime_seconds": 3600,
+  "timestamp": "2026-02-07T12:00:00Z"
+}
+```
+
+### `GET /.well-known/agent.json`
+
+A2A agent discovery card.
+
+**Response:**
+
+```json
+{
+  "name": "cognition-engines",
+  "description": "Decision Intelligence Service",
+  "version": "0.9.0",
+  "url": "http://localhost:8100",
+  "capabilities": ["queryDecisions", "checkGuardrails", "recordDecision", "reviewDecision", "getCalibration"],
+  "protocol": "cstp",
+  "protocolVersion": "0.9.0"
+}
+```
+
+---
+
+## CSTP Methods
+
+### `cstp.queryDecisions` — Search Decision Memory
+
+Search for semantically similar decisions using vector similarity, keyword matching, or hybrid search.
+
+**Parameters:**
+
+| Param | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `query` | string | ✅ | — | Natural language search query |
+| `limit` | int | ❌ | 10 | Maximum results |
+| `include_reasons` | bool | ❌ | false | Include decision reasons in results |
+| `retrieval_mode` | string | ❌ | `"semantic"` | `"semantic"`, `"keyword"`, or `"hybrid"` |
+| `bridge_side` | string | ❌ | `"both"` | `"structure"`, `"function"`, or `"both"` |
+| `hybrid_weight` | float | ❌ | 0.7 | Semantic weight in hybrid mode (0.0–1.0) |
+| `filters` | object | ❌ | `{}` | Filtering criteria (see below) |
+
+**Filter object:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `category` | string | Filter by decision category |
+| `min_confidence` | float | Minimum confidence (0.0–1.0) |
+| `max_confidence` | float | Maximum confidence (0.0–1.0) |
+| `stakes` | string[] | Filter by stakes level (`"low"`, `"medium"`, `"high"`, `"critical"`) |
+| `status` | string[] | Filter by status (`"pending"`, `"reviewed"`) |
+| `project` | string | Filter by project name |
+| `feature` | string | Filter by feature name |
+| `pr` | int | Filter by PR number |
+| `has_outcome` | bool | Only reviewed (true) or pending (false) |
+| `date_after` | string | ISO 8601 minimum date |
+| `date_before` | string | ISO 8601 maximum date |
+
+**Example request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "cstp.queryDecisions",
+  "params": {
+    "query": "database selection for agent memory storage",
+    "limit": 5,
+    "retrieval_mode": "hybrid",
+    "include_reasons": true,
+    "filters": {
+      "category": "architecture",
+      "min_confidence": 0.6
+    }
+  },
+  "id": "q-001"
+}
+```
+
+**Example response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "decisions": [
+      {
+        "id": "2026-01-15-decision-a1b2c3",
+        "title": "Use ChromaDB for semantic memory",
+        "category": "architecture",
+        "confidence": 0.85,
+        "stakes": "high",
+        "status": "reviewed",
+        "outcome": "success",
+        "date": "2026-01-15",
+        "distance": 0.234,
+        "reasons": ["Lightweight vector DB", "HTTP API", "Good Python support"]
+      }
+    ],
+    "total": 1,
+    "query": "database selection for agent memory storage",
+    "query_time_ms": 142,
+    "agent": "cognition-engines",
+    "retrieval_mode": "hybrid",
+    "scores": {
+      "2026-01-15-decision-a1b2c3": {
+        "semantic": 0.892,
+        "keyword": 0.654,
+        "combined": 0.821
+      }
+    }
+  },
+  "id": "q-001"
+}
+```
+
+---
+
+### `cstp.checkGuardrails` — Evaluate Policy Rules
+
+Check a proposed action against all active guardrails.
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `action` | object | ✅ | Action context |
+| `action.description` | string | ✅ | What the agent intends to do |
+| `action.category` | string | ❌ | Decision category |
+| `action.stakes` | string | ❌ | Stakes level (default: `"medium"`) |
+| `action.confidence` | float | ❌ | Agent's confidence (0.0–1.0) |
+| `action.context` | object | ❌ | Arbitrary context fields for condition matching |
+| `agent` | object | ❌ | Agent identity |
+| `agent.id` | string | ❌ | Agent identifier |
+| `agent.url` | string | ❌ | Agent callback URL |
+
+**Example request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "cstp.checkGuardrails",
+  "params": {
+    "action": {
+      "description": "Deploy new ML pipeline to production",
+      "category": "deployment",
+      "stakes": "high",
+      "confidence": 0.75,
+      "context": {
+        "affects_production": true,
+        "code_review_completed": false
+      }
+    }
+  },
+  "id": "g-001"
+}
+```
+
+**Example response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "allowed": false,
+    "violations": [
+      {
+        "guardrail_id": "no-production-without-review",
+        "name": "Production changes require code review",
+        "message": "Production changes require completed code review",
+        "severity": "block",
+        "suggestion": "Complete code review before proceeding"
+      }
+    ],
+    "warnings": [],
+    "evaluated": 3,
+    "evaluated_at": "2026-02-07T12:00:00Z",
+    "agent": "cognition-engines"
+  },
+  "id": "g-001"
+}
+```
+
+---
+
+### `cstp.listGuardrails` — List Active Guardrails
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `scope` | string | ❌ | Filter by scope/project |
+
+**Example response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "guardrails": [
+      {
+        "id": "no-production-without-review",
+        "description": "Production changes require code review",
+        "action": "block",
+        "scope": null,
+        "conditions": 1,
+        "requirements": 1
+      }
+    ],
+    "total": 3
+  },
+  "id": "lg-001"
+}
+```
+
+---
+
+### `cstp.recordDecision` — Record a Decision
+
+Record a new decision with full metadata, reasoning trace, and optional guardrail pre-check.
+
+**Parameters:**
+
+| Param | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `decision` | string | ✅ | — | Decision text / title |
+| `confidence` | float | ✅ | — | Confidence level (0.0–1.0) |
+| `category` | string | ✅ | — | Category (e.g., `"architecture"`, `"trading"`) |
+| `stakes` | string | ❌ | `"medium"` | `"low"`, `"medium"`, `"high"`, `"critical"` |
+| `context` | string | ❌ | — | Free-text context |
+| `reasons` | array | ❌ | `[]` | List of reason objects |
+| `reasons[].type` | string | — | — | Reason type: `"technical"`, `"risk"`, `"constraint"`, etc. |
+| `reasons[].text` | string | — | — | Reason text |
+| `reasons[].strength` | float | — | — | Weight (0.0–1.0) |
+| `alternatives_considered` | array | ❌ | `[]` | List of rejected alternatives |
+| `review_in` | string | ❌ | `"7d"` | Review cadence: `"24h"`, `"3d"`, `"7d"`, `"30d"` |
+| `project` | object | ❌ | — | Project context |
+| `project.name` | string | — | — | Project name |
+| `project.feature` | string | — | — | Feature name |
+| `project.pr` | int | — | — | Pull request number |
+| `project.files` | array | — | — | Affected files |
+| `reasoning_trace` | array | ❌ | — | Step-by-step reasoning |
+| `bridge` | object | ❌ | — | Bridge definition (structure + function) |
+| `bridge.structure` | string | ❌ | — | What the decision looks like (pattern) |
+| `bridge.function` | string | ❌ | — | What problem it solves (purpose) |
+| `bridge.tolerance` | array | ❌ | — | Features that don't matter |
+| `bridge.enforcement` | array | ❌ | — | Features that must be present |
+| `bridge.prevention` | array | ❌ | — | Features that must be absent |
+| `pre_decision_protocol` | object | ❌ | — | Track whether query + guardrail check were performed |
+
+**Example request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "cstp.recordDecision",
+  "params": {
+    "decision": "Use PostgreSQL for persistent state storage",
+    "confidence": 0.82,
+    "category": "architecture",
+    "stakes": "high",
+    "bridge": {
+        "structure": "PostgreSQL with row-level security",
+        "function": "secure multi-tenant data storage"
+    },
+    "context": "Evaluating database options for agent state persistence",
+    "reasons": [
+      {"type": "technical", "text": "ACID compliance for critical state", "strength": 0.9},
+      {"type": "risk", "text": "Team has PostgreSQL experience", "strength": 0.7}
+    ],
+    "alternatives_considered": ["SQLite", "Redis", "MongoDB"],
+    "project": {
+      "name": "CryptoTrader",
+      "feature": "state-persistence",
+      "pr": 42
+    }
+  },
+  "id": "r-001"
+}
+```
+
+**Example response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "success": true,
+    "decision_id": "2026-02-07-decision-a1b2c3d4",
+    "path": "decisions/2026/02/2026-02-07-decision-a1b2c3d4.yaml",
+    "indexed": true,
+    "guardrails_checked": false,
+    "bridge_auto": false,
+    "deliberation_auto": true,
+    "deliberation_inputs_count": 3,
+    "related_count": 5,
+    "message": "Decision recorded and indexed"
+  },
+  "id": "r-001"
+}
+```
+
+---
+
+### `cstp.reviewDecision` — Record Outcome
+
+Record the actual outcome of a previously recorded decision.
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `decision_id` | string | ✅ | Decision ID (full or prefix) |
+| `outcome` | string | ✅ | `"success"`, `"failure"`, `"partial"`, `"abandoned"` |
+| `actual_result` | string | ✅ | Description of what actually happened |
+| `lessons` | string | ❌ | Lessons learned |
+
+**Example request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "cstp.reviewDecision",
+  "params": {
+    "decision_id": "2026-02-07-decision-a1b2c3d4",
+    "outcome": "success",
+    "actual_result": "PostgreSQL has been stable for 30 days with zero data loss",
+    "lessons": "Connection pooling was needed sooner than expected"
+  },
+  "id": "rv-001"
+}
+```
+
+---
+
+### `cstp.getDecision` — Get Decision Details
+
+Retrieve full decision record including bridge definition and deliberation trace.
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | ✅ | Decision ID |
+
+**Example response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "id": "2026-02-07-decision-a1b2c3d4",
+    "title": "Use PostgreSQL",
+    "deliberation": {
+      "inputs": [{"type": "query", "content": "db options"}],
+      "steps": [{"step": 1, "thought": "PostgreSQL meets ACID reqs"}]
+    },
+    "bridge": {
+      "structure": "PostgreSQL",
+      "function": "persistence"
+    }
+  },
+  "id": "gd-001"
+}
+```
+
+---
+
+### `cstp.getReasonStats` — Reason Analytics
+
+Analyze success rates and diversity of decision reasons.
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `min_reviewed` | int | ❌ | Minimum number of reviewed decisions (default 10) |
+
+**Example response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "success_rates": {"technical": 0.9, "intuition": 0.6},
+    "diversity_score": 0.75,
+    "dominant_type": "technical"
+  },
+  "id": "grs-001"
+}
+```
+
+---
+
+### `cstp.getCalibration` — Calibration Statistics
+
+Compute confidence calibration metrics for reviewed decisions.
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `agent` | string | ❌ | Filter by recording agent |
+| `category` | string | ❌ | Filter by decision category |
+| `stakes` | string | ❌ | Filter by stakes level |
+| `project` | string | ❌ | Filter by project |
+| `feature` | string | ❌ | Filter by feature |
+| `window` | string | ❌ | Time window: `"30d"`, `"60d"`, `"90d"` |
+
+**Example response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "total_decisions": 47,
+    "reviewed_decisions": 32,
+    "overall": {
+      "brier_score": 0.142,
+      "accuracy": 0.78,
+      "calibration_gap": 0.05,
+      "interpretation": "Good calibration"
+    },
+    "buckets": [
+      {"range": "0.0-0.2", "decisions": 2, "predicted": 0.15, "actual": 0.0, "brier": 0.023},
+      {"range": "0.2-0.4", "decisions": 5, "predicted": 0.32, "actual": 0.4, "brier": 0.051},
+      {"range": "0.4-0.6", "decisions": 8, "predicted": 0.52, "actual": 0.5, "brier": 0.098},
+      {"range": "0.6-0.8", "decisions": 10, "predicted": 0.72, "actual": 0.7, "brier": 0.089},
+      {"range": "0.8-1.0", "decisions": 7, "predicted": 0.88, "actual": 0.86, "brier": 0.021}
+    ],
+    "confidence_stats": {
+      "mean": 0.64,
+      "std_dev": 0.21,
+      "min": 0.12,
+      "max": 0.95,
+      "habituation_detected": false
+    },
+    "recommendations": [
+      {"type": "improvement", "message": "Consider more decisions in 0.0-0.2 range", "severity": "low"}
+    ]
+  },
+  "id": "c-001"
+}
+```
+
+---
+
+### `cstp.attributeOutcomes` — Automatic Outcome Attribution
+
+Automatically attribute outcomes to decisions based on PR stability (age).
+
+**Parameters:**
+
+| Param | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `project` | string | ✅ | — | Project name |
+| `since` | string | ❌ | `"30d"` | Look-back window |
+| `stability_days` | int | ❌ | 7 | Days before PR is considered stable |
+| `dry_run` | bool | ❌ | false | Preview only, don't modify files |
+
+---
+
+### `cstp.checkDrift` — Calibration Drift Detection
+
+Compare recent calibration against historical baseline to detect degradation.
+
+**Parameters:**
+
+| Param | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `category` | string | ❌ | — | Filter by category |
+| `project` | string | ❌ | — | Filter by project |
+| `brier_threshold` | float | ❌ | 0.05 | Brier score change threshold for alerts |
+| `accuracy_threshold` | float | ❌ | 0.1 | Accuracy change threshold for alerts |
+
+**Example response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "drift_detected": true,
+    "alerts": [
+      {
+        "type": "brier_degradation",
+        "recent_value": 0.22,
+        "historical_value": 0.14,
+        "change_pct": 57.1,
+        "severity": "warning"
+      }
+    ],
+    "recent_period": "30d",
+    "historical_period": "90d+",
+    "recommendations": ["Review recent high-stakes decisions for confidence accuracy"]
+  },
+  "id": "d-001"
+}
+```
+
+---
+
+### `cstp.reindex` — Full Reindex
+
+Delete and rebuild the ChromaDB collection from YAML files.
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `decisions_path` | string | ❌ | Override decisions directory |
+
+**Example response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "success": true,
+    "decisions_indexed": 47,
+    "errors": 0,
+    "duration_ms": 12340
+  },
+  "id": "ri-001"
+}
+```
+
+---
+
+## MCP Interface (Model Context Protocol)
+
+Since v0.9.0, CSTP exposes decision intelligence capabilities as **MCP tools** for native integration with any MCP-compliant agent. The MCP layer is a thin bridge — each tool maps 1:1 to an existing CSTP service method with zero code duplication.
+
+### Transports
+
+| Transport | Endpoint | Use Case |
+|-----------|----------|----------|
+| **Streamable HTTP** | `POST`/`GET` `http://host:8100/mcp` | Remote access from any network-reachable MCP client |
+| **stdio** | `python -m a2a.mcp_server` | Local access or Docker exec |
+
+### Connecting
+
+```bash
+# Claude Code — add as remote MCP server
+claude mcp add --transport http cstp-decisions http://your-server:8100/mcp
+
+# Claude Desktop — add to claude_desktop_config.json (stdio via Docker)
+{
+  "mcpServers": {
+    "cstp": {
+      "command": "docker",
+      "args": ["exec", "-i", "cstp", "python", "-m", "a2a.mcp_server"]
+    }
+  }
+}
+
+# Local development (stdio)
+python -m a2a.mcp_server
+```
+
+### MCP Tools
+
+#### `query_decisions`
+
+Search similar past decisions using semantic search, keyword matching, or hybrid retrieval.
+
+**Input Schema:**
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `query` | string | ✅ | — | Natural language query |
+| `limit` | int | ❌ | 5 | Max results (1–50) |
+| `retrieval_mode` | string | ❌ | `"hybrid"` | `"semantic"`, `"keyword"`, or `"hybrid"` |
+| `filters` | object | ❌ | — | `category`, `stakes`, `project`, `has_outcome` |
+
+**Maps to:** `cstp.queryDecisions`
+
+---
+
+#### `check_action`
+
+Validate an intended action against safety guardrails and policies.
+
+**Input Schema:**
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `description` | string | ✅ | — | Action you intend to take |
+| `category` | string | ❌ | — | Action category |
+| `stakes` | string | ❌ | `"medium"` | `"low"`, `"medium"`, `"high"`, `"critical"` |
+| `confidence` | float | ❌ | — | Your confidence (0.0–1.0) |
+
+**Maps to:** `cstp.checkGuardrails`
+
+---
+
+#### `log_decision`
+
+Record a decision to the immutable decision log.
+
+**Input Schema:**
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `decision` | string | ✅ | — | What you decided (state the choice) |
+| `confidence` | float | ✅ | — | Confidence level (0.0–1.0) |
+| `category` | string | ✅ | — | `"architecture"`, `"process"`, `"integration"`, `"tooling"`, `"security"` |
+| `stakes` | string | ❌ | `"medium"` | Stakes level |
+| `context` | string | ❌ | — | Situation context |
+| `reasons` | array | ❌ | — | `[{"type": "analysis", "text": "..."}]` — types: authority, analogy, analysis, pattern, intuition |
+| `tags` | array | ❌ | — | Tags for categorization |
+| `project` | string | ❌ | — | Project in owner/repo format |
+| `feature` | string | ❌ | — | Feature or epic name |
+| `pr` | int | ❌ | — | Pull request number |
+
+**Maps to:** `cstp.recordDecision`
+
+---
+
+#### `review_outcome`
+
+Record the outcome of a past decision for calibration.
+
+**Input Schema:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | ✅ | Decision ID (8-char hex) |
+| `outcome` | string | ✅ | `"success"`, `"partial"`, `"failure"`, `"abandoned"` |
+| `actual_result` | string | ❌ | What actually happened |
+| `lessons` | string | ❌ | Lessons learned |
+| `notes` | string | ❌ | Additional review notes |
+
+**Maps to:** `cstp.reviewDecision`
+
+---
+
+#### `get_stats`
+
+Get calibration statistics to assess decision-making quality.
+
+**Input Schema:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `category` | string | ❌ | Filter by category |
+| `project` | string | ❌ | Filter by project (owner/repo) |
+| `window` | string | ❌ | `"30d"`, `"60d"`, `"90d"`, or `"all"` |
+
+**Maps to:** `cstp.getCalibration`
+
+---
+
+### Error Handling
+
+MCP tool errors are returned as `TextContent` with JSON:
+
+```json
+{
+  "error": "validation_error",
+  "message": "1 validation error for QueryDecisionsInput..."
+}
+```
+
+Error types:
+- `validation_error` — Invalid input (Pydantic validation failure)
+- `internal_error` — Unexpected server error
+
+---
+
+## cURL Quick Reference
+
+```bash
+# Query decisions
+curl -X POST http://localhost:8100/cstp \
+  -H "Authorization: Bearer myagent:mytoken" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"cstp.queryDecisions","params":{"query":"authentication approach"},"id":"1"}'
+
+# Check guardrails
+curl -X POST http://localhost:8100/cstp \
+  -H "Authorization: Bearer myagent:mytoken" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"cstp.checkGuardrails","params":{"action":{"description":"Deploy to prod","stakes":"high","context":{"affects_production":true}}},"id":"2"}'
+
+# Record decision
+curl -X POST http://localhost:8100/cstp \
+  -H "Authorization: Bearer myagent:mytoken" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"cstp.recordDecision","params":{"decision":"Use Redis for caching","confidence":0.8,"category":"architecture"},"id":"3"}'
+
+# Health check (no auth)
+curl http://localhost:8100/health
+```

--- a/website/reference/architecture.md
+++ b/website/reference/architecture.md
@@ -1,0 +1,436 @@
+# System Architecture
+
+## High-Level Architecture
+
+```mermaid
+graph TB
+    subgraph Agents["AI AGENTS"]
+        direction LR
+        LC["LangChain"]
+        AG["AutoGen"]
+        CR["CrewAI"]
+        CD["Claude Desktop"]
+        OC["OpenClaw"]
+        CP["Custom Python"]
+    end
+
+    subgraph A2A["A2A LAYER"]
+        direction TB
+        FS["FastAPI Server<br/>(a2a/server.py)"]
+        CSTP_EP["POST /cstp<br/>JSON-RPC 2.0"]
+        MCP_EP["POST|GET /mcp<br/>Streamable HTTP"]
+        HEALTH["GET /health"]
+        AGENT_CARD["GET /.well-known/agent.json"]
+        FS --- CSTP_EP
+        FS --- MCP_EP
+        FS --- HEALTH
+        FS --- AGENT_CARD
+    end
+
+    subgraph MCP_LAYER["MCP LAYER"]
+        direction TB
+        MCP_SRV["MCP Server<br/>(a2a/mcp_server.py)"]
+        MCP_SCH["MCP Schemas<br/>(a2a/mcp_schemas.py)"]
+        STDIO["stdio transport<br/>python -m a2a.mcp_server"]
+        SHTTP["StreamableHTTPSessionManager"]
+        MCP_SRV --- MCP_SCH
+        MCP_EP --> SHTTP --> MCP_SRV
+        STDIO --> MCP_SRV
+    end
+
+    subgraph DISPATCH["CSTP DISPATCHER"]
+        direction TB
+        DISP["dispatcher.py"]
+        QD["queryDecisions"]
+        CG["checkGuardrails"]
+        LG["listGuardrails"]
+        RD["recordDecision"]
+        RV["reviewDecision"]
+        GC["getCalibration"]
+        AO["attributeOutcomes"]
+        CDR["checkDrift"]
+        RI["reindex"]
+        DISP --- QD & CG & LG & RD & RV & GC & AO & CDR & RI
+    end
+
+    subgraph CLI_LAYER["CLI LAYER"]
+        direction TB
+        CLI["bin/cognition"]
+        CLI_INDEX["index <dir>"]
+        CLI_QUERY["query <context>"]
+        CLI_CHECK["check --stakes"]
+        CLI --- CLI_INDEX & CLI_QUERY & CLI_CHECK
+    end
+
+    subgraph DASHBOARD["WEB DASHBOARD"]
+        FLASK["Flask + Jinja2<br/>(dashboard/app.py)"]
+    end
+
+    subgraph SERVICES["CSTP SERVICES"]
+        direction TB
+        QS["query_service<br/>(semantic + BM25 hybrid)"]
+        DS["decision_service<br/>(record + YAML + ChromaDB)"]
+        CS["calibration_service<br/>(Brier + buckets)"]
+        GS["guardrails_service<br/>(YAML-based evaluation)"]
+        AS["attribution_service<br/>(PR stability)"]
+        DRS["drift_service<br/>(30d vs 90d)"]
+        RS["reindex_service<br/>(full rebuild)"]
+        DT["deliberation_tracker<br/>(auto-capture traces)"]
+        BE["bridge_extractor<br/>(structure/function)"]
+        BM["bm25_index<br/>(keyword search)"]
+    end
+
+    subgraph CORE["CORE ENGINES (src/cognition_engines/)"]
+        direction TB
+        SI["SemanticIndex<br/>(ChromaDB + Gemini)"]
+        PD["PatternDetector<br/>(calibration, anti-patterns)"]
+        GE["GuardrailEngine<br/>(YAML loader + evaluator)"]
+        AL["AuditLog<br/>(JSON audit trail)"]
+    end
+
+    subgraph STORAGE["STORAGE LAYER"]
+        direction LR
+        CHROMA["ChromaDB<br/>(vectors + metadata)"]
+        YAML["YAML Decision Files<br/>decisions/YYYY/MM/"]
+        GUARD["Guardrail YAML Files"]
+        AUDIT["Audit Trail<br/>audit/*.json"]
+    end
+
+    Agents -->|JSON-RPC 2.0 / Bearer Token| CSTP_EP
+    Agents -->|MCP / Streamable HTTP| MCP_EP
+    Agents -->|MCP / stdio| STDIO
+    CLI_LAYER -->|direct import| CORE
+    DASHBOARD -->|HTTP client| CSTP_EP
+
+    CSTP_EP --> DISP
+    MCP_SRV -->|direct function calls| SERVICES
+    DISP --> SERVICES
+    SERVICES --> CORE
+    CORE --> STORAGE
+
+```
+
+---
+
+## Component Breakdown
+
+### 1. A2A Layer (`a2a/`)
+
+The **Agent-to-Agent** layer is the network-facing surface of Cognition Engines.
+
+| File | Purpose |
+|------|---------|
+| `server.py` | FastAPI application with lifespan management, CORS, route registration, and MCP mount at `/mcp` |
+| `config.py` | Multi-source configuration: YAML file → environment variables → defaults |
+| `auth.py` | Bearer token authentication with constant-time comparison (`secrets.compare_digest`) |
+| `mcp_server.py` | MCP Server with 5 tool handlers; exposes `mcp_app` Server instance for mounting |
+| `mcp_schemas.py` | Pydantic input schemas for MCP tool definitions (auto-generates JSON Schema for tool discovery) |
+| `__init__.py` | Package exports |
+
+**Endpoints:**
+
+- `POST /cstp` — JSON-RPC 2.0 dispatch (authenticated)
+- `POST|GET /mcp` — MCP Streamable HTTP transport (tool calls + event streams)
+- `GET /health` — Health check with uptime (unauthenticated)
+- `GET /.well-known/agent.json` — A2A agent card for discovery (unauthenticated)
+
+### 2. CSTP Services (`a2a/cstp/`)
+
+Each JSON-RPC method is backed by a dedicated service module:
+
+| Service | Method | Description |
+|---------|--------|-------------|
+| `query_service.py` | `cstp.queryDecisions` | Semantic search over ChromaDB with optional BM25 hybrid |
+| `decision_service.py` | `cstp.recordDecision` | Record new decisions as YAML + ChromaDB index |
+| `decision_service.py` | `cstp.reviewDecision` | Record outcome of a past decision for calibration |
+| `guardrails_service.py` | `cstp.checkGuardrails` | Evaluate context against all loaded guardrails |
+| `guardrails_service.py` | `cstp.listGuardrails` | List active guardrail definitions |
+| `calibration_service.py` | `cstp.getCalibration` | Compute Brier scores, confidence buckets, and variance |
+| `attribution_service.py` | `cstp.attributeOutcomes` | Auto-attribute outcomes via PR stability |
+| `drift_service.py` | `cstp.checkDrift` | Compare 30-day vs. 90-day+ calibration |
+| `reindex_service.py` | `cstp.reindex` | Delete and rebuild ChromaDB collection |
+| `deliberation_tracker.py` | (auto-hook) | Tracks inputs and steps for reasoning traces |
+| `bridge_extractor.py` | (auto-hook) | Extracts structure/function from decision text |
+| `dispatcher.py` | (router) | Maps JSON-RPC method names to async handlers |
+| `models.py` | (shared) | Pydantic-style dataclasses for request/response objects |
+| `bm25_index.py` | (internal) | BM25Okapi keyword index with caching and score merging |
+
+### 3. MCP Layer (`a2a/mcp_server.py` + `a2a/mcp_schemas.py`)
+
+The MCP layer provides **Model Context Protocol** access to CSTP capabilities. It is a thin bridge — Pydantic schemas validate inputs, then tool handlers delegate directly to CSTP service functions.
+
+| Component | File | Description |
+|-----------|------|-------------|
+| `mcp_app` | `mcp_server.py` | `Server("cstp-decisions")` instance — importable for ASGI mounting |
+| `list_tools()` | `mcp_server.py` | Returns 5 `Tool` definitions with JSON Schema from Pydantic models |
+| `call_tool()` | `mcp_server.py` | Dispatches tool calls to `_handle_*` functions |
+| `run_stdio()` | `mcp_server.py` | Runs the MCP server with stdio transport |
+| `StreamableHTTPSessionManager` | `server.py` | Manages Streamable HTTP sessions; mounted at `/mcp` via lifespan |
+| `QueryDecisionsInput` | `mcp_schemas.py` | Schema for `query_decisions` tool |
+| `CheckActionInput` | `mcp_schemas.py` | Schema for `check_action` tool |
+| `LogDecisionInput` | `mcp_schemas.py` | Schema for `log_decision` tool |
+| `ReviewOutcomeInput` | `mcp_schemas.py` | Schema for `review_outcome` tool |
+| `GetStatsInput` | `mcp_schemas.py` | Schema for `get_stats` tool |
+
+**MCP tools → CSTP method mapping:**
+
+| MCP Tool | CSTP Method | Service |
+|----------|-------------|---------|
+| `query_decisions` | `cstp.queryDecisions` | `query_service.py` |
+| `check_action` | `cstp.checkGuardrails` | `guardrails_service.py` |
+| `log_decision` | `cstp.recordDecision` | `decision_service.py` |
+| `review_outcome` | `cstp.reviewDecision` | `decision_service.py` |
+| `get_stats` | `cstp.getCalibration` | `calibration_service.py` |
+
+### 4. Core Engines (`src/cognition_engines/`)
+
+The library-level logic, usable independently of the HTTP server.
+
+#### Accelerators (`accelerators/`)
+
+| Class | File | Description |
+|-------|------|-------------|
+| `SemanticIndex` | `semantic_index.py` | ChromaDB HTTP API wrapper with Gemini embedding generation, decision indexing, filtered vector query |
+
+#### Guardrails (`guardrails/`)
+
+| Class | File | Description |
+|-------|------|-------------|
+| `GuardrailEngine` | `engine.py` | Loads YAML guardrails, evaluates conditions + requirements, returns pass/block/warn results |
+| `GuardrailCondition` | `engine.py` | Parsed condition with operator support (`<`, `>`, `=`, `!=`, `in`) |
+| `GuardrailRequirement` | `engine.py` | Boolean requirement check (field must be `true`) |
+| `Guardrail` | `engine.py` | Full guardrail definition with scope, conditions, requirements, action, message |
+| `ConditionEvaluator` | `evaluators.py` | Protocol for pluggable evaluators |
+| `FieldCondition` | `evaluators.py` | v2 field comparison with extended operators |
+| `SemanticCondition` | `evaluators.py` | Checks semantic similarity to past decisions |
+| `TemporalCondition` | `evaluators.py` | Time-window based conditions |
+| `AggregateCondition` | `evaluators.py` | Statistical aggregate checks (e.g., success rate < 50%) |
+| `CompoundCondition` | `evaluators.py` | AND/OR logical composition of conditions |
+| `AuditLog` | `audit.py` | Manages JSON audit trail for guardrail evaluations |
+| `AuditRecord` | `audit.py` | Per-decision audit record with override support |
+
+#### Patterns (`patterns/`)
+
+| Class | File | Description |
+|-------|------|-------------|
+| `PatternDetector` | `detector.py` | Loads YAML decisions, generates calibration reports, detects anti-patterns, produces category analysis |
+| `CalibrationBucket` | `detector.py` | Confidence bucket with Brier score computation |
+| `AntiPattern` | `detector.py` | Detected anti-pattern (e.g., overcalibration, flip-flopping) |
+
+### 5. Web Dashboard (`dashboard/`)
+
+A Flask-based web UI for human-friendly decision browsing and outcome review.
+
+| File | Description |
+|------|-------------|
+| `app.py` | Flask routes: decisions list, detail, review, calibration |
+| `config.py` | Dashboard-specific config (CSTP URL, auth, port) |
+| `auth.py` | HTTP Basic Auth decorator |
+| `cstp_client.py` | Async CSTP client for backend communication |
+| `models.py` | Dashboard-specific data models |
+| `templates/` | Jinja2 HTML templates (base, decisions, decision, review, calibration) |
+| `static/` | CSS/JS assets |
+
+### 6. Guardrail Definitions (`guardrails/`)
+
+| File | Description |
+|------|-------------|
+| `cornerstone.yaml` | Non-negotiable block-level rules (production review, confidence minimum, backtest requirement) |
+| `templates/financial.yaml` | Template for financial/trading projects (risk assessment, position limits, audit trail) |
+| `templates/production-safety.yaml` | Template for production deployments (code review, CI, rollback, no-Friday deploys) |
+
+### 7. CLI (`bin/cognition`)
+
+A standalone Python CLI providing all core operations without the HTTP server.
+
+---
+
+## Data Flow
+
+### Query Flow
+
+```mermaid
+sequenceDiagram
+    participant Agent
+    participant FastAPI as POST /cstp
+    participant Dispatcher
+    participant QuerySvc as query_service
+    participant Gemini as Gemini API
+    participant Chroma as ChromaDB
+    participant BM25 as BM25 Index
+
+    Agent->>FastAPI: JSON-RPC queryDecisions
+    FastAPI->>Dispatcher: dispatch
+    Dispatcher->>QuerySvc: query_decisions()
+    QuerySvc->>Gemini: generate embedding
+    Gemini-->>QuerySvc: 768-dim vector
+    QuerySvc->>Chroma: semantic search
+    Chroma-->>QuerySvc: ranked results
+    opt hybrid mode
+        QuerySvc->>BM25: keyword search
+        BM25-->>QuerySvc: BM25 scores
+        QuerySvc->>QuerySvc: merge & rank
+    end
+    QuerySvc-->>Agent: JSON-RPC response
+```
+
+### Record Flow
+
+```mermaid
+sequenceDiagram
+    participant Agent
+    participant FastAPI as POST /cstp
+    participant Dispatcher
+    participant DecSvc as decision_service
+    participant Guard as guardrails_service
+    participant Gemini as Gemini API
+    participant Chroma as ChromaDB
+    participant Disk as YAML File
+
+    Agent->>FastAPI: JSON-RPC recordDecision
+    FastAPI->>Dispatcher: dispatch
+    Dispatcher->>DecSvc: record_decision()
+    DecSvc->>Guard: check guardrails
+    Guard-->>DecSvc: pass/fail
+    DecSvc->>DecSvc: build YAML structure
+    DecSvc->>Disk: write YAML file
+    DecSvc->>Gemini: generate embedding
+    Gemini-->>DecSvc: 768-dim vector
+    DecSvc->>Chroma: index decision
+    DecSvc-->>Agent: decision ID + path
+```
+
+### MCP Data Flow
+
+```mermaid
+sequenceDiagram
+    participant Client as MCP Client
+    participant Transport as Transport Layer
+    participant MCPSrv as MCP Server (mcp_app)
+    participant Services as CSTP Services
+    participant Storage as ChromaDB + YAML
+
+    alt Streamable HTTP
+        Client->>Transport: POST /mcp (HTTP)
+        Transport->>MCPSrv: StreamableHTTPSessionManager
+    else stdio
+        Client->>Transport: stdin/stdout
+        Transport->>MCPSrv: stdio_server
+    end
+
+    MCPSrv->>MCPSrv: validate via Pydantic schemas
+    MCPSrv->>Services: direct function call
+    Services->>Storage: read/write
+    Storage-->>Services: result
+    Services-->>MCPSrv: response dict
+    MCPSrv-->>Client: TextContent (JSON)
+```
+
+### Guardrail Flow
+
+```mermaid
+sequenceDiagram
+    participant Agent
+    participant FastAPI as POST /cstp
+    participant Dispatcher
+    participant GuardSvc as guardrails_service
+    participant Engine as GuardrailEngine
+    participant Audit as AuditLog
+
+    Agent->>FastAPI: JSON-RPC checkGuardrails
+    FastAPI->>Dispatcher: dispatch
+    Dispatcher->>GuardSvc: evaluate_guardrails()
+    GuardSvc->>Engine: load YAML (cached 5 min)
+    Engine->>Engine: match conditions
+    Engine->>Engine: evaluate requirements
+    Engine-->>GuardSvc: violations + warnings
+    GuardSvc->>Audit: log audit trail
+    GuardSvc-->>Agent: allowed/blocked + details
+```
+
+### Deliberation & Bridge Flow
+
+```mermaid
+sequenceDiagram
+    participant Agent
+    participant FastAPI as POST /cstp
+    participant Tracker as DeliberationTracker
+    participant DecSvc as decision_service
+    participant Extractor as BridgeExtractor
+    participant Storage as ChromaDB + YAML
+
+    Agent->>FastAPI: queryDecisions("...")
+    FastAPI->>Tracker: track_query(agent_id, query)
+    FastAPI-->>Agent: results
+
+    Agent->>FastAPI: checkGuardrails("...")
+    FastAPI->>Tracker: track_check(agent_id, action)
+    FastAPI-->>Agent: allowed/blocked
+
+    Agent->>FastAPI: recordDecision("...", bridge=None)
+    FastAPI->>DecSvc: record_decision()
+    
+    DecSvc->>Tracker: auto_attach_deliberation(agent_id)
+    Tracker-->>DecSvc: Deliberation object (inputs + steps)
+    
+    alt No explicit bridge
+        DecSvc->>Extractor: auto_extract_bridge(decision, context)
+        Extractor-->>DecSvc: BridgeDefinition (structure + function)
+    end
+
+    DecSvc->>Storage: write YAML (with deliberation + bridge)
+    DecSvc->>Storage: index (embedding: structure + function)
+    DecSvc-->>Agent: success
+```
+
+---
+
+## Deployment Architecture
+
+```mermaid
+graph TB
+    subgraph Docker["Docker Compose"]
+        subgraph CSTP["cstp-server (Python 3.11)"]
+            PORT_8100["Port: 8100"]
+            EP_CSTP["/cstp — JSON-RPC 2.0"]
+            EP_MCP["/mcp — MCP Streamable HTTP"]
+            EP_HEALTH["/health"]
+            VOL_CONFIG["config/ (ro)"]
+            VOL_GUARD["guardrails/"]
+            VOL_DEC["decisions/"]
+        end
+
+        subgraph CHROMA["chromadb (chromadb/chroma)"]
+            PORT_8000["Port: 8000"]
+            VOL_CHROMA["chroma_data"]
+            HB["/api/v1/heartbeat"]
+        end
+
+        CSTP -->|HTTP| CHROMA
+    end
+
+    NET["Network: cstp-network (bridge)"]
+    Docker --- NET
+```
+
+**Docker Image:** Multi-stage build (`python:3.11-slim`)
+
+- **Builder stage:** Installs `uv` and Python dependencies from `pyproject.toml`
+- **Runtime stage:** Copies installed packages, app code, creates non-root user
+- **Security:** Runs as `appuser` (non-root), read-only config mounts
+- **MCP:** Both `/cstp` (JSON-RPC) and `/mcp` (MCP Streamable HTTP) are served on port 8100
+
+---
+
+## Security Model
+
+| Layer | Mechanism |
+|-------|-----------|
+| **Transport** | HTTPS (reverse proxy recommended for production) |
+| **Authentication** | Bearer token per agent, validated with `secrets.compare_digest` |
+| **Authorization** | Agent ID embedded in each request; audit trail records who did what |
+| **MCP Auth** | MCP Streamable HTTP inherits FastAPI bearer token middleware |
+| **Secrets** | Environment variables or `${VAR}` expansion in YAML config |
+| **Container** | Non-root user, minimal base image, no-cache pip installs |
+| **CORS** | Configurable allowed origins (defaults to `*`) |
+| **CSRF** | Dashboard uses Flask-WTF CSRF protection |

--- a/website/reference/cli.md
+++ b/website/reference/cli.md
@@ -1,0 +1,165 @@
+# CLI Reference
+
+Cognition Engines provides two CLI tools:
+1. **`bin/cognition`** — Local/offline tool for direct database access (server-side)
+2. **`scripts/cstp.py`** — Remote client for connecting to the CSTP server (client-side)
+
+---
+
+## 1. Local CLI (`bin/cognition`)
+
+**Location:** `bin/cognition`
+**Use case:** Server maintenance, offline indexing, direct guardrail checks.
+
+### Prerequisites
+
+- Python 3.11+
+- `cognition-engines` package installed
+- `GEMINI_API_KEY` environment variable
+- ChromaDB accessible
+
+### Commands
+
+#### `cognition index <directory>`
+
+Index all YAML decision files from a directory into ChromaDB.
+
+```bash
+# Index decisions from the default directory
+python bin/cognition index decisions/
+```
+
+#### `cognition query <context>`
+
+Search for semantically similar decisions.
+
+```bash
+# Basic query
+python bin/cognition query "database selection"
+```
+
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `--category CAT` | Filter by decision category |
+| `--min-confidence N` | Minimum confidence threshold |
+
+#### `cognition check`
+
+Evaluate guardrails against a decision context.
+
+```bash
+python bin/cognition check --category architecture --stakes high --confidence 0.8
+```
+
+#### `cognition guardrails`
+
+List all loaded guardrail definitions.
+
+#### `cognition count`
+
+Count indexed decisions.
+
+#### `cognition patterns <subcommand>`
+
+Run pattern analysis: `calibration`, `categories`, `antipatterns`, `full`.
+
+---
+
+## 2. CSTP Client (`scripts/cstp.py`)
+
+**Location:** `scripts/cstp.py`
+**Use case:** Agent interaction, recording decisions, querying the server.
+
+### Setup
+
+Requires `.secrets/cstp.env` with `CSTP_URL` and `CSTP_TOKEN`.
+
+### `cstp.py query`
+
+Query similar decisions from the server.
+
+```bash
+python scripts/cstp.py query "how to persist state" --top 5 --mode hybrid
+```
+
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `--top N` | Number of results (default: 5) |
+| `--category CAT` | Filter by category |
+| `--project PROJ` | Filter by project |
+| `--mode MODE` | Retrieval mode: `semantic`, `keyword`, `hybrid` |
+| `--bridge-side SIDE` | Search by bridge side: `structure`, `function` |
+
+### `cstp.py check`
+
+Check guardrails before acting.
+
+```bash
+python scripts/cstp.py check -d "deploy to prod" -s high -f 0.9
+```
+
+### `cstp.py record`
+
+Record a decision.
+
+```bash
+python scripts/cstp.py record \
+  -d "Use PostgreSQL" \
+  -c architecture \
+  -s high \
+  -f 0.85 \
+  --structure "PostgreSQL" \
+  --function "Relational persistence"
+```
+
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `-d`, `--decision` | Decision text (required) |
+| `-c`, `--category` | Category (required) |
+| `-s`, `--stakes` | Stakes: low, medium, high, critical |
+| `-f`, `--confidence` | Confidence (0.0-1.0) |
+| `--context` | Context description |
+| `-r`, `--reason` | Add reason (type:text) |
+| `--structure` | Bridge: structure/pattern |
+| `--function` | Bridge: function/purpose |
+| `--tolerance` | Bridge: features that don't matter |
+| `--enforcement` | Bridge: features that must be present |
+| `--prevention` | Bridge: features that must be absent |
+
+### `cstp.py get`
+
+Get full decision details by ID, including reasons, bridge, related decisions, and deliberation.
+
+```bash
+python scripts/cstp.py get <ID>
+```
+
+### `cstp.py review`
+
+Review a decision outcome.
+
+```bash
+python scripts/cstp.py review --id <ID> --outcome success
+```
+
+### `cstp.py calibration`
+
+Get calibration stats.
+
+```bash
+python scripts/cstp.py calibration
+```
+
+### `cstp.py reason-stats`
+
+Get reason-type statistics.
+
+```bash
+python scripts/cstp.py reason-stats --min-reviewed 5
+```

--- a/website/reference/configuration.md
+++ b/website/reference/configuration.md
@@ -1,0 +1,252 @@
+# Configuration Guide
+
+Cognition Engines supports configuration through three sources (in order of precedence):
+
+1. **Environment variables** (highest priority)
+2. **YAML configuration file** (`config/server.yaml`)
+3. **Built-in defaults** (lowest priority)
+
+---
+
+## Environment Variables
+
+### Required
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `GEMINI_API_KEY` | Google Gemini API key for text embeddings | `AIza...` |
+| `CSTP_AUTH_TOKENS` | Comma-separated `agent:token` pairs | `emerson:abc123,claude:xyz789` |
+
+### Server
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CSTP_HOST` | `0.0.0.0` | Server bind address |
+| `CSTP_PORT` | `8100` | Server port |
+| `LOG_LEVEL` | `INFO` | `DEBUG`, `INFO`, `WARNING`, `ERROR` |
+
+### ChromaDB
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CHROMA_URL` | `http://chromadb:8000` | ChromaDB server URL |
+| `CHROMA_TOKEN` | — | ChromaDB auth token (optional) |
+| `CHROMA_COLLECTION` | `decisions_gemini` | Collection name |
+
+### Storage
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DECISIONS_PATH` | `decisions` | Directory for decision YAML files |
+| `GUARDRAILS_PATHS` | `guardrails` | Colon-separated guardrail directories |
+| `SECRETS_PATHS` | — | Directories to search for secret files |
+
+### Agent Card
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CSTP_AGENT_NAME` | `cognition-engines` | Agent name in discovery card |
+| `CSTP_AGENT_DESCRIPTION` | `Decision Intelligence Service` | Agent description |
+| `CSTP_AGENT_VERSION` | `0.9.0` | Reported version |
+| `CSTP_AGENT_URL` | — | Public URL for agent card |
+| `CSTP_AGENT_CONTACT` | — | Contact email |
+
+---
+
+## YAML Configuration File
+
+**Location:** `config/server.yaml`
+
+```yaml
+# Server settings
+host: 0.0.0.0
+port: 8100
+
+# CORS (comma-separated or list)
+cors_origins:
+  - "*"
+
+# Agent identity (shown in /.well-known/agent.json)
+agent:
+  name: cognition-engines
+  description: Decision Intelligence Service - Semantic search and guardrail evaluation
+  version: 0.9.0
+  url: https://your-domain.com
+  contact: admin@your-domain.com
+
+# Authentication
+auth:
+  enabled: true
+  tokens:
+    - agent: emerson
+      token: your-secret-token-here
+    - agent: claude
+      token: another-secret-token
+```
+
+### Variable Substitution in YAML
+
+YAML values support `${ENV_VAR}` expansion:
+
+```yaml
+auth:
+  tokens:
+    - agent: emerson
+      token: ${EMERSON_TOKEN}
+```
+
+---
+
+## Authentication Configuration
+
+### Token Format
+
+Tokens are `agent:secret` pairs. The agent name is:
+
+- Extracted from the `Authorization: Bearer agent:secret` header
+- Logged in audit trails
+- Used for per-agent calibration filtering
+
+### Via Environment
+
+```bash
+# Single agent
+CSTP_AUTH_TOKENS=myagent:mysecrettoken
+
+# Multiple agents
+CSTP_AUTH_TOKENS=emerson:abc123,claude:xyz789,autogen:secret99
+```
+
+### Via YAML
+
+```yaml
+auth:
+  enabled: true
+  tokens:
+    - agent: emerson
+      token: abc123
+    - agent: claude
+      token: xyz789
+```
+
+### Disabling Auth
+
+For development or testing:
+
+```yaml
+auth:
+  enabled: false
+```
+
+> **Warning:** Never disable auth in production.
+
+### MCP Authentication
+
+The MCP Streamable HTTP transport at `/mcp` inherits authentication from the FastAPI bearer token middleware. The same `CSTP_AUTH_TOKENS` configuration applies to both the JSON-RPC `/cstp` endpoint and the MCP `/mcp` endpoint.
+
+The stdio transport (`python -m a2a.mcp_server`) does not use bearer tokens — it relies on the process-level security of the hosting environment (e.g., Docker container isolation).
+
+---
+
+## Storage Configuration
+
+### Decision Storage
+
+Decisions are stored as YAML files in a hierarchical directory:
+
+```
+decisions/
+├── 2026/
+│   ├── 01/
+│   │   ├── 2026-01-15-decision-a1b2c3d4.yaml
+│   │   └── 2026-01-20-decision-e5f6g7h8.yaml
+│   └── 02/
+│       └── 2026-02-07-decision-i9j0k1l2.yaml
+```
+
+**File naming:** `YYYY-MM-DD-decision-<8-char-id>.yaml`
+
+### Guardrail Storage
+
+Guardrails are loaded from YAML files in configured directories:
+
+```
+guardrails/
+├── cornerstone.yaml           # Core rules (always loaded)
+├── project-specific.yaml      # Your project rules
+└── templates/
+    ├── financial.yaml         # Template for financial projects
+    └── production-safety.yaml # Template for production deploys
+```
+
+Multiple guardrail directories can be configured:
+
+```bash
+GUARDRAILS_PATHS=/app/guardrails:/app/custom-guardrails:/shared/company-guardrails
+```
+
+---
+
+## CORS Configuration
+
+Configure allowed origins for the CSTP API:
+
+```yaml
+cors_origins:
+  - "http://localhost:3000"
+  - "http://localhost:5001"
+  - "https://your-domain.com"
+```
+
+Or allow all origins (development only):
+
+```yaml
+cors_origins:
+  - "*"
+```
+
+---
+
+## Secrets Management
+
+The system searches for secret files in `SECRETS_PATHS`:
+
+```bash
+SECRETS_PATHS=/run/secrets:/app/secrets
+```
+
+This is used primarily for loading `GEMINI_API_KEY` from files (useful in Docker secrets or Kubernetes secrets):
+
+```bash
+# Create a secret file
+echo "AIza..." > /run/secrets/gemini_api_key
+```
+
+The `load_gemini_key()` function searches for files named `gemini_api_key` or `GEMINI_API_KEY` in these paths.
+
+---
+
+## Docker Compose Configuration
+
+The `docker-compose.yml` file manages all configuration via environment variables:
+
+```yaml
+services:
+  cstp-server:
+    environment:
+      - GEMINI_API_KEY=${GEMINI_API_KEY}
+      - CSTP_AUTH_TOKENS=${CSTP_AUTH_TOKENS}
+      - CHROMA_URL=http://chromadb:8000
+      - DECISIONS_PATH=/app/decisions
+      - GUARDRAILS_PATHS=/app/guardrails
+      - LOG_LEVEL=INFO
+```
+
+Create a `.env` file in the project root:
+
+```env
+GEMINI_API_KEY=AIza...
+CSTP_AUTH_TOKENS=myagent:mysecrettoken
+```
+
+Docker Compose automatically loads variables from `.env`.

--- a/website/reference/installation.md
+++ b/website/reference/installation.md
@@ -1,0 +1,373 @@
+# Installation Guide
+
+This guide covers three installation methods: Docker (recommended for production), local development, and integration as a skill.
+
+---
+
+## Prerequisites
+
+| Requirement | Version | Purpose |
+|-------------|---------|---------|
+| Python | ≥ 3.11 | Core runtime |
+| Docker + Docker Compose | Latest | Container deployment |
+| Gemini API Key | — | Text embeddings (`text-embedding-004`) |
+| ChromaDB | ≥ 0.4 | Vector database |
+
+### Obtaining a Gemini API Key
+
+1. Visit [Google AI Studio](https://makersuite.google.com/app/apikey)
+2. Create a new API key
+3. Save it — you'll need it for configuration
+
+---
+
+## Method 1: Docker (Recommended)
+
+### Quick Start
+
+```bash
+# 1. Clone the repository
+git clone https://github.com/tfatykhov/cognition-agent-decisions.git
+cd cognition-agent-decisions
+
+# 2. Create environment file
+cp .env.example .env
+
+# 3. Edit .env with your settings
+#    At minimum, set:
+#    - GEMINI_API_KEY=your_key_here
+#    - CSTP_AUTH_TOKENS=myagent:mysecrettoken
+
+# 4. Start services
+docker compose up -d
+
+# 5. Verify
+curl http://localhost:8100/health
+```
+
+### What Gets Started
+
+| Service | Port | Description |
+|---------|------|-------------|
+| `cstp-server` | 8100 | CSTP API server |
+| `chromadb` | 8000 | ChromaDB vector database |
+
+### Docker Compose Details
+
+```yaml
+services:
+  cstp-server:
+    build: .
+    ports:
+      - "8100:8100"
+    environment:
+      - GEMINI_API_KEY=${GEMINI_API_KEY}
+      - CSTP_AUTH_TOKENS=${CSTP_AUTH_TOKENS}
+      - CHROMA_URL=http://chromadb:8000
+    volumes:
+      - ./config:/app/config:ro
+      - ./guardrails:/app/guardrails:ro
+      - decisions_data:/app/decisions
+    depends_on:
+      chromadb:
+        condition: service_healthy
+
+  chromadb:
+    image: chromadb/chroma:latest
+    ports:
+      - "8000:8000"
+    volumes:
+      - chroma_data:/chroma/chroma
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/api/v1/heartbeat"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+```
+
+### Persistent Volumes
+
+| Volume | Purpose |
+|--------|---------|
+| `decisions_data` | Recorded decision YAML files |
+| `chroma_data` | ChromaDB index data |
+
+### Custom Guardrails
+
+Mount your guardrail YAML files:
+
+```yaml
+volumes:
+  - ./my-guardrails:/app/custom-guardrails:ro
+environment:
+  - GUARDRAILS_PATHS=/app/guardrails:/app/custom-guardrails
+```
+
+### Rebuilding
+
+```bash
+# Rebuild after code changes
+docker compose build --no-cache cstp-server
+
+# Restart services
+docker compose up -d
+
+# View logs
+docker compose logs -f cstp-server
+```
+
+---
+
+## Method 2: Local Development
+
+### Step 1: Clone and Set Up Environment
+
+```bash
+# Clone
+git clone https://github.com/tfatykhov/cognition-agent-decisions.git
+cd cognition-agent-decisions
+
+# Create virtual environment
+python -m venv .venv
+
+# Activate (Windows PowerShell)
+.\.venv\Scripts\Activate
+
+# Activate (Linux/macOS)
+source .venv/bin/activate
+```
+
+### Step 2: Install Dependencies
+
+```bash
+# Install with pip (including A2A server dependencies)
+python -m pip install -e ".[a2a,dev]"
+
+# Install with MCP support
+python -m pip install -e ".[a2a,mcp,dev]"
+
+# Or with uv (faster)
+pip install uv
+uv pip install -e ".[a2a,mcp,dev]"
+```
+
+**Dependency groups:**
+
+- **Core:** `pyyaml`, `chromadb`, `rank-bm25`
+- **`[a2a]`:** `fastapi`, `uvicorn`, `httpx`, `python-multipart`
+- **`[mcp]`:** `mcp` (Model Context Protocol SDK)
+- **`[dev]`:** `pytest`, `pytest-asyncio`, `pytest-cov`, `mypy`, `ruff`
+
+### Step 3: Start ChromaDB
+
+You need ChromaDB running independently:
+
+```bash
+# Option A: Docker
+docker run -d --name chromadb -p 8000:8000 chromadb/chroma:latest
+
+# Option B: Python (in-process)
+pip install chromadb
+chroma run --host 0.0.0.0 --port 8000
+```
+
+### Step 4: Configure Environment
+
+```bash
+# Create .env file
+cp .env.example .env
+
+# Set required variables
+$env:GEMINI_API_KEY = "your_gemini_api_key"
+$env:CSTP_AUTH_TOKENS = "myagent:mysecrettoken"
+$env:CHROMA_URL = "http://localhost:8000"
+```
+
+### Step 5: Start the CSTP Server
+
+```bash
+# Using the package script
+cstp-server --config config/server.yaml
+
+# Or directly with Python
+python -m uvicorn a2a.server:app --host 0.0.0.0 --port 8100
+
+# Or with the entry point
+python a2a/server.py --config config/server.yaml --port 8100
+```
+
+### Step 6: Verify
+
+```bash
+# Health check
+curl http://localhost:8100/health
+
+# Agent card
+curl http://localhost:8100/.well-known/agent.json
+
+# Query decisions (requires auth)
+curl -X POST http://localhost:8100/cstp `
+  -H "Authorization: Bearer myagent:mysecrettoken" `
+  -H "Content-Type: application/json" `
+  -d '{"jsonrpc":"2.0","method":"cstp.queryDecisions","params":{"query":"test"},"id":"1"}'
+```
+
+### Step 7: Run Tests
+
+```bash
+# Run all tests
+python -m pytest tests/ -v
+
+# Run with coverage
+python -m pytest tests/ --cov=src/cognition_engines --cov=a2a --cov-report=term-missing
+
+# Run specific test module
+python -m pytest tests/test_guardrails.py -v
+
+# Type checking
+python -m mypy src/ a2a/ --ignore-missing-imports
+
+# Linting
+python -m ruff check src/ a2a/
+```
+
+---
+
+## Method 3: Integration as Library
+
+Use Cognition Engines directly in your Python agent without the HTTP server.
+
+### Install
+
+```bash
+pip install cognition-engines
+# Or from source:
+pip install -e /path/to/cognition-agent-decisions
+```
+
+### Usage
+
+```python
+from cognition_engines.accelerators.semantic_index import get_index
+from cognition_engines.guardrails.engine import get_engine, load_default_guardrails
+from cognition_engines.patterns.detector import PatternDetector
+
+# --- Semantic Index ---
+index = get_index()
+index.index_decisions([{
+    "title": "Use Redis for caching",
+    "category": "architecture",
+    "confidence": 0.85,
+    "decision": "Chose Redis over Memcached for caching layer",
+}])
+
+results = index.query("caching solution", n_results=5)
+
+# --- Guardrails ---
+load_default_guardrails()
+engine = get_engine()
+allowed, results = engine.check({
+    "category": "deployment",
+    "stakes": "high",
+    "affects_production": True,
+    "code_review_completed": True,
+})
+
+# --- Pattern Detection ---
+detector = PatternDetector()
+detector.load_from_directory("decisions/")
+report = detector.full_report()
+```
+
+---
+
+## Method 4: OpenClaw Skill
+
+If using the [OpenClaw](https://github.com/tfatykhov/openclaw) agent framework:
+
+```bash
+# Copy the skill definition
+cp -r skills/openclaw/cognition_skill.py /path/to/openclaw/skills/
+```
+
+The skill provides `query_decisions` and `check_guardrails` tools to any OpenClaw agent.
+
+---
+
+## Method 5: MCP Quick Start
+
+Connect any MCP-compliant agent to CSTP decision intelligence. The MCP server exposes 5 tools (`query_decisions`, `check_action`, `log_decision`, `review_outcome`, `get_stats`) via two transports.
+
+### Streamable HTTP (Remote)
+
+The CSTP server exposes MCP at `/mcp` on the same port (8100):
+
+```bash
+# Claude Code
+claude mcp add --transport http cstp-decisions http://your-server:8100/mcp
+
+# Any MCP client — point to:
+http://your-server:8100/mcp
+```
+
+### stdio (Local / Docker)
+
+```bash
+# Via Docker (recommended — container has all deps)
+docker exec -i cstp python -m a2a.mcp_server
+
+# Local development
+pip install -e ".[mcp]"
+export CHROMA_URL=http://localhost:8000
+export GEMINI_API_KEY=your-key
+python -m a2a.mcp_server
+```
+
+### Claude Desktop
+
+Add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "cstp": {
+      "command": "docker",
+      "args": ["exec", "-i", "cstp", "python", "-m", "a2a.mcp_server"],
+      "env": {}
+    }
+  }
+}
+```
+
+> See [MCP Integration Guide](/guide/mcp-integration) for full details, schemas, and examples.
+
+---
+
+## Troubleshooting
+
+### Common Issues
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| `GEMINI_API_KEY not found` | Missing API key | Set `GEMINI_API_KEY` in `.env` or environment |
+| `ChromaDB connection refused` | ChromaDB not running | Start ChromaDB with Docker or `chroma run` |
+| `401 Unauthorized` | Invalid or missing token | Check `CSTP_AUTH_TOKENS` format: `agent:token` |
+| `ModuleNotFoundError: cognition_engines` | Package not installed | Run `pip install -e .` |
+| `Docker build fails at uv` | Build tools missing | The Dockerfile includes `gcc`/`g++` — ensure Docker build doesn't cache stale layers |
+
+### Port Conflicts
+
+Default ports:
+
+| Service | Default Port | Environment Variable |
+|---------|-------------|---------------------|
+| CSTP Server | 8100 | `CSTP_PORT` |
+| ChromaDB | 8000 | `CHROMA_URL` (full URL) |
+| Dashboard | 5001 | `DASHBOARD_PORT` |
+
+Override with environment variables:
+
+```bash
+$env:CSTP_PORT = "9100"
+$env:CHROMA_URL = "http://localhost:9000"
+```

--- a/website/reference/modules.md
+++ b/website/reference/modules.md
@@ -1,0 +1,421 @@
+# Module Reference
+
+This document provides a detailed breakdown of every module, class, and function in the Cognition Engines codebase.
+
+---
+
+## 1. Core Library — `src/cognition_engines/`
+
+### 1.1 Accelerators — `accelerators/`
+
+#### `semantic_index.py`
+
+The heart of the decision memory system. Provides vector-based similarity search over decisions using ChromaDB and Google Gemini embeddings.
+
+##### Module-Level Functions
+
+| Function | Description |
+|----------|-------------|
+| `load_gemini_key()` | Loads Gemini API key from secrets files if not present in environment |
+| `api_request(method, url, data)` | Makes HTTP requests to ChromaDB REST API |
+| `generate_embedding(text)` | Generates a 768-dimensional embedding vector via Gemini `text-embedding-004` |
+| `get_api_base()` | Returns the ChromaDB API base URL from environment |
+| `get_or_create_collection()` | Ensures the `cognition_decisions` collection exists in ChromaDB |
+| `decision_to_text(decision)` | Converts a decision dict into searchable text (title + category + context + reasons) |
+| `decision_id(decision)` | Generates a deterministic MD5 hash ID from decision title |
+| `get_index()` | Returns the singleton `SemanticIndex` instance |
+
+##### `SemanticIndex` Class
+
+| Method | Description |
+|--------|-------------|
+| `__init__()` | Initializes with `collection_id = None` |
+| `ensure_collection()` | Lazily creates/gets the ChromaDB collection |
+| `index_decision(decision)` | Indexes a single decision: generates embedding, constructs metadata, upserts to ChromaDB |
+| `index_decisions(decisions)` | Batch indexes a list of decisions, returns count |
+| `query(context, n_results, category, min_confidence)` | Generates embedding for query text, performs filtered vector search, returns ranked results |
+| `count()` | Returns the number of indexed decisions in the collection |
+
+**Metadata stored per decision:**
+
+- `title`, `category`, `confidence`, `stakes`, `date`, `status`, `outcome`, `project`, `feature`, `pr`, `reason_types`
+
+---
+
+### 1.2 Guardrails — `guardrails/`
+
+#### `engine.py`
+
+The main guardrail evaluation engine. Loads YAML guardrail definitions and evaluates them against decision contexts.
+
+##### Data Classes
+
+| Class | Fields | Description |
+|-------|--------|-------------|
+| `GuardrailCondition` | `field`, `operator`, `value` | A condition that must match for a guardrail to apply (e.g., `stakes == "high"`) |
+| `GuardrailRequirement` | `field`, `expected` | A requirement that must be met (e.g., `code_review_completed == true`) |
+| `Guardrail` | `id`, `description`, `conditions`, `requirements`, `scope`, `action`, `message` | Full guardrail definition |
+| `GuardrailResult` | `guardrail_id`, `passed`, `action`, `message`, `failed_requirements` | Result of evaluating one guardrail |
+
+##### `GuardrailEngine` Class
+
+| Method | Description |
+|--------|-------------|
+| `load_from_yaml(content)` | Parses YAML string and loads guardrail definitions. Returns count loaded |
+| `load_from_file(path)` | Loads guardrails from a single YAML file |
+| `load_from_directory(directory)` | Recursively loads all `.yaml`/`.yml` files from a directory |
+| `evaluate(context)` | Evaluates all guardrails against a context dict, returns list of `GuardrailResult` |
+| `check(context)` | Convenience method: returns `(allowed: bool, results: list)` |
+| `list_guardrails()` | Returns list of all loaded guardrail definitions as dicts |
+
+**Condition operators:** `=`, `!=`, `<`, `>`, `<=`, `>=`, `in`, `not in`
+
+##### Module-Level Functions
+
+| Function | Description |
+|----------|-------------|
+| `parse_condition(field, value)` | Parses a condition from YAML format, detecting operator from string prefix |
+| `parse_guardrail(data)` | Parses a full guardrail from YAML dict (supports flat `condition_*` and nested formats) |
+| `get_engine()` | Returns the singleton `GuardrailEngine` instance |
+| `load_default_guardrails()` | Loads guardrails from `guardrails/` directory |
+
+#### `evaluators.py`
+
+Advanced condition evaluators for the v2 guardrail format. Provides pluggable evaluation strategies.
+
+| Class | Type | Description |
+|-------|------|-------------|
+| `ConditionEvaluator` | Protocol | Abstract protocol for condition evaluators |
+| `FieldCondition` | Evaluator | Simple field comparison with extended operators |
+| `SemanticCondition` | Evaluator | Checks semantic similarity to past decisions matching criteria. Fields: `query_field`, `threshold`, `filter_outcome`, `filter_since_days`, `min_matches` |
+| `TemporalCondition` | Evaluator | Time-window check: "Was a similar decision made within N hours?" |
+| `AggregateCondition` | Evaluator | Statistical check across decision history: "Is category success rate below 50%?" |
+| `CompoundCondition` | Evaluator | AND/OR logical composition of multiple conditions |
+
+`parse_condition_v2(condition_def)` — Factory function that creates the appropriate evaluator from a YAML condition definition.
+
+#### `audit.py`
+
+Audit trail system for guardrail evaluations.
+
+| Class | Description |
+|-------|-------------|
+| `GuardrailEvaluation` | Record of a single guardrail check: `guardrail_id`, `matched`, `passed`, `action`, `message` |
+| `AuditRecord` | Complete audit for one decision: list of evaluations, `overall_allowed`, optional `override` with reason |
+| `AuditLog` | Manager that creates records, saves to JSON files, queries violations, and computes aggregate stats |
+
+**Output formats:** JSON files (`audit/YYYY-MM-DD-<decision_id>.json`) and embeddable YAML blocks.
+
+---
+
+### 1.3 Patterns — `patterns/`
+
+#### `detector.py`
+
+Analyzes decision history for patterns, calibration accuracy, and anti-patterns.
+
+##### Data Classes
+
+| Class | Description |
+|-------|-------------|
+| `CalibrationBucket` | Confidence range bucket: computes predicted rate, actual success rate, and Brier score |
+| `CategoryStats` | Per-category statistics: count, average confidence, success rate |
+| `AntiPattern` | Detected anti-pattern: type, description, severity, affected decisions |
+
+##### `PatternDetector` Class
+
+| Method | Description |
+|--------|-------------|
+| `load_from_directory(directory)` | Recursively loads all YAML decision files |
+| `calibration_report()` | Generates Brier scores for 5 confidence buckets (0-0.2, 0.2-0.4, ..., 0.8-1.0) |
+| `category_analysis()` | Success rates and patterns per category, identifies concerning categories |
+| `detect_antipatterns()` | Detects: overcalibration, flip-flopping, anchoring, blind spots, hot-hand fallacy |
+| `full_report()` | Combines calibration + category + antipattern reports |
+
+---
+
+## 2. A2A Layer — `a2a/`
+
+### 2.1 `server.py` — FastAPI Application
+
+| Function | Description |
+|----------|-------------|
+| `lifespan(app)` | Async context manager: loads config, initializes `AuthManager`, creates `CstpDispatcher`, registers methods, initializes MCP `StreamableHTTPSessionManager` and runs it within the lifespan context |
+| `create_app(config)` | Factory: creates FastAPI app with CORS, lifespan, routes, and MCP mount at `/mcp` |
+| `_mount_mcp(app)` | Mounts the MCP Streamable HTTP handler as a raw ASGI app at `/mcp`; returns 503 if MCP SDK not installed |
+| `_register_routes(app)` | Registers `/health`, `/.well-known/agent.json`, and `POST /cstp` |
+| `run_server(host, port, config_path)` | Entry point: loads config, creates app, runs uvicorn |
+
+### 2.2 `mcp_server.py` — MCP Server
+
+Exposes CSTP capabilities as MCP tools for native integration with MCP-compliant agents (Claude Desktop, Claude Code, OpenClaw, etc.).
+
+| Component | Description |
+|-----------|-------------|
+| `mcp_app` | `Server("cstp-decisions")` instance — importable for mounting in ASGI apps |
+| `list_tools()` | Returns 5 `Tool` definitions with JSON Schema auto-generated from Pydantic models |
+| `call_tool(name, arguments)` | Dispatches tool calls to `_handle_*` functions; returns `TextContent` with JSON result |
+| `_handle_query_decisions()` | Validates input via `QueryDecisionsInput`, calls `query_service.query_decisions()` |
+| `_handle_check_action()` | Validates input via `CheckActionInput`, calls `guardrails_service.evaluate_guardrails()` |
+| `_handle_log_decision()` | Validates input via `LogDecisionInput`, calls `decision_service.record_decision()` |
+| `_handle_review_outcome()` | Validates input via `ReviewOutcomeInput`, calls `decision_service.review_decision()` |
+| `_handle_get_stats()` | Validates input via `GetStatsInput`, calls `calibration_service.get_calibration()` |
+| `run_stdio()` | Runs the MCP server with stdio transport (`async with stdio_server()`) |
+| `main()` | Entry point: `asyncio.run(run_stdio())` |
+
+**Transports:**
+
+- **stdio** — `python -m a2a.mcp_server` (local or `docker exec -i cstp python -m a2a.mcp_server`)
+- **Streamable HTTP** — Mounted at `/mcp` on port 8100 via `StreamableHTTPSessionManager` in `server.py` lifespan
+
+### 2.3 `mcp_schemas.py` — MCP Input Schemas
+
+Pydantic models that define the JSON Schema MCP clients see during tool discovery. They map to existing CSTP dataclass models but use Pydantic for automatic schema generation required by the MCP protocol.
+
+| Schema | MCP Tool | Key Fields |
+|--------|----------|------------|
+| `QueryDecisionsInput` | `query_decisions` | `query` (str), `limit` (1–50), `retrieval_mode` (semantic/keyword/hybrid), `filters` (QueryFiltersInput) |
+| `QueryFiltersInput` | (nested) | `category`, `stakes`, `project`, `has_outcome` |
+| `CheckActionInput` | `check_action` | `description` (str), `category`, `stakes` (low/medium/high/critical), `confidence` (0.0–1.0) |
+| `LogDecisionInput` | `log_decision` | `decision` (str), `confidence` (float), `category`, `stakes`, `context`, `reasons` (ReasonInput[]), `tags`, `project`, `feature`, `pr` |
+| `ReasonInput` | (nested) | `type` (authority/analogy/analysis/pattern/intuition), `text` (str) |
+| `ReviewOutcomeInput` | `review_outcome` | `id` (str), `outcome` (success/partial/failure/abandoned), `actual_result`, `lessons`, `notes` |
+| `GetStatsInput` | `get_stats` | `category`, `project`, `window` (30d/60d/90d/all) |
+
+### 2.4 `config.py` — Configuration Management
+
+| Class | Description |
+|-------|-------------|
+| `AuthToken` | Agent + token pair |
+| `AuthConfig` | `enabled` flag + list of `AuthToken`; `validate_token()` with constant-time comparison |
+| `AgentConfig` | Agent identity: name, description, version, URL, contact |
+| `ServerConfig` | HTTP settings: host, port, CORS origins |
+| `Config` | Composite config with `from_yaml(path)`, `from_env()`, `_from_dict(data)` class methods |
+
+**Config loading priority:** YAML file → Environment variables → Defaults
+
+### 2.5 `auth.py` — Authentication
+
+| Component | Description |
+|-----------|-------------|
+| `AuthManager` | Wraps `Config`, validates bearer tokens, returns agent ID |
+| `verify_bearer_token()` | FastAPI `Depends` function for route-level auth |
+| `set_auth_manager()` / `get_auth_manager()` | Global singleton management |
+
+### 2.6 `models/` — Shared Models
+
+| File | Classes |
+|------|---------|
+| `jsonrpc.py` | `JsonRpcRequest`, `JsonRpcResponse`, `JsonRpcError`, error codes (PARSE_ERROR, INVALID_REQUEST, METHOD_NOT_FOUND, INTERNAL_ERROR) |
+| `agent_card.py` | `AgentCard`, `AgentCapabilities` for `/.well-known/agent.json` |
+| `health.py` | `HealthResponse` with status, version, uptime, timestamp |
+
+---
+
+## 3. CSTP Services — `a2a/cstp/`
+
+### 3.1 `dispatcher.py` — Method Router
+
+| Component | Description |
+|-----------|-------------|
+| `CstpDispatcher` | Registry of method name → async handler; dispatches requests, catches errors, returns JSON-RPC responses |
+| `register_methods(dispatcher)` | Registers all 9 method handlers: `queryDecisions`, `checkGuardrails`, `listGuardrails`, `recordDecision`, `reviewDecision`, `getCalibration`, `attributeOutcomes`, `checkDrift`, `reindex` |
+| Custom error codes | `QUERY_FAILED` (-32003), `RATE_LIMITED` (-32002), `GUARDRAIL_EVAL_FAILED` (-32004), `RECORD_FAILED` (-32005), `REVIEW_FAILED` (-32006), `DECISION_NOT_FOUND` (-32007), `ATTRIBUTION_FAILED` (-32008) |
+
+### 3.2 `query_service.py` — Semantic Search
+
+| Component | Description |
+|-----------|-------------|
+| `QueryResult` | Single result: id, title, category, confidence, distance |
+| `QueryResponse` | Wrapper with results list, query, timing |
+| `query_decisions()` | Full query pipeline: embedding, ChromaDB search, metadata filtering, optional BM25 hybrid |
+| `load_all_decisions()` | Loads YAML files from disk for BM25 indexing |
+
+### 3.3 `decision_service.py` — Decision Recording & Review
+
+| Component | Description |
+|-----------|-------------|
+| `BridgeDefinition` | Dataclass: structure, function, tolerance, enforcement, prevention |
+| `Reason` | Decision reason with type, text, strength |
+| `PreDecisionProtocol` | Tracks whether query was run and guardrails were checked before recording |
+| `ProjectContext` | Project, feature, PR, file, line, commit associations |
+| `ReasoningStep` | Step in a reasoning trace: step number, thought, output, confidence, tags |
+| `RecordDecisionRequest` | Full request with validation: decision text, confidence, category, stakes, reasons, review_in |
+| `RecordDecisionResponse` | Success indicator, generated ID, file path, index status |
+| `ReviewDecisionRequest` | Review request: decision ID, outcome, actual result, lessons |
+| `review_decision()` | Loads decision YAML, updates with outcome and review metadata, reindexes in ChromaDB |
+| `build_decision_yaml()` | Constructs the YAML dictionary structure |
+| `write_decision_file()` | Writes to `decisions/YYYY/MM/YYYY-MM-DD-decision-<id>.yaml` |
+| `generate_embedding(text)` | Gemini embedding for ChromaDB indexing |
+| `ensure_collection_exists()` | ChromaDB collection management |
+
+### 3.4 `calibration_service.py` — Confidence Calibration
+
+| Component | Description |
+|-----------|-------------|
+| `GetCalibrationRequest` | Filters: agent, category, stakes, date range, window, project, feature |
+| `CalibrationResult` | Overall: Brier score, accuracy, calibration gap, interpretation |
+| `ConfidenceBucket` | Per-bucket: decisions, success rate, expected rate, gap, interpretation |
+| `ConfidenceStats` | Distribution stats: mean, std_dev, min, max, bucket counts |
+| `CalibrationRecommendation` | Actionable recommendation with type, message, severity |
+| `get_reviewed_decisions()` | Loads reviewed decisions matching filters from YAML files |
+| `calculate_calibration()` | Computes Brier score: `mean((confidence - outcome)²)` |
+| `calculate_buckets()` | Splits into 5 confidence buckets and computes per-bucket stats |
+| `calculate_confidence_stats()` | Habituation detection: identifies low-variance confidence patterns |
+| `generate_recommendations()` | Produces actionable advice based on calibration gaps |
+
+### 3.5 `attribution_service.py` — Outcome Attribution
+
+| Component | Description |
+|-----------|-------------|
+| `AttributeOutcomesRequest` | Project, since date, stability days, dry_run flag |
+| `find_pending_decisions()` | Finds pending decisions for a project |
+| `is_pr_stable()` | Checks if PR is older than stability window (simplified) |
+| `update_decision_outcome()` | Atomic file update: marks as reviewed with outcome + reason |
+| `attribute_outcomes()` | Main pipeline: find pending → check stability → update files |
+
+### 3.6 `drift_service.py` — Calibration Drift Detection
+
+| Component | Description |
+|-----------|-------------|
+| `CheckDriftRequest` | Thresholds for Brier and accuracy, category/project filters |
+| `DriftAlert` | Alert: type (brier_degradation/accuracy_drop), recent vs. historical values, change %, severity |
+| `check_drift()` | Compares 30-day calibration against 90-day+ baseline |
+| `generate_drift_recommendations()` | Actionable recommendations based on drift alerts |
+
+### 3.7 `guardrails_service.py` — Guardrail Evaluation (CSTP)
+
+| Component | Description |
+|-----------|-------------|
+| `evaluate_guardrails(context)` | Loads guardrails (cached 5 min), evaluates, returns violations/warnings |
+| `list_guardrails(scope)` | Lists active guardrails, optionally filtered by scope |
+| `log_guardrail_check()` | Structured audit logging |
+
+### 3.8 `reindex_service.py` — Collection Rebuild
+
+| Component | Description |
+|-----------|-------------|
+| `reindex_decisions()` | Full pipeline: delete collection → create → load decisions → generate embeddings → batch insert |
+| `ReindexResult` | Success, count indexed, errors, duration |
+
+### 3.9 `bm25_index.py` — Keyword Search
+
+| Component | Description |
+|-----------|-------------|
+| `BM25Index` | Wraps `rank-bm25` BM25Okapi algorithm |
+| `BM25Index.from_decisions()` | Builds index from decision dicts |
+| `BM25Index.search()` | Returns ranked `(doc_id, score)` pairs |
+| `tokenize(text)` | Simple word tokenization with lowercasing |
+| `merge_results()` | Weighted merge of semantic + keyword results (default 70/30) |
+| `get_cached_index()` | 5-minute TTL cache with count-based invalidation |
+
+### 3.10 `deliberation_tracker.py` — Deliberation Traces
+
+Tracks input/reasoning steps across API calls to build full deliberation traces.
+
+| Component | Description |
+|-----------|-------------|
+| `TrackedInput` | Dataclass: type (query/check), content, timestamp, source |
+| `TrackerSession` | Per-agent session state with inputs list and start time |
+| `DeliberationTracker` | Singleton manager for active deliberation sessions |
+| `track_query(agent_id, query)` | Hooks into `queryDecisions` to record search inputs |
+| `track_check(agent_id, action)` | Hooks into `checkGuardrails` to record constraint inputs |
+| `track_lookup(agent_id, id)` | Hooks into `getDecision` to record reference inputs |
+| `auto_attach_deliberation(agent_id)` | Returns and clears tracked inputs for `recordDecision` |
+
+### 3.11 `bridge_extractor.py` — Bridge Auto-Extraction
+
+Extracts structure/function pairs from decision text when not explicitly provided.
+
+| Component | Description |
+|-----------|-------------|
+| `auto_extract_bridge(text, context)` | Main entry point: heuristic extraction pipeline |
+| `_score_as_function(text)` | Scorer: how likely is text to be a function/purpose? |
+| `_score_as_structure(text)` | Scorer: how likely is text to be a structure/pattern? |
+
+### 3.12 `bridge_hook.py` — Shared Hook
+
+| Component | Description |
+|-----------|-------------|
+| `maybe_auto_extract_bridge(req)` | Wraps extraction logic for use in `decision_service` |
+
+### 3.13 `models.py` — CSTP Data Models
+
+| Model | Used By |
+|-------|---------|
+| `QueryFilters` | `cstp.queryDecisions` — category, confidence, stakes, status, project, feature, PR, has_outcome |
+| `QueryDecisionsRequest` | `cstp.queryDecisions` — query text, bridge_side (structure/function), filters, limit |
+| `DecisionSummary` | Query results — id, title, category, confidence, distance, reasons |
+| `QueryDecisionsResponse` | Wrapper with decisions, total, timing, retrieval mode, scores |
+| `ActionContext` | `cstp.checkGuardrails` — description, category, stakes, confidence, context dict |
+| `CheckGuardrailsRequest` | Action + agent info |
+| `GuardrailViolation` | Block/warn result with id, name, message, severity, suggestion |
+| `CheckGuardrailsResponse` | allowed flag, violations, warnings, evaluated count |
+
+---
+
+## 4. Dashboard — `dashboard/`
+
+### `app.py` — Flask Routes
+
+| Route | Method | Description |
+|-------|--------|-------------|
+| `/` | GET | Redirects to `/decisions` |
+| `/health` | GET | Health check (no auth) |
+| `/decisions` | GET | Paginated decision list with category/status filters |
+| `/decisions/<id>` | GET | Decision detail view |
+| `/decisions/<id>/review` | GET/POST | Review form for recording outcomes |
+| `/calibration` | GET | Calibration dashboard with drift detection |
+
+### `cstp_client.py` — CSTP Client
+
+Async HTTP client for communicating with the CSTP server. Uses `httpx` for non-blocking requests.
+
+| Method | Description |
+|--------|-------------|
+| `health_check()` | Check CSTP server health |
+| `list_decisions()` | Query decisions with pagination |
+| `get_decision(id)` | Get single decision by ID |
+| `review_decision()` | Submit decision review |
+| `get_calibration()` | Get calibration statistics |
+| `check_drift()` | Check for calibration drift |
+
+---
+
+## 5. CLI — `bin/cognition`
+
+| Command | Description |
+|---------|-------------|
+| `cognition index <dir>` | Index all YAML decisions from a directory |
+| `cognition query <context>` | Search for similar decisions |
+| `cognition check --stakes high --confidence 0.8` | Evaluate guardrails for a context |
+| `cognition guardrails` | List all loaded guardrails |
+| `cognition count` | Count indexed decisions |
+| `cognition patterns calibration` | Confidence calibration report (Brier scores) |
+| `cognition patterns categories` | Category success analysis |
+| `cognition patterns antipatterns` | Detect decision anti-patterns |
+| `cognition patterns full` | Complete pattern report (JSON) |
+
+---
+
+## 6. Test Suite — `tests/`
+
+| Test File | Coverage |
+|-----------|----------|
+| `test_a2a_server.py` | FastAPI app creation, health endpoint, agent card, CSTP dispatch |
+| `test_decision_service.py` | Decision recording, YAML generation, validation |
+| `test_query_service.py` | Semantic query pipeline |
+| `test_guardrails.py` | Core guardrail engine evaluation |
+| `test_guardrails_service.py` | CSTP guardrail service |
+| `test_evaluators.py` | v2 condition evaluators |
+| `test_audit.py` | Audit trail creation and querying |
+| `test_patterns.py` | Pattern detection and calibration |
+| `test_calibration_service.py` | Calibration computation and recommendations |
+| `test_attribution_service.py` | Outcome attribution pipeline |
+| `test_semantic_index.py` | ChromaDB semantic index |
+| `test_config_env.py` | Configuration loading |
+| `test_f002_query_decisions.py` | F002 feature: query decisions |
+| `test_f003_check_guardrails.py` | F003 feature: check guardrails |
+| `test_f007_record_decision.py` | F007 feature: record decision |
+| `test_f008_review_decision.py` | F008 feature: review decision |
+| `test_f009_get_calibration.py` | F009 feature: get calibration |

--- a/website/specs/f022-mcp-server.md
+++ b/website/specs/f022-mcp-server.md
@@ -1,0 +1,60 @@
+# F022: MCP Server Implementation Plan
+
+## 1. Overview
+Implement an **MCP (Model Context Protocol) Server** for the CSTP Decision Engine.
+This allows any MCP-compliant agent (Claude Desktop, OpenClaw, other AI assistants) to natively discover and use CSTP capabilities without custom client code.
+
+## 2. Architecture
+- **Bridge Pattern:** Create `a2a/mcp_server.py` that wraps the existing `Dispatcher`.
+- **Transport:** Support Standard Input/Output (stdio) for local agents and SSE (Server-Sent Events) for remote.
+- **Protocol:** Implement MCP v1.0.0-rc.1 spec.
+
+## 3. Exposed Tools (Resources & Prompts)
+
+The MCP server will expose CSTP methods as **Tools**:
+
+| CSTP Method | MCP Tool Name | Description |
+|-------------|---------------|-------------|
+| `cstp.queryDecisions` | `query_decisions` | Find similar past decisions using semantic search |
+| `cstp.checkGuardrails` | `check_action` | Validate an intended action against safety policies |
+| `cstp.recordDecision` | `log_decision` | Record a final decision to the immutable log |
+| `cstp.reviewDecision` | `review_outcome` | Record the outcome of a past decision |
+| `cstp.getCalibration` | `get_stats` | Get accuracy and Brier score metrics |
+
+## 4. Implementation Phases
+
+### Phase 1: Core MCP Bridge (2 Days)
+- [ ] Add `mcp` python package dependency
+- [ ] Create `a2a/mcp_server.py` using `mcp.server.fastmcp`
+- [ ] Map `query_decisions` tool to `dispatcher.query_decisions`
+- [ ] Map `check_action` tool to `dispatcher.check_guardrails`
+- [ ] Verify local stdio connection with Claude Desktop
+
+### Phase 2: Full Tool Suite (2 Days)
+- [ ] Map `log_decision` (record)
+- [ ] Map `review_outcome` (review)
+- [ ] Map `get_stats` (calibration)
+- [ ] Add input schema validation (Pydantic models)
+
+### Phase 3: Docker & Deployment (1 Day)
+- [ ] Update `Dockerfile` to expose MCP entrypoint
+- [ ] Add SSE (HTTP) transport support for remote agents
+- [ ] Update documentation with "How to connect via MCP"
+
+## 5. Usage Example (Claude Desktop Config)
+
+```json
+{
+  "mcpServers": {
+    "cstp": {
+      "command": "docker",
+      "args": ["exec", "-i", "cstp", "uv", "run", "python", "-m", "a2a.mcp_server"]
+    }
+  }
+}
+```
+
+## 6. Success Criteria
+1.  **Discovery:** Agent sees `query_decisions` and `check_action` in its tool list.
+2.  **Execution:** Agent can successfully query past decisions via the tool.
+3.  **Safety:** Guardrails are enforced exactly as they are in the JSON-RPC API.

--- a/website/specs/f023-deliberation-traces.md
+++ b/website/specs/f023-deliberation-traces.md
@@ -1,0 +1,223 @@
+# F023: Deliberation Traces — Chain-of-Thought Capture
+
+## Status: Draft
+## Author: ⚡ Emerson
+## Date: 2026-02-08
+
+## Problem
+
+Current decision records capture WHAT was decided and WHY (reasons), but not 
+HOW the thinking process unfolded. This loses:
+
+1. **Provenance** — which inputs influenced which conclusions
+2. **Temporal dynamics** — thinking order, time spent per step
+3. **Convergence patterns** — how independent inputs combined into a conclusion
+4. **Replay capability** — can't reconstruct the reasoning path for learning
+
+## Solution
+
+Add a `deliberation` field to decision records that captures the step-by-step 
+reasoning trace with inputs, intermediate thoughts, and timing.
+
+## Schema
+
+```yaml
+deliberation:
+  inputs:
+    - id: "i1"
+      text: "Description of input/evidence"
+      source: "where it came from"  # optional: url, file, memory, api, etc.
+      timestamp: "2026-02-08T14:01:00Z"  # when this input was gathered
+
+  steps:
+    - step: 1
+      thought: "What was considered at this step"
+      inputs_used: ["i1", "i2"]  # which inputs contributed
+      timestamp: "2026-02-08T14:01:03Z"
+      duration_ms: 3200  # optional: how long this step took
+      type: "analysis"  # optional: maps to reason types
+
+    - step: 2
+      thought: "How inputs converged"
+      inputs_used: ["i1", "i2", "i3"]
+      timestamp: "2026-02-08T14:01:05Z"
+      duration_ms: 1800
+      type: "pattern"
+      conclusion: true  # marks the concluding step
+
+  total_duration_ms: 8200  # total deliberation time
+  convergence_point: 2  # step where inputs converged to decision
+```
+
+## Requirements
+
+### R1: Schema Extension
+- Add `deliberation` field to `RecordDecisionRequest`
+- Required for new decisions, absent in legacy decisions
+- Backward compatible: existing decisions without deliberation still work
+
+### R2: Automatic Capture (Client-Side)
+The CSTP client (`cstp.py` / MCP tool) tracks deliberation automatically:
+
+```
+Agent workflow:
+  1. query_decisions("should I use X?")     → input i1 (similar past decisions)
+  2. check_action("deploy X")               → input i2 (guardrail result)
+  3. [agent reasoning]                       → step 1: considered i1+i2
+  4. query_decisions("X vs Y comparison")    → input i3 (more evidence)
+  5. [agent reasoning]                       → step 2: converged on X
+  6. log_decision(deliberation={...})        → record with full trace
+```
+
+Implementation approach:
+- CSTP client maintains a `DeliberationContext` that accumulates inputs/steps
+- Each `query_decisions` / `check_action` call auto-registers as an input
+- Agent explicitly adds `steps` via `add_step()` or they're inferred from 
+  the sequence of API calls
+- On `log_decision`, the accumulated trace is attached automatically
+
+### R3: Search Enhancement
+When `queryDecisions` returns similar past decisions, optionally include 
+deliberation traces so agents can see HOW those decisions were made:
+
+```json
+{
+  "query": "should I use Izhikevich neurons?",
+  "includeDeliberation": true,
+  "decisions": [{
+    "id": "abc123",
+    "title": "Use Izhikevich for Membrain",
+    "deliberation": { ... }  // full trace
+  }]
+}
+```
+
+### R4: Deliberation Analytics
+New analytics on deliberation patterns:
+
+- **Step count vs outcome**: Do more deliberate decisions succeed more?
+- **Input count vs outcome**: Do decisions with more inputs perform better?
+- **Convergence speed**: Fast convergence = intuition, slow = analysis
+- **Input source diversity**: Decisions using varied sources (memory, search, 
+  analysis) vs single-source
+
+### R5: Membrain Integration (Future)
+Deliberation traces map to SNN temporal patterns:
+
+- Each input = activation of a neuron population
+- Each step = a time window of network dynamics
+- Convergence = attractor basin formation
+- Replay = feed the temporal sequence back through the SNN
+
+The trace format is designed to be directly convertible to spike timing 
+patterns for Membrain's STDP-based learning.
+
+## API Changes
+
+### `cstp.recordDecision` — Extended
+```json
+{
+  "decision": "Use Izhikevich neurons",
+  "confidence": 0.85,
+  "deliberation": {
+    "inputs": [...],
+    "steps": [...],
+    "totalDurationMs": 8200
+  }
+}
+```
+
+### `cstp.queryDecisions` — Extended
+```json
+{
+  "query": "neuron model selection",
+  "includeDeliberation": true
+}
+```
+
+### `cstp.getDeliberationStats` — New Endpoint
+```json
+{
+  "filters": { "category": "architecture" }
+}
+// Returns: avg steps, avg inputs, step_count vs success_rate, etc.
+```
+
+## Implementation Phases
+
+### Phase 1: Schema + Storage
+- Add `Deliberation` dataclass to `decision_service.py`
+- Extend `RecordDecisionRequest` to accept deliberation
+- Store in YAML alongside existing fields
+- Backward compatible (field is optional for reads)
+
+### Phase 2: Server-Side Auto-Capture
+Server-side `DeliberationTracker` captures inputs automatically for both
+JSON-RPC and MCP — zero client changes required.
+
+**Tracking key:** `agent_id` (from auth token) for JSON-RPC, `session_id`
+for MCP. Sub-agents have different agent_ids, so parallel agents are
+naturally isolated.
+
+**Hooks:**
+- After `queryDecisions` succeeds → register query + result count as input
+- After `checkGuardrails` succeeds → register action + allowed/blocked as input
+- After `getDecision` succeeds → register decision lookup as input
+- After `getReasonStats` succeeds → register stats snapshot as input
+- On `recordDecision` → auto-build `Deliberation` from unconsumed inputs,
+  attach to decision, clear tracker for that agent
+
+**Edge case — sequential decisions by same agent:**
+Inputs captured AFTER the last `recordDecision` belong to the next decision.
+`recordDecision` consumes and clears tracked inputs atomically.
+
+**Auto-generated steps:** The server creates `DeliberationStep` entries from
+the call sequence (query → check → record), each referencing which inputs
+they used. These are lower-fidelity than manual steps but provide baseline
+provenance automatically.
+
+**Merge behavior:** If `recordDecision` includes an explicit `deliberation`
+field, tracked inputs are merged into it (appended, not overwritten).
+
+**TTL:** Tracked inputs expire after 5 minutes (configurable). Periodic
+cleanup sweeps expired entries.
+
+### Phase 3: Search Integration
+- Extend `queryDecisions` with `includeDeliberation` flag
+- Return traces alongside decision summaries
+
+### Phase 4: Analytics
+- `cstp.getDeliberationStats` endpoint
+- Step count vs outcome correlation
+- Input diversity analysis
+- Convergence speed patterns
+
+### Phase 5: Membrain Bridge (Future — deferred until Membrain ready)
+- Export deliberation traces as spike timing patterns
+- Feed into Membrain SNN for associative learning
+
+## Open Questions
+
+~~1. **MCP auto-capture**: Should the MCP server maintain session-level 
+   deliberation context, or is this purely client-side?~~
+   **RESOLVED:** Server-side. `DeliberationTracker` tracks inputs per
+   `agent_id` (JSON-RPC) or `session_id` (MCP). Sub-agents are naturally
+   isolated by their auth identity. No client changes needed — the server
+   hooks into query/check/record handlers and auto-captures inputs.
+   `recordDecision` consumes tracked inputs and clears the tracker.
+
+~~2. **Size limits**: Deliberation traces could get large. Cap at N steps/inputs?~~
+   **RESOLVED:** No limits for now.
+
+~~3. **Privacy**: Deliberation may contain sensitive intermediate thoughts. 
+   Should there be a `redact` option?~~
+   **RESOLVED:** No redaction. Full traces are stored.
+
+## Related
+
+- Minsky Ch 18: Parallel bundles — deliberation captures how independent 
+  reasons converge
+- Minsky Ch 21: Pronomes — inputs are like pronome assignments, steps are 
+  action scripts operating on them
+- F017: Hybrid retrieval — deliberation search benefits from both semantic 
+  and keyword matching

--- a/website/specs/f024-bridge-definitions.md
+++ b/website/specs/f024-bridge-definitions.md
@@ -1,0 +1,175 @@
+# F024: Bridge-Definitions for Decisions
+
+**Status:** Proposed
+**Origin:** Minsky, Society of Mind, Ch 12.13 (Bridge-Definitions)
+**Author:** Emerson
+**Date:** 2026-02-08
+
+## Core Insight
+
+> "Our best ideas are often those that bridge between two different worlds!"
+> - Minsky, 12.13
+
+A decision has two faces:
+- **Structure** - what pattern was used, what it looks like (files, tools, code shapes, configurations)
+- **Function** - what problem it solves, what purpose it serves (goals, constraints, tradeoffs)
+
+Today CSTP stores a flat `decision` text and `context`. These mix structure and function together, making it hard to search from either direction. Bridge-definitions separate them so you can query:
+- "I see this pattern (structure) - what is it for?" (structure -> function)
+- "I have this problem (function) - what patterns solve it?" (function -> structure)
+
+## Design
+
+### Phase 1: Schema + Storage
+
+Add two optional fields to `RecordDecisionRequest`:
+
+```python
+@dataclass
+class BridgeDefinition:
+    """Minsky Ch 12 bridge-definition: connects structure to function."""
+    structure: str          # What it looks like / recognizable pattern
+    function: str           # What problem it solves / purpose
+    tolerance: list[str]    # Features that DON'T matter (Ch 12.3)
+    enforcement: list[str]  # Features that MUST be present (Ch 12.3)
+    prevention: list[str]   # Features that MUST NOT be present (Ch 12.3)
+```
+
+**Usage in record call:**
+```json
+{
+  "decision": "Used fail-open pattern for deliberation tracking",
+  "bridge": {
+    "structure": "try/except around telemetry calls, catch Exception, log debug, return default",
+    "function": "prevent observability failures from breaking core API paths",
+    "tolerance": ["log level", "specific exception types", "return value shape"],
+    "enforcement": ["must catch all exceptions", "must log for debugging", "must return safe default"],
+    "prevention": ["must not swallow errors silently without logging", "must not re-raise"]
+  }
+}
+```
+
+**YAML output:**
+```yaml
+bridge:
+  structure: "try/except around telemetry calls, catch Exception, log debug, return default"
+  function: "prevent observability failures from breaking core API paths"
+  tolerance:
+    - "log level"
+    - "specific exception types"
+  enforcement:
+    - "must catch all exceptions"
+    - "must log for debugging"
+  prevention:
+    - "must not swallow errors silently"
+```
+
+### Phase 2: Dual Indexing
+
+Index both `structure` and `function` into ChromaDB embeddings so queries from either side find matches.
+
+Update `build_embedding_text()`:
+```python
+if request.bridge:
+    parts.append(f"Structure: {request.bridge.structure}")
+    parts.append(f"Function: {request.bridge.function}")
+```
+
+Add query filter `bridgeSide`:
+- `"structure"` - boost structure field similarity (I recognize this pattern)
+- `"function"` - boost function field similarity (I need to solve this problem)
+- `"both"` (default) - search across both equally
+
+### Phase 3: Auto-Extraction (Optional)
+
+For decisions recorded without explicit bridge fields, use the existing `decision` + `context` + `reasons` to auto-extract structure/function:
+
+- Structure hints: file paths, tool names, code patterns, configuration details
+- Function hints: "to solve", "to prevent", "to enable", reason text
+
+This could be a background job that enriches older decisions, or a real-time extraction during `recordDecision`.
+
+### Phase 4: Bridge Analytics
+
+New endpoint `cstp.getBridgeStats`:
+- Most reusable structures (patterns that solve multiple problems)
+- Most common functions (problems solved by multiple patterns)
+- Orphan structures (patterns without clear function)
+- Orphan functions (problems without known patterns)
+- Bridge strength: how often a structure-function pair leads to success
+
+## Implementation Plan
+
+### Phase 1 (Core - 1 PR)
+
+1. **`BridgeDefinition` dataclass** in `decision_service.py`
+   - Fields: `structure`, `function`, `tolerance`, `enforcement`, `prevention`
+   - `from_dict()` / `to_dict()` methods
+   - All fields optional strings/lists
+
+2. **Add `bridge` field to `RecordDecisionRequest`**
+   - Optional `BridgeDefinition | None`
+   - Parse from `bridge` key in JSON-RPC params
+   - Support both camelCase and snake_case
+
+3. **YAML persistence**
+   - Add `bridge:` section to decision YAML output
+   - Backward compatible - old decisions without bridge still work
+
+4. **MCP schema**
+   - Add `BridgeSchema` to `mcp_schemas.py`
+   - Wire into `log_decision` tool input
+
+5. **Embedding text**
+   - Include structure + function in `build_embedding_text()`
+   - Weight structure and function equally
+
+6. **CLI**
+   - `cstp.py record --structure "..." --function "..."`
+   - Optional `--tolerance`, `--enforcement`, `--prevention`
+
+7. **Tests**
+   - Bridge parsing, YAML round-trip, embedding inclusion
+
+### Phase 2 (Search - 1 PR)
+
+8. **Query filter `bridgeSide`**
+   - Add to `QueryFiltersInput` and `_build_query_params()`
+   - When `bridgeSide=structure`, prepend "Structure: " to query for embedding similarity
+   - When `bridgeSide=function`, prepend "Function: " to query
+
+9. **`cstp.getDecision` response**
+   - Include full bridge in decision detail
+
+### Phase 3 (Auto-Extract - 1 PR, optional)
+
+10. **Heuristic extractor**
+    - Regex/keyword-based extraction from decision text + context
+    - Run on `recordDecision` if no explicit bridge provided
+    - Mark as `bridge_auto: true` (like deliberation_auto)
+
+### Phase 4 (Analytics - 1 PR, optional)
+
+11. **`cstp.getBridgeStats` endpoint**
+    - Most reused structures/functions
+    - Bridge strength (success correlation)
+
+## Compatibility
+
+- Fully backward compatible - bridge is optional
+- Old decisions without bridge still query normally
+- New decisions with bridge get richer search results
+- No breaking changes to existing API
+
+## Relation to Other Features
+
+- **F023 (Deliberation Traces):** Deliberation captures HOW you decided. Bridge captures WHAT you decided in dual form.
+- **F020 (Reasoning Trace):** Reasoning trace is sequential steps. Bridge is a static dual description.
+- **Ch 18 (Parallel Bundles):** Reasons are parallel evidence. Bridge connects that evidence to outcomes.
+- **Ch 21 (Pronomes):** Pronomes separate assignment from action. Bridge separates structure from function.
+
+## Open Questions
+
+1. Should `tolerance/enforcement/prevention` be in Phase 1 or deferred? They add richness but also complexity.
+2. Should auto-extraction (Phase 3) be opt-in or default?
+3. Should we retroactively enrich existing decisions?

--- a/website/specs/f027-censor-layer.md
+++ b/website/specs/f027-censor-layer.md
@@ -1,0 +1,65 @@
+# F027: Censor Layer - Proactive Failure Pattern Warnings
+
+> **Status:** Proposed
+> **Source:** Minsky Society of Mind Ch 27 (Censors and Jokes)
+> **Depends on:** Sufficient failure data (~10+ failed/partial decisions)
+> **Priority:** Low (blocked by data)
+
+## Concept
+
+Current guardrails are **suppressors** - they block actions at the moment of execution ("high stakes + low confidence = blocked"). Minsky distinguishes these from **censors**, which intercept *before* the bad thought forms.
+
+A censor layer would sit between query and guardrail check:
+
+```
+query -> CENSOR (warns based on failure patterns) -> check -> record
+```
+
+### Suppressors (what we have)
+- Evaluate at action time
+- Block based on static rules (stakes/confidence thresholds)
+- Reactive - the agent already formulated the bad idea
+
+### Censors (what we'd add)
+- Evaluate at query time
+- Warn based on *patterns from failed decisions*
+- Proactive - deflect before the agent commits to a path
+
+## How It Would Work
+
+1. When `cstp.queryDecisions` returns results, check if any are **failed** or **partial** decisions
+2. If failed decisions match the current query context above a threshold, inject a warning:
+   ```json
+   {
+     "results": [...],
+     "censors": [
+       {
+         "source_id": "79462120",
+         "pattern": "Skipped mandatory query/check workflow",
+         "outcome": "failed",
+         "warning": "Similar approach failed before - ensure full workflow compliance"
+       }
+     ]
+   }
+   ```
+3. The warning is informational (deflect, not block) - the agent can proceed but is made aware
+
+## Activation Criteria
+
+- Minimum 10 failed/partial decisions in corpus
+- Failure patterns must be classifiable (not just random one-offs)
+- Current corpus: 2 failed, 1 partial (insufficient)
+
+## Key Insight from Minsky
+
+> "Censors avoid waste of time by interceding earlier. Instead of waiting until an action is about to occur, a censor operates earlier, when there still remains time to select alternatives."
+
+> "Sometimes our censors must themselves be suppressed. In order to sketch out long-range plans, we must adopt a style of thought that sets minor obstacles aside."
+
+This means censors should be overridable - useful for exploratory/creative decisions where past failures shouldn't constrain new approaches.
+
+## Related Decisions
+
+- `7ee5358d` - Initial Ch 27 analysis
+- `84e7563b` - Deferred knowledge graph (similar "good idea, insufficient data" pattern)
+- `5e7b17bb` - Synced guardrails with CSTP server

--- a/website/specs/f028-decomposed-confidence.md
+++ b/website/specs/f028-decomposed-confidence.md
@@ -1,0 +1,100 @@
+# F028: Decomposed Confidence - Per-Reason Confidence Weights
+
+> **Status:** Proposed
+> **Source:** Minsky Society of Mind Ch 28 (The Mind and the World, section 28.3)
+> **Depends on:** Schema change across dataclass, YAML, CLI, MCP
+> **Priority:** Medium (addresses known calibration issue)
+
+## Problem
+
+Our confidence score is a single number (0.0-1.0) that, per Minsky 28.3, "perfectly conceals all traces of its origins." When an agent rates a decision at 0.85, that number hides:
+- Which reasons are strong vs weak
+- Where uncertainty actually lives
+- Why the agent chose that number
+
+This contributes to our low variance problem (stdDev 0.049) - agents collapse rich reasoning into a narrow band of scores.
+
+## Concept
+
+Each reason gets its own confidence weight:
+
+```yaml
+reasons:
+  - type: empirical
+    text: "Similar pattern succeeded in order-service"
+    confidence: 0.95    # Strong - direct evidence
+  - type: analysis
+    text: "Backoff handles transient failures"
+    confidence: 0.80    # Moderate - theoretical
+  - type: intuition
+    text: "Feels like the right approach"
+    confidence: 0.50    # Low - gut feeling
+
+confidence: 0.82  # Weighted aggregate (computed or manual)
+```
+
+## Benefits
+
+1. **Preserves structure** - the reasoning behind the number is visible
+2. **Better calibration** - can track which *reason types at which confidence levels* predict success
+3. **Natural variance** - per-reason scores will spread out even when aggregates cluster
+4. **Richer analytics** - "your empirical reasons at 0.90+ are well-calibrated, but your analysis reasons at 0.80 are overconfident"
+
+## Schema Changes
+
+### Reason dataclass
+```python
+@dataclass
+class Reason:
+    type: str           # existing
+    text: str           # existing
+    confidence: float   # NEW - optional, 0.0-1.0
+```
+
+### Aggregation options
+- **Manual override**: Agent sets overall confidence explicitly (current behavior, preserved)
+- **Weighted average**: Auto-compute from per-reason confidences
+- **Min-of-reasons**: Overall confidence = weakest reason (conservative)
+
+### CLI
+```bash
+uv run scripts/cstp.py record \
+  -d "my decision" \
+  -f 0.85 \
+  -r "empirical:direct evidence from prod:0.95" \
+  -r "analysis:theoretical reasoning:0.70"
+```
+
+### MCP
+```json
+{
+  "reasons": [
+    {"type": "empirical", "text": "...", "confidence": 0.95},
+    {"type": "analysis", "text": "...", "confidence": 0.70}
+  ]
+}
+```
+
+## Backward Compatibility
+
+- `confidence` field on reasons is optional (defaults to null)
+- Overall `confidence` field unchanged
+- Existing decisions unaffected
+- Analytics only activate when per-reason confidence data exists
+
+## Key Insight from Minsky
+
+> "Whenever we turn to measurements, we forfeit some uses of intellect. Currencies and magnitudes help us make comparisons only by concealing the differences among what they purport to represent."
+
+> "Add five and eight to make thirteen, and tell that answer to a friend: thirteen will be all your friend can know, since no amount of ingenious thought can ever show that it came from adding five and eight!"
+
+## Related Decisions
+
+- `4fe7b03d` - Initial Ch 28 analysis
+- `ee4c12be` - P2 finding on inconsistent reason types
+- `b02d10ba` - Adopted Ch 18 parallel bundles (multiple independent reasons)
+
+## Activation Criteria
+
+- Build when specifically addressing the low-variance calibration issue
+- Or when reason-type stats (`cstp.getReasonStats`) show actionable patterns worth decomposing

--- a/website/specs/index.md
+++ b/website/specs/index.md
@@ -1,0 +1,27 @@
+# Feature Specs
+
+Design documents for Cognition Engines features - past, present, and future.
+
+## Shipped (v0.10.0)
+
+| Spec | Feature | Status |
+|------|---------|--------|
+| [F022](/specs/f022-mcp-server) | MCP Server | Shipped |
+| [F023](/specs/f023-deliberation-traces) | Deliberation Traces | Shipped |
+| [F024](/specs/f024-bridge-definitions) | Bridge-Definitions | Shipped |
+
+## Proposed
+
+| Spec | Feature | Status |
+|------|---------|--------|
+| [F027](/specs/f027-censor-layer) | Censor Layer | Proposed (needs failure data) |
+| [F028](/specs/f028-decomposed-confidence) | Decomposed Confidence | Proposed |
+
+## Theoretical Sources
+
+| Chapter | Concept | Applied In |
+|---------|---------|-----------|
+| Minsky Ch 12 | Bridge-Definitions | F024 |
+| Minsky Ch 18 | Parallel Bundles | Reason types, confidence |
+| Minsky Ch 27 | Censors vs Suppressors | F027 |
+| Minsky Ch 28 | Mental Currencies | F028 |


### PR DESCRIPTION
## VitePress Documentation Website

**Landing page** with hero section, 8 feature cards, and code examples.

**Guide** (9 pages):
- What is Cognition Engines?
- Getting Started
- Agent Quick Start
- Decision Protocol
- Deliberation Traces (F023)
- Bridge-Definitions (F024)
- Related Decisions (F025)
- Guardrails
- MCP Integration (F022)
- Dashboard

**Reference** (6 pages): API, CLI, Architecture, Modules, Configuration, Installation

**Specs** (5 pages): F022, F023, F024, F027, F028

**Deployment**: GitHub Actions auto-deploys to GitHub Pages on push to main.

**Build**: VitePress 1.6.4, builds in ~24s, 2.9MB output.

URL will be: https://tfatykhov.github.io/cognition-agent-decisions/

Note: GitHub Pages needs to be enabled in repo Settings > Pages > Source: GitHub Actions.