### PR TITLE
fix: dark theme + missing product documentation pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ rad.json
 TestResults.xml__pycache__/
 **/pycache__/
 *.pyc
-.envwebsite/node_modules/
+.env
+website/node_modules/
 website/.vitepress/dist/
 website/.vitepress/cache/

--- a/website/.vitepress/config.mjs
+++ b/website/.vitepress/config.mjs
@@ -4,6 +4,7 @@ export default defineConfig({
   title: 'Cognition Engines',
   description: 'Decision Intelligence for AI Agents',
   base: '/cognition-agent-decisions/',
+  appearance: 'dark',
 
   head: [
     ['meta', { name: 'theme-color', content: '#6366f1' }],
@@ -18,7 +19,7 @@ export default defineConfig({
 
     nav: [
       { text: 'Guide', link: '/guide/what-is-cognition-engines' },
-      { text: 'Reference', link: '/reference/api' },
+      { text: 'Reference', link: '/reference/product-overview' },
       { text: 'Specs', link: '/specs/' },
       {
         text: 'v0.10.0',
@@ -59,14 +60,28 @@ export default defineConfig({
       ],
       '/reference/': [
         {
-          text: 'Reference',
+          text: 'Product Documentation',
+          items: [
+            { text: 'Product Overview', link: '/reference/product-overview' },
+            { text: 'Architecture', link: '/reference/architecture' },
+            { text: 'Module Reference', link: '/reference/modules' },
+          ]
+        },
+        {
+          text: 'API & CLI',
           items: [
             { text: 'API Reference', link: '/reference/api' },
             { text: 'CLI Reference', link: '/reference/cli' },
-            { text: 'Architecture', link: '/reference/architecture' },
-            { text: 'Module Reference', link: '/reference/modules' },
-            { text: 'Configuration', link: '/reference/configuration' },
+            { text: 'MCP Quick Start', link: '/reference/mcp-quickstart' },
+          ]
+        },
+        {
+          text: 'Setup',
+          items: [
             { text: 'Installation', link: '/reference/installation' },
+            { text: 'Configuration', link: '/reference/configuration' },
+            { text: 'Dashboard Guide', link: '/reference/dashboard-guide' },
+            { text: 'Guardrails Authoring', link: '/reference/guardrails-authoring' },
           ]
         }
       ],

--- a/website/reference/dashboard-guide.md
+++ b/website/reference/dashboard-guide.md
@@ -1,0 +1,148 @@
+# Dashboard Guide
+
+The Cognition Engines Dashboard is a Flask-based web UI for browsing decisions, reviewing outcomes, and monitoring calibration.
+
+---
+
+## Overview
+
+| Feature | Route | Description |
+|---------|-------|-------------|
+| Decision List | `/decisions` | Paginated list with category/status filters |
+| Decision Detail | `/decisions/<id>` | Full decision view with metadata and context |
+| Outcome Review | `/decisions/<id>/review` | Form to record success/failure outcomes |
+| Calibration | `/calibration` | Brier scores, confidence buckets, drift alerts |
+| Health Check | `/health` | Backend connectivity status |
+
+---
+
+## Prerequisites
+
+The dashboard requires:
+
+- Python 3.11+
+- Flask + Flask-WTF
+- A running CSTP server (the dashboard is a client, not a server replacement)
+
+### Install Dashboard Dependencies
+
+```bash
+pip install flask flask-wtf httpx
+```
+
+---
+
+## Starting the Dashboard
+
+### Option 1: Standalone
+
+```bash
+cd dashboard
+python app.py
+```
+
+Dashboard starts on `http://localhost:5001` by default.
+
+### Option 2: With Configuration
+
+Set environment variables before starting:
+
+```bash
+$env:DASHBOARD_CSTP_URL = "http://localhost:8100"
+$env:DASHBOARD_CSTP_TOKEN = "myagent:mysecrettoken"
+$env:DASHBOARD_SECRET_KEY = "your-flask-secret-key"
+$env:DASHBOARD_PORT = "5001"
+python dashboard/app.py
+```
+
+---
+
+## Dashboard Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DASHBOARD_CSTP_URL` | `http://localhost:8100` | CSTP server URL |
+| `DASHBOARD_CSTP_TOKEN` | — | Bearer token for CSTP API |
+| `DASHBOARD_SECRET_KEY` | (random) | Flask session secret key |
+| `DASHBOARD_PORT` | `5001` | Dashboard HTTP port |
+| `DASHBOARD_USERNAME` | — | HTTP Basic Auth username |
+| `DASHBOARD_PASSWORD` | — | HTTP Basic Auth password |
+
+---
+
+## Pages
+
+### Decisions List (`/decisions`)
+
+Displays a paginated table of all recorded decisions.
+
+**Filters:**
+
+- **Category** — Select a specific decision category
+- **Status** — `pending` (awaiting review) or `reviewed` (outcome recorded)
+
+**Pagination:** 20 decisions per page with page navigation.
+
+### Decision Detail (`/decisions/<id>`)
+
+Shows complete decision information:
+
+- Decision text, category, confidence, stakes
+- Reasons with type and strength
+- Project context (project, feature, PR, files)
+- Alternatives considered
+- Outcome and review data (if reviewed)
+- Timestamps (created, reviewed)
+
+### Outcome Review (`/decisions/<id>/review`)
+
+A form to record what actually happened after a decision was made:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| Outcome | ✅ | `success`, `failure`, `partial`, `abandoned` |
+| Actual Result | ✅ | What actually happened |
+| Lessons Learned | ❌ | Key takeaways for future decisions |
+
+CSRF protection is enabled on this form.
+
+### Calibration Dashboard (`/calibration`)
+
+Displays calibration metrics computed from reviewed decisions:
+
+- **Overall Brier Score** — Lower is better (< 0.1 = excellent, < 0.2 = good)
+- **Confidence Buckets** — Predicted vs. actual success rates by confidence range
+- **Accuracy** — Overall success rate
+- **Drift Alerts** — If recent performance diverges from historical baseline
+
+**Filters:**
+
+- **Project** — Filter by project name
+- **Window** — Time window: 30d, 60d, 90d
+
+---
+
+## Security
+
+- **HTTP Basic Auth:** Protects all routes (configurable username/password)
+- **CSRF Protection:** Flask-WTF CSRF tokens on all form submissions
+- **Session Management:** Secure cookie-based sessions
+
+---
+
+## Architecture
+
+```
+┌──────────────┐     HTTP/JSON-RPC     ┌──────────────────┐
+│   Dashboard  │  ──────────────────▶  │   CSTP Server    │
+│   (Flask)    │                        │   (FastAPI)      │
+│   Port 5001  │  ◀──────────────────  │   Port 8100      │
+│              │     JSON responses     │                  │
+└──────────────┘                        └──────────────────┘
+```
+
+The dashboard is a **thin client** — it communicates with the CSTP server via the same JSON-RPC API that agents use. It adds:
+
+- HTML rendering via Jinja2 templates
+- Form handling for outcome reviews
+- Human-friendly data presentation

--- a/website/reference/guardrails-authoring.md
+++ b/website/reference/guardrails-authoring.md
@@ -1,0 +1,380 @@
+# Guardrails Authoring Guide
+
+This guide explains how to write custom guardrail rules to enforce decision-making policies in your organization.
+
+---
+
+## What Are Guardrails?
+
+Guardrails are YAML-defined rules that are evaluated against a decision context **before** the decision is committed. They can:
+
+- **Block** — Prevent the decision entirely
+- **Warn** — Allow but flag the risk
+- **Log** — Record for audit without blocking
+
+---
+
+## Guardrail Structure
+
+```yaml
+- id: unique-guardrail-id          # Required: unique identifier
+  description: Human-readable text  # Required: what this rule does
+  
+  # Conditions — when does this rule apply?
+  condition_<field>: <value>        # Field-based condition matching
+  
+  # Requirements — what must be true?
+  requires_<field>: true            # Boolean requirement check
+  
+  # Scope — which projects does this apply to?
+  scope: ProjectName                # Optional: restrict to specific projects
+  
+  # Action — what to do on violation
+  action: block                     # block | warn | log
+  
+  # Message — what to tell the agent
+  message: "Explanation of the violation"
+```
+
+---
+
+## Condition Types
+
+### Field Conditions
+
+Match a specific field in the decision context:
+
+```yaml
+# Exact match
+condition_category: architecture
+
+# Comparison operators (prefix in string)
+condition_confidence: "< 0.5"
+condition_confidence: "> 0.8"
+condition_confidence: "<= 0.3"
+condition_confidence: ">= 0.9"
+condition_confidence: "!= 0.5"
+
+# Boolean match
+condition_affects_production: true
+
+# String match
+condition_stakes: high
+condition_decision_type: strategy_change
+```
+
+### Operator Reference
+
+| Operator | Syntax | Example |
+|----------|--------|---------|
+| Equals | `field: value` | `condition_category: trading` |
+| Not equals | `field: "!= value"` | `condition_stakes: "!= low"` |
+| Less than | `field: "< value"` | `condition_confidence: "< 0.5"` |
+| Greater than | `field: "> value"` | `condition_position_size_pct: "> 10"` |
+| Less/equal | `field: "<= value"` | `condition_confidence: "<= 0.3"` |
+| Greater/equal | `field: ">= value"` | `condition_confidence: ">= 0.9"` |
+
+### V2 Conditions (Advanced)
+
+For more complex scenarios, use the v2 structured condition format:
+
+```yaml
+conditions:
+  - type: field
+    field: stakes
+    operator: "=="
+    value: high
+
+  - type: semantic
+    query_field: description
+    threshold: 0.85
+    filter_outcome: failure
+    filter_since_days: 30
+    min_matches: 2
+
+  - type: temporal
+    field: category
+    value: deployment
+    window_hours: 24
+    max_occurrences: 2
+
+  - type: aggregate
+    field: category
+    value: trading
+    metric: success_rate
+    operator: "<"
+    threshold: 0.5
+
+  - type: compound
+    operator: and   # or | or
+    conditions:
+      - type: field
+        field: stakes
+        operator: "=="
+        value: critical
+      - type: field
+        field: confidence
+        operator: "<"
+        value: 0.7
+```
+
+---
+
+## Requirements
+
+Requirements are boolean checks — the named field must be `true` in the context:
+
+```yaml
+# Requires code review to be completed
+requires_code_review: true
+
+# Requires backtest to have run
+requires_backtest_completed: true
+
+# Requires risk assessment
+requires_risk_assessed: true
+
+# Requires human approval
+requires_human_approval: true
+
+# Custom requirements
+requires_monitoring_configured: true
+requires_rollback_plan: true
+requires_ci_green: true
+requires_audit_logged: true
+```
+
+If the corresponding field is missing or `false` in the context, the requirement fails.
+
+---
+
+## Scope
+
+Restrict a guardrail to specific projects:
+
+```yaml
+# Single scope
+scope: CryptoTrader
+
+# The guardrail only applies when the context has:
+# { "scope": "CryptoTrader" } or { "project": "CryptoTrader" }
+```
+
+---
+
+## Actions
+
+| Action | Behavior | Return |
+|--------|----------|--------|
+| `block` | Prevents the decision | `allowed: false` |
+| `warn` | Allows but flags concern | `allowed: true` (with warnings) |
+| `log` | Silently records evaluation | `allowed: true` |
+
+---
+
+## Examples
+
+### Cornerstone Rules (Non-Negotiable)
+
+```yaml
+# guardrails/cornerstone.yaml
+
+- id: no-production-without-review
+  description: Production changes require code review
+  condition_affects_production: true
+  requires_code_review: true
+  action: block
+  message: Production changes require completed code review
+
+- id: no-high-stakes-low-confidence
+  description: High-stakes decisions need minimum confidence
+  condition_stakes: high
+  condition_confidence: "< 0.5"
+  action: block
+  message: High-stakes decisions require 50% confidence or more
+
+- id: no-trading-strategy-without-backtest
+  description: Trading strategy changes need backtesting
+  scope: CryptoTrader
+  condition_category: trading
+  condition_decision_type: strategy_change
+  requires_backtest_completed: true
+  action: block
+  message: Trading strategy changes require completed backtest
+```
+
+### Financial Template
+
+```yaml
+# guardrails/templates/financial.yaml
+
+template:
+  name: financial
+  description: Guardrails for financial and trading decisions
+  version: "1.0"
+
+guardrails:
+  - id: require-backtest
+    description: Strategy changes require backtesting
+    condition_category: trading
+    condition_decision_type: strategy_change
+    requires_backtest_completed: true
+    action: block
+    message: "Trading strategy changes require completed backtest"
+
+  - id: require-risk-assessment
+    description: Financial decisions need risk assessment
+    condition_category: financial
+    condition_stakes: high
+    requires_risk_assessed: true
+    action: block
+    message: "High-stakes financial decisions require risk assessment"
+
+  - id: limit-single-position
+    description: Warn on large position sizes
+    condition_category: trading
+    condition_position_size_pct: "> 10"
+    action: warn
+    message: "Position size exceeds 10% of portfolio - review risk"
+
+  - id: require-approval-large-amounts
+    description: Large transactions need approval
+    condition_amount_usd: "> 10000"
+    requires_human_approval: true
+    action: block
+    message: "Transactions over $10k require human approval"
+
+  - id: no-trading-during-volatility
+    description: Pause new trades during high volatility
+    condition_category: trading
+    condition_market_volatility: high
+    action: warn
+    message: "High market volatility detected - consider pausing new positions"
+```
+
+### Production Safety Template
+
+```yaml
+# guardrails/templates/production-safety.yaml
+
+template:
+  name: production-safety
+  description: Guardrails for production deployments
+  version: "1.0"
+
+guardrails:
+  - id: require-code-review
+    description: All production changes must be code reviewed
+    condition_affects_production: true
+    requires_code_review: true
+    action: block
+    message: "Production changes require completed code review"
+
+  - id: require-tests-passing
+    description: CI tests must pass before production deploy
+    condition_affects_production: true
+    requires_ci_green: true
+    action: block
+    message: "CI tests must pass before deploying to production"
+
+  - id: require-rollback-plan
+    description: Production deploys need rollback strategy
+    condition_affects_production: true
+    condition_change_type: deployment
+    requires_rollback_plan: true
+    action: warn
+    message: "Consider documenting rollback plan before deploying"
+
+  - id: no-friday-deploys
+    description: Avoid production deploys on Fridays
+    condition_affects_production: true
+    condition_day_of_week: friday
+    action: warn
+    message: "Friday deploys are risky - consider waiting until Monday"
+```
+
+---
+
+## Writing Your Own Guardrails
+
+### Step 1: Create a YAML File
+
+```bash
+# Create in the guardrails directory
+touch guardrails/my-project-rules.yaml
+```
+
+### Step 2: Define Rules
+
+Think about:
+
+1. **What decisions should be blocked?** → Use `action: block`
+2. **What decisions should be flagged?** → Use `action: warn`
+3. **What conditions trigger the rule?** → Use `condition_*` fields
+4. **What requirements must be met?** → Use `requires_*` fields
+
+### Step 3: Test Locally
+
+```bash
+# List guardrails to verify they load
+python bin/cognition guardrails
+
+# Test with a specific context
+python bin/cognition check --category trading --stakes high --confidence 0.3
+```
+
+### Step 4: Deploy
+
+Place your YAML file in a configured guardrail directory:
+
+```bash
+GUARDRAILS_PATHS=/app/guardrails:/app/my-custom-guardrails
+```
+
+---
+
+## Audit Trail
+
+Every guardrail evaluation is recorded in the audit trail:
+
+**Output location:** `audit/YYYY-MM-DD-<decision_id>.json`
+
+**Contents:**
+
+```json
+{
+  "decision_id": "2026-02-07-decision-a1b2c3d4",
+  "timestamp": "2026-02-07T12:00:00Z",
+  "overall_allowed": false,
+  "evaluations": [
+    {
+      "guardrail_id": "no-production-without-review",
+      "matched": true,
+      "passed": false,
+      "action": "block",
+      "message": "Production changes require completed code review"
+    }
+  ],
+  "override": null
+}
+```
+
+### Querying Audit Records
+
+The `AuditLog` class provides methods for querying:
+
+- `get_violations(since)` — All violations since a timestamp
+- `get_statistics()` — Aggregate stats: total evaluations, block rate, most triggered rules
+- `get_overrides()` — Decisions where violations were overridden
+
+---
+
+## Best Practices
+
+1. **Start with cornerstone rules** — Block non-negotiable violations (safety, compliance)
+2. **Use warnings for soft guidelines** — Don't block everything; let agents learn
+3. **Scope to projects** — Use `scope:` to avoid overly broad rules
+4. **Write clear messages** — Agents need to understand *why* they were blocked
+5. **Review audit trails** — Monitor which rules trigger most often
+6. **Version your templates** — Include `version:` for tracking changes
+7. **Test before deploying** — Use the CLI to verify rules work as expected

--- a/website/reference/mcp-quickstart.md
+++ b/website/reference/mcp-quickstart.md
@@ -1,0 +1,385 @@
+# MCP Integration Guide
+
+> **Since:** v0.9.0  
+> **Protocol:** [Model Context Protocol](https://modelcontextprotocol.io/) (MCP)
+
+This guide covers connecting MCP-compliant agents to CSTP decision intelligence. The MCP layer exposes the same capabilities as the JSON-RPC API through a standardized tool interface.
+
+---
+
+## Architecture
+
+The MCP server is a **thin bridge** over the existing CSTP dispatcher. Each MCP tool maps 1:1 to a CSTP service method — there is zero business logic duplication.
+
+```mermaid
+graph TB
+    subgraph Clients["MCP Clients"]
+        CC["Claude Code"]
+        CD["Claude Desktop"]
+        OC["OpenClaw"]
+        GEN["Generic MCP Client"]
+    end
+
+    subgraph Transport["Transport Layer"]
+        HTTP["Streamable HTTP<br/>POST/GET :8100/mcp"]
+        STDIO["stdio<br/>python -m a2a.mcp_server"]
+    end
+
+    subgraph MCP["MCP Server"]
+        APP["mcp_app<br/>Server('cstp-decisions')"]
+        SCHEMAS["Pydantic Schemas<br/>(mcp_schemas.py)"]
+        TOOLS["5 Tool Handlers"]
+    end
+
+    subgraph Services["CSTP Services"]
+        QS["query_service"]
+        GS["guardrails_service"]
+        DS["decision_service"]
+        CS["calibration_service"]
+    end
+
+    subgraph Storage["Storage"]
+        CHROMA["ChromaDB"]
+        YAML["YAML Files"]
+    end
+
+    Clients -->|"Streamable HTTP"| HTTP
+    Clients -->|"stdio"| STDIO
+    HTTP --> APP
+    STDIO --> APP
+    APP --> SCHEMAS
+    APP --> TOOLS
+    TOOLS -->|"direct function calls"| Services
+    Services --> Storage
+```
+
+Key design principles:
+
+- **Bridge pattern** — MCP tools validate inputs via Pydantic, then delegate to CSTP services
+- **Shared server instance** — Both stdio and Streamable HTTP use the same `mcp_app` and tool handlers
+- **Zero duplication** — No business logic in the MCP layer; all logic lives in CSTP services
+
+---
+
+## Connection Methods
+
+### Streamable HTTP (Remote)
+
+The CSTP FastAPI server mounts the MCP handler at `/mcp` on port 8100. The endpoint handles both `POST` (tool calls) and `GET` (event streams) on the same path.
+
+```
+http://your-server:8100/mcp
+```
+
+**Requirements:** The CSTP server must be running (Docker or local).
+
+### stdio (Local / Docker)
+
+The MCP server can run as a standalone process communicating over stdin/stdout:
+
+```bash
+# Direct (requires Python env with dependencies)
+python -m a2a.mcp_server
+
+# Via Docker (recommended)
+docker exec -i cstp python -m a2a.mcp_server
+```
+
+**Requirements:** The container/environment must have `CHROMA_URL`, `GEMINI_API_KEY`, and `DECISIONS_PATH` configured.
+
+---
+
+## Client Setup
+
+### Claude Code
+
+```bash
+claude mcp add --transport http cstp-decisions http://your-server:8100/mcp
+```
+
+After adding, CSTP tools appear in Claude Code's tool list automatically.
+
+### Claude Desktop
+
+Add to your Claude Desktop configuration file (`claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "cstp": {
+      "command": "docker",
+      "args": ["exec", "-i", "cstp", "python", "-m", "a2a.mcp_server"],
+      "env": {}
+    }
+  }
+}
+```
+
+> **Note:** The CSTP container must be running. The MCP server inherits all environment variables (`CHROMA_URL`, `GEMINI_API_KEY`, etc.) from the container.
+
+### OpenClaw
+
+Point OpenClaw's MCP client configuration to the Streamable HTTP endpoint:
+
+```
+http://your-server:8100/mcp
+```
+
+Or configure stdio transport to launch the MCP server process directly.
+
+### Generic MCP Client
+
+Any client implementing the [MCP specification](https://modelcontextprotocol.io/) can connect via either transport. The server advertises itself as `cstp-decisions` and exposes 5 tools via the standard `tools/list` method.
+
+---
+
+## Available Tools
+
+### `query_decisions`
+
+Search similar past decisions using semantic search, keyword matching, or hybrid retrieval. Returns matching decisions with confidence scores, categories, and outcomes.
+
+**Use before making new decisions to learn from history.**
+
+```json
+{
+  "query": "database migration strategy",
+  "limit": 5,
+  "retrieval_mode": "hybrid",
+  "filters": {
+    "category": "architecture",
+    "project": "owner/repo"
+  }
+}
+```
+
+**Input Schema:**
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `query` | string | ✅ | — | Natural language query (min 1 char) |
+| `limit` | int | ❌ | 5 | Maximum results (1–50) |
+| `retrieval_mode` | `"semantic"` \| `"keyword"` \| `"hybrid"` | ❌ | `"hybrid"` | Search mode |
+| `bridge_side` | `"structure"` \| `"function"` \| `"both"` | ❌ | `"both"` | Search by bridge side |
+| `filters` | object | ❌ | — | See below |
+
+**Filters:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `category` | string | `architecture`, `process`, `integration`, `tooling`, `security` |
+| `stakes` | string[] | `low`, `medium`, `high`, `critical` |
+| `project` | string | Project in `owner/repo` format |
+| `has_outcome` | bool | Filter to decisions with/without recorded outcomes |
+
+**Output:** List of matching decisions with IDs, titles, confidence scores, categories, stakes, dates, and similarity distances.
+
+---
+
+### `check_action`
+
+Validate an intended action against safety guardrails and policies. Returns whether the action is allowed, any blocking violations, and warnings.
+
+**Always check before high-stakes actions.**
+
+```json
+{
+  "description": "Deploy to production without tests",
+  "stakes": "high",
+  "confidence": 0.6
+}
+```
+
+**Input Schema:**
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `description` | string | ✅ | — | Action you intend to take (min 1 char) |
+| `category` | string | ❌ | — | Action category |
+| `stakes` | `"low"` \| `"medium"` \| `"high"` \| `"critical"` | ❌ | `"medium"` | Stakes level |
+| `confidence` | float | ❌ | — | Your confidence (0.0–1.0) |
+
+**Output:** `allowed` boolean, list of violations (blocking), list of warnings, count of evaluated guardrails.
+
+---
+
+### `log_decision`
+
+Record a decision to the immutable decision log. Include what you decided, your confidence level, category, and supporting reasons.
+
+**Use after making a decision to build calibration history.**
+
+```json
+{
+  "decision": "Use PostgreSQL for the new service",
+  "confidence": 0.85,
+  "category": "architecture",
+  "stakes": "high",
+  "context": "Evaluated PostgreSQL vs MongoDB for the analytics service",
+  "reasons": [
+    {"type": "analysis", "text": "Need ACID transactions for financial data"},
+    {"type": "pattern", "text": "Team has strong PostgreSQL expertise"}
+  ],
+  "project": "owner/repo",
+  "pr": 42,
+  "bridge": {
+    "structure": "PostgreSQL",
+    "function": "persistence"
+  }
+}
+```
+
+**Deliberation Auto-Capture:**
+When `log_decision` is called, the server automatically attaches a "deliberation trace" if you previously called `query_decisions` or `check_action` within the same session. This captures the "chain of thought" leading to the decision without extra effort.
+
+**Input Schema:**
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `decision` | string | ✅ | — | What you decided — state the choice |
+| `confidence` | float | ✅ | — | Confidence (0.0–1.0) |
+| `category` | `"architecture"` \| `"process"` \| `"integration"` \| `"tooling"` \| `"security"` | ✅ | — | Decision category |
+| `stakes` | `"low"` \| `"medium"` \| `"high"` \| `"critical"` | ❌ | `"medium"` | Stakes level |
+| `context` | string | ❌ | — | Situation context |
+| `reasons` | array | ❌ | — | Supporting reasons (see below) |
+| `tags` | string[] | ❌ | — | Tags for categorization |
+| `project` | string | ❌ | — | Project in `owner/repo` format |
+| `feature` | string | ❌ | — | Feature or epic name |
+| `pr` | int | ❌ | — | Pull request number (≥ 1) |
+| `bridge` | object | ❌ | — | Bridge definition (structure/function) |
+
+**Bridge object:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `structure` | string | What it looks like (pattern) |
+| `function` | string | What problem it solves (purpose) |
+| `tolerance` | string[] | Features that don't matter |
+| `enforcement` | string[] | Features that must be present |
+| `prevention` | string[] | Features that must be absent |
+
+**Reason object:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `"authority"` \| `"analogy"` \| `"analysis"` \| `"pattern"` \| `"intuition"` | Reasoning type |
+| `text` | string | Explanation |
+
+**Output:** Decision ID, file path, indexed status, and timestamp.
+
+---
+
+### `review_outcome`
+
+Record the outcome of a past decision. Provide the decision ID, whether it succeeded or failed, what actually happened, and lessons learned.
+
+**Builds calibration data over time.**
+
+```json
+{
+  "id": "a1b2c3d4",
+  "outcome": "success",
+  "actual_result": "PostgreSQL handled the load well, no issues",
+  "lessons": "ACID transactions were indeed critical for data integrity"
+}
+```
+
+**Input Schema:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | ✅ | Decision ID (8-char hex) |
+| `outcome` | `"success"` \| `"partial"` \| `"failure"` \| `"abandoned"` | ✅ | Outcome of the decision |
+| `actual_result` | string | ❌ | What actually happened |
+| `lessons` | string | ❌ | Lessons learned |
+| `notes` | string | ❌ | Additional review notes |
+
+**Output:** Review status, updated path, and reindex confirmation.
+
+---
+
+### `get_stats`
+
+Get calibration statistics: Brier score, accuracy, confidence distribution, and decision counts. Optionally filter by category, project, or time window.
+
+**Use to check decision-making quality.**
+
+```json
+{
+  "category": "architecture",
+  "window": "90d"
+}
+```
+
+**Input Schema:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `category` | string | ❌ | Filter by category |
+| `project` | string | ❌ | Filter by project (`owner/repo`) |
+| `window` | `"30d"` \| `"60d"` \| `"90d"` \| `"all"` | ❌ | Rolling time window |
+
+**Output:** Brier score, accuracy, confidence distribution, decision counts, and confidence variance metrics.
+
+---
+
+## Error Handling
+
+All MCP tool errors are returned as `TextContent` containing a JSON object:
+
+```json
+{
+  "error": "validation_error",
+  "message": "1 validation error for QueryDecisionsInput\nquery\n  Field required [type=missing, ...]"
+}
+```
+
+| Error Type | Cause |
+|------------|-------|
+| `validation_error` | Invalid input — Pydantic schema validation failed |
+| `internal_error` | Unexpected server error — check server logs |
+
+The MCP server logs to stderr (stdout is reserved for the MCP protocol). Check container logs for debugging:
+
+```bash
+docker logs cstp 2>&1 | grep "cstp-mcp"
+```
+
+---
+
+## Authentication
+
+- **Streamable HTTP** — Inherits authentication from the FastAPI bearer token middleware. The same `CSTP_AUTH_TOKENS` apply.
+- **stdio** — No bearer token authentication. Security relies on process-level isolation (e.g., Docker container, local access).
+
+---
+
+## Local Development
+
+```bash
+# 1. Install with MCP support
+pip install -e ".[a2a,mcp,dev]"
+
+# 2. Set required environment variables
+export CHROMA_URL=http://localhost:8000
+export GEMINI_API_KEY=your-key
+export DECISIONS_PATH=./decisions
+
+# 3. Run MCP server (stdio)
+python -m a2a.mcp_server
+
+# 4. Or start the full server (includes /mcp endpoint)
+python -m uvicorn a2a.server:app --host 0.0.0.0 --port 8100
+```
+
+---
+
+## Tool-to-Method Mapping
+
+| MCP Tool | CSTP JSON-RPC Method | Service Module |
+|----------|----------------------|----------------|
+| `query_decisions` | `cstp.queryDecisions` | `a2a/cstp/query_service.py` |
+| `check_action` | `cstp.checkGuardrails` | `a2a/cstp/guardrails_service.py` |
+| `log_decision` | `cstp.recordDecision` | `a2a/cstp/decision_service.py` |
+| `review_outcome` | `cstp.reviewDecision` | `a2a/cstp/decision_service.py` |
+| `get_stats` | `cstp.getCalibration` | `a2a/cstp/calibration_service.py` |

--- a/website/reference/product-overview.md
+++ b/website/reference/product-overview.md
@@ -1,0 +1,138 @@
+# Product Overview
+
+## What Is Cognition Engines?
+
+**Cognition Engines** is the intelligence layer for AI agent decision-making. It extends the [agent-decisions](https://github.com/tfatykhov/agent-decisions) project with three core pillars:
+
+| Pillar | Purpose |
+|--------|---------|
+| **Accelerators** | Cross-agent learning through semantic decision querying, hybrid retrieval, and pattern detection |
+| **Bridge Definitions** | Dual-indexing of decisions by structure (form) and function (purpose) |
+| **Related Decisions** | Auto-linked predecessors from pre-decision queries (lightweight graph edges) |
+| **Deliberation** | Full chain-of-thought capture with step-by-step reasoning traces |
+| **Guardrails** | Policy enforcement that prevents violations before they occur |
+| **MCP Transport** | Native integration with any MCP-compliant agent via Model Context Protocol |
+
+Inspired by Cisco Outshift's [Internet of Cognition](https://outshift.cisco.com/blog/from-connection-to-cognition-scaling-superintelligence) architecture, Cognition Engines provides a shared cognitive substrate for multi-agent systems.
+
+---
+
+## Core Value Proposition
+
+### 1. Semantic Decision Memory
+
+Every decision made by any agent is embedded as a high-dimensional vector (via Google Gemini `text-embedding-004`) and stored in **ChromaDB**. Any agent can later query the collective memory:
+
+```
+"Has anyone made a similar decision before?"
+"What happened last time we chose PostgreSQL for agent memory?"
+```
+
+### 2. Policy Enforcement at Decision Time
+
+YAML-defined guardrails are evaluated **before** an agent commits to a decision. Rules can block, warn, or log:
+
+```yaml
+- id: no-high-stakes-low-confidence
+  description: High-stakes decisions need minimum confidence
+  condition_stakes: high
+  condition_confidence: "< 0.5"
+  action: block
+  message: High-stakes decisions require ≥50% confidence
+```
+
+### 3. Confidence Calibration & Feedback Loop
+
+The system tracks predicted confidence vs. actual outcomes over time, computing **Brier scores** per agent, per category, and per confidence bucket. This reveals whether agents are over-confident, under-confident, or well-calibrated.
+
+The feedback loop (v0.8.0) enables agents to record decisions, review outcomes, retrieve calibration statistics, and auto-attribute outcomes — closing the cycle between prediction and actuality. Rolling calibration windows (v0.9.0) with drift alerts detect when decision quality degrades over time.
+
+### 4. Cross-Agent Federation (CSTP)
+
+The **Cognition State Transfer Protocol** (CSTP v0.9.0) exposes all capabilities via a JSON-RPC 2.0 API over HTTP, allowing remote agents to query, record, and review decisions across organizational boundaries.
+
+### 5. MCP Integration (Model Context Protocol)
+
+Since v0.9.0, Cognition Engines exposes all decision intelligence capabilities as **MCP tools**, enabling native integration with Claude Desktop, Claude Code, OpenClaw, and any MCP-compliant client. Two transports are supported:
+
+- **Streamable HTTP** — `POST`/`GET` to `/mcp` on the existing CSTP server (port 8100)
+- **stdio** — `python -m a2a.mcp_server` for local or Docker-based access
+
+The MCP layer is a **zero-duplication bridge** — each MCP tool maps 1:1 to an existing CSTP service method.
+
+---
+
+## Key Features
+
+| Feature | Status | Version |
+|---------|--------|---------|
+| Semantic Decision Index | ✅ Shipped | v0.5.0 |
+| Pattern Detection Engine | ✅ Shipped | v0.6.0 |
+| Enhanced Guardrails + Audit Trail | ✅ Shipped | v0.6.0 |
+| Cross-Agent Federation (CSTP) | ✅ Shipped | v0.7.0 |
+| Decision Recording (`cstp.recordDecision`) | ✅ Shipped | v0.7.1 |
+| Project Context & Attribution | ✅ Shipped | v0.7.2 |
+| Web Dashboard | ✅ Shipped | v0.7.4 |
+| Feedback Loop (`recordDecision`, `reviewDecision`, `getCalibration`, `attributeOutcomes`) | ✅ Shipped | v0.8.0 |
+| Rolling Calibration & Drift Alerts | ✅ Shipped | v0.9.0 |
+| Confidence Variance Detection | ✅ Shipped | v0.9.0 |
+| Hybrid Retrieval (BM25 + Semantic) | ✅ Shipped | v0.9.0 |
+| MCP Server (5 tools, stdio + Streamable HTTP) | ✅ Shipped | v0.9.0 |
+| Bridge-Definitions (F024) | ✅ Shipped | v0.9.1 |
+| Related Decisions (F025) | ✅ Shipped | v0.9.4 |
+| Deliberation Traces (F023) | ✅ Shipped | v0.9.1 |
+| Shared Intent Protocol | 📋 Future | — |
+| Context Graphs | 📋 Future | — |
+| Multi-Agent Cognition Network | 📋 Future | — |
+
+---
+
+## Framework Compatibility
+
+Cognition Engines is **agent-framework agnostic** — it is pure Python + ChromaDB and works with:
+
+- **LangChain / LangGraph** — Add as a tool or pre-decision hook
+- **AutoGen** — Integrate into agent decision steps
+- **CrewAI** — Expose as a custom tool
+- **Claude Desktop / Claude Code** — Connect via MCP (stdio or Streamable HTTP)
+- **OpenClaw** — Connect via MCP or direct HTTP
+- **Any MCP client** — Native tool discovery and invocation
+- **Any Python agent** — Import directly or call via HTTP/CLI
+
+---
+
+## Technology Stack
+
+| Layer | Technology |
+|-------|------------|
+| Language | Python 3.11+ |
+| API Framework | FastAPI (async, JSON-RPC 2.0) |
+| MCP Transport | `mcp` SDK — Streamable HTTP + stdio |
+| Vector Database | ChromaDB (semantic search) |
+| Keyword Search | BM25 via `rank-bm25` |
+| Embeddings | Google Gemini `text-embedding-004` (768-dim) |
+| Dashboard | Flask + Jinja2 |
+| Authentication | Bearer token (constant-time comparison) |
+| Containerization | Docker (multi-stage build) |
+| Build System | Hatchling (`pyproject.toml`) |
+| Testing | pytest + pytest-asyncio + pytest-cov |
+| Linting | ruff + mypy (strict) |
+
+---
+
+## Decision Lifecycle
+
+```mermaid
+flowchart LR
+    A["1. Record\nAgent submits\ndecision"] --> B["2. Evaluate\nGuardrails\npass/fail"]
+    B --> C["3. Store & Index\nChromaDB + YAML\npersisted"]
+    C --> D["4. Review\nOutcomes\nBrier scores"]
+    D --> E["5. Calibrate\nDrift detection\n& alerts"]
+    E -->|"feedback loop"| A
+```
+
+1. **Record** — An agent records a decision with confidence, category, stakes, reasons, and optional project context.
+2. **Evaluate** — Guardrails are evaluated against the decision context. Violations block or warn.
+3. **Store** — The decision is written to a YAML file and indexed into ChromaDB with Gemini embeddings.
+4. **Review** — After outcomes are known, the decision is reviewed (success/failure/partial/abandoned).
+5. **Calibrate** — Brier scores and calibration buckets are computed. Rolling windows and drift detection compare recent vs. historical accuracy.


### PR DESCRIPTION
- Dark theme set as default
- Added 4 missing pages: Product Overview, Dashboard Guide, Guardrails Authoring, MCP Quick Start
- Reorganized Reference sidebar into Product Documentation / API & CLI / Setup sections
- Fixed .gitignore (missing newline before website/)