### PR TITLE
docs: fix phantom cognition_skill.py reference, update MCP tool count

### DIFF
--- a/ProductDocumentation/06-Installation-Guide.md
+++ b/ProductDocumentation/06-Installation-Guide.md
@@ -283,20 +283,27 @@ report = detector.full_report()
 
 ## Method 4: OpenClaw Skill
 
-If using the [OpenClaw](https://github.com/tfatykhov/openclaw) agent framework:
+If using the [OpenClaw](https://openclaw.ai) agent framework:
 
 ```bash
-# Copy the skill definition
-cp -r skills/openclaw/cognition_skill.py /path/to/openclaw/skills/
+# Copy the skill into your OpenClaw workspace
+cp -r skills/cognition-engines /path/to/openclaw/workspace/skills/
+
+# Copy the CLI client
+cp scripts/cstp.py /path/to/openclaw/workspace/scripts/
+
+# Configure credentials
+echo 'CSTP_URL=http://your-server:8100' >> /path/to/openclaw/workspace/.secrets/cstp.env
+echo 'CSTP_TOKEN=your-token' >> /path/to/openclaw/workspace/.secrets/cstp.env
 ```
 
-The skill provides `query_decisions` and `check_guardrails` tools to any OpenClaw agent.
+The skill provides a `SKILL.md` with decision workflow instructions, and `cstp.py` gives the agent CLI access to query, check, record, and review decisions.
 
 ---
 
 ## Method 5: MCP Quick Start
 
-Connect any MCP-compliant agent to CSTP decision intelligence. The MCP server exposes 5 tools (`query_decisions`, `check_action`, `log_decision`, `review_outcome`, `get_stats`) via two transports.
+Connect any MCP-compliant agent to CSTP decision intelligence. The MCP server exposes 7 tools (`query_decisions`, `check_action`, `log_decision`, `review_outcome`, `get_stats`, `get_decision`, `get_reason_stats`) via two transports.
 
 ### Streamable HTTP (Remote)
 

--- a/website/guide/getting-started.md
+++ b/website/guide/getting-started.md
@@ -283,20 +283,27 @@ report = detector.full_report()
 
 ## Method 4: OpenClaw Skill
 
-If using the [OpenClaw](https://github.com/tfatykhov/openclaw) agent framework:
+If using the [OpenClaw](https://openclaw.ai) agent framework:
 
 ```bash
-# Copy the skill definition
-cp -r skills/openclaw/cognition_skill.py /path/to/openclaw/skills/
+# Copy the skill into your OpenClaw workspace
+cp -r skills/cognition-engines /path/to/openclaw/workspace/skills/
+
+# Copy the CLI client
+cp scripts/cstp.py /path/to/openclaw/workspace/scripts/
+
+# Configure credentials
+echo 'CSTP_URL=http://your-server:8100' >> /path/to/openclaw/workspace/.secrets/cstp.env
+echo 'CSTP_TOKEN=your-token' >> /path/to/openclaw/workspace/.secrets/cstp.env
 ```
 
-The skill provides `query_decisions` and `check_guardrails` tools to any OpenClaw agent.
+The skill provides a `SKILL.md` with decision workflow instructions, and `cstp.py` gives the agent CLI access to query, check, record, and review decisions.
 
 ---
 
 ## Method 5: MCP Quick Start
 
-Connect any MCP-compliant agent to CSTP decision intelligence. The MCP server exposes 5 tools (`query_decisions`, `check_action`, `log_decision`, `review_outcome`, `get_stats`) via two transports.
+Connect any MCP-compliant agent to CSTP decision intelligence. The MCP server exposes 7 tools (`query_decisions`, `check_action`, `log_decision`, `review_outcome`, `get_stats`, `get_decision`, `get_reason_stats`) via two transports.
 
 ### Streamable HTTP (Remote)
 

--- a/website/reference/installation.md
+++ b/website/reference/installation.md
@@ -283,20 +283,27 @@ report = detector.full_report()
 
 ## Method 4: OpenClaw Skill
 
-If using the [OpenClaw](https://github.com/tfatykhov/openclaw) agent framework:
+If using the [OpenClaw](https://openclaw.ai) agent framework:
 
 ```bash
-# Copy the skill definition
-cp -r skills/openclaw/cognition_skill.py /path/to/openclaw/skills/
+# Copy the skill into your OpenClaw workspace
+cp -r skills/cognition-engines /path/to/openclaw/workspace/skills/
+
+# Copy the CLI client
+cp scripts/cstp.py /path/to/openclaw/workspace/scripts/
+
+# Configure credentials
+echo 'CSTP_URL=http://your-server:8100' >> /path/to/openclaw/workspace/.secrets/cstp.env
+echo 'CSTP_TOKEN=your-token' >> /path/to/openclaw/workspace/.secrets/cstp.env
 ```
 
-The skill provides `query_decisions` and `check_guardrails` tools to any OpenClaw agent.
+The skill provides a `SKILL.md` with decision workflow instructions, and `cstp.py` gives the agent CLI access to query, check, record, and review decisions.
 
 ---
 
 ## Method 5: MCP Quick Start
 
-Connect any MCP-compliant agent to CSTP decision intelligence. The MCP server exposes 5 tools (`query_decisions`, `check_action`, `log_decision`, `review_outcome`, `get_stats`) via two transports.
+Connect any MCP-compliant agent to CSTP decision intelligence. The MCP server exposes 7 tools (`query_decisions`, `check_action`, `log_decision`, `review_outcome`, `get_stats`, `get_decision`, `get_reason_stats`) via two transports.
 
 ### Streamable HTTP (Remote)
 


### PR DESCRIPTION
## What

Fixes the phantom `skills/openclaw/cognition_skill.py` reference that Tim spotted - the file never existed.

## Changes

- **Replaced** nonexistent `cp -r skills/openclaw/cognition_skill.py` with actual OpenClaw integration instructions:
  - Copy `skills/cognition-engines/` (contains `SKILL.md`)
  - Copy `scripts/cstp.py` CLI client
  - Configure `.secrets/cstp.env` credentials
- **Updated** MCP tool count from 5 to 7 (added `get_decision`, `get_reason_stats` from PRs #44/#45)
- Fixed in all 3 copies: `website/guide/getting-started.md`, `website/reference/installation.md`, `ProductDocumentation/06-Installation-Guide.md`

## Why

OpenClaw uses markdown-based skills (`SKILL.md`), not Python plugin files. The docs referenced a file format that does not exist.

Docs-only PR - no code changes.