### PR TITLE
fix: standardize docs - ports, tool counts, add golden-path + why pages

### DIFF
--- a/website/.vitepress/config.mjs
+++ b/website/.vitepress/config.mjs
@@ -36,7 +36,9 @@ export default defineConfig({
           text: 'Introduction',
           items: [
             { text: 'What is Cognition Engines?', link: '/guide/what-is-cognition-engines' },
+            { text: 'Why Cognition Engines?', link: '/guide/why-cognition-engines' },
             { text: 'Getting Started', link: '/guide/getting-started' },
+            { text: 'Golden Path Walkthrough', link: '/guide/golden-path' },
             { text: 'Agent Quick Start', link: '/guide/agent-quickstart' },
           ]
         },

--- a/website/guide/getting-started.md
+++ b/website/guide/getting-started.md
@@ -42,14 +42,16 @@ cp .env.example .env
 docker compose up -d
 
 # 5. Verify
-curl http://localhost:8100/health
+curl http://localhost:9991/health
 ```
+
+> **Note:** Port 9991 is the default. Override it with the `CSTP_PORT` environment variable.
 
 ### What Gets Started
 
 | Service | Port | Description |
 |---------|------|-------------|
-| `cstp-server` | 8100 | CSTP API server |
+| `cstp-server` | 9991 | CSTP API server |
 | `chromadb` | 8000 | ChromaDB vector database |
 
 ### Docker Compose Details
@@ -59,7 +61,7 @@ services:
   cstp-server:
     build: .
     ports:
-      - "8100:8100"
+      - "9991:9991"
     environment:
       - GEMINI_API_KEY=${GEMINI_API_KEY}
       - CSTP_AUTH_TOKENS=${CSTP_AUTH_TOKENS}
@@ -190,23 +192,23 @@ $env:CHROMA_URL = "http://localhost:8000"
 cstp-server --config config/server.yaml
 
 # Or directly with Python
-python -m uvicorn a2a.server:app --host 0.0.0.0 --port 8100
+python -m uvicorn a2a.server:app --host 0.0.0.0 --port 9991
 
 # Or with the entry point
-python a2a/server.py --config config/server.yaml --port 8100
+python a2a/server.py --config config/server.yaml --port 9991
 ```
 
 ### Step 6: Verify
 
 ```bash
 # Health check
-curl http://localhost:8100/health
+curl http://localhost:9991/health
 
 # Agent card
-curl http://localhost:8100/.well-known/agent.json
+curl http://localhost:9991/.well-known/agent.json
 
 # Query decisions (requires auth)
-curl -X POST http://localhost:8100/cstp `
+curl -X POST http://localhost:9991/cstp `
   -H "Authorization: Bearer myagent:mysecrettoken" `
   -H "Content-Type: application/json" `
   -d '{"jsonrpc":"2.0","method":"cstp.queryDecisions","params":{"query":"test"},"id":"1"}'
@@ -293,7 +295,7 @@ cp -r skills/cognition-engines /path/to/openclaw/workspace/skills/
 cp scripts/cstp.py /path/to/openclaw/workspace/scripts/
 
 # Configure credentials
-echo 'CSTP_URL=http://your-server:8100' >> /path/to/openclaw/workspace/.secrets/cstp.env
+echo 'CSTP_URL=http://your-server:9991' >> /path/to/openclaw/workspace/.secrets/cstp.env
 echo 'CSTP_TOKEN=your-token' >> /path/to/openclaw/workspace/.secrets/cstp.env
 ```
 
@@ -307,14 +309,14 @@ Connect any MCP-compliant agent to CSTP decision intelligence. The MCP server ex
 
 ### Streamable HTTP (Remote)
 
-The CSTP server exposes MCP at `/mcp` on the same port (8100):
+The CSTP server exposes MCP at `/mcp` on the same port (9991):
 
 ```bash
 # Claude Code
-claude mcp add --transport http cstp-decisions http://your-server:8100/mcp
+claude mcp add --transport http cstp-decisions http://your-server:9991/mcp
 
 # Any MCP client — point to:
-http://your-server:8100/mcp
+http://your-server:9991/mcp
 ```
 
 ### stdio (Local / Docker)
@@ -368,7 +370,7 @@ Default ports:
 
 | Service | Default Port | Environment Variable |
 |---------|-------------|---------------------|
-| CSTP Server | 8100 | `CSTP_PORT` |
+| CSTP Server | 9991 | `CSTP_PORT` |
 | ChromaDB | 8000 | `CHROMA_URL` (full URL) |
 | Dashboard | 5001 | `DASHBOARD_PORT` |
 

--- a/website/guide/golden-path.md
+++ b/website/guide/golden-path.md
@@ -1,0 +1,368 @@
+# Golden Path — End-to-End Walkthrough
+
+Follow these steps to verify your Cognition Engines installation and explore the full decision lifecycle. Every command is copy-paste ready.
+
+> All examples assume the CSTP server is running at `http://localhost:9991` (the default port, configurable via `CSTP_PORT`). Set your token first:
+
+```bash
+export CSTP_TOKEN="your-api-token"
+export CSTP_URL="http://localhost:9991"
+```
+
+---
+
+## 1. Health Check
+
+Confirm the server is up and reachable.
+
+```bash
+curl -s $CSTP_URL/health | python3 -m json.tool
+```
+
+**Expected output:**
+
+```json
+{
+    "status": "healthy",
+    "version": "0.10.0",
+    "uptime_seconds": 1234.5,
+    "decision_count": 0
+}
+```
+
+If you see `"status": "healthy"`, you're good to go.
+
+---
+
+## 2. Record a Decision
+
+Log your first decision — an agent choosing a caching strategy.
+
+```bash
+curl -s -X POST $CSTP_URL/cstp \
+  -H "Authorization: Bearer $CSTP_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "cstp.recordDecision",
+    "params": {
+      "decision": "Use Redis for session caching instead of in-memory store",
+      "confidence": 0.85,
+      "category": "architecture",
+      "stakes": "medium",
+      "context": "Evaluating caching strategies for multi-instance deployment. In-memory fails on restart; Redis provides persistence and shared state across instances.",
+      "reasons": [
+        {"type": "analysis", "text": "Redis survives process restarts and supports multi-instance deployments"},
+        {"type": "pattern", "text": "Previous projects had cache-loss bugs with in-memory stores"}
+      ]
+    },
+    "id": 1
+  }' | python3 -m json.tool
+```
+
+**Expected output:**
+
+```json
+{
+    "jsonrpc": "2.0",
+    "result": {
+        "id": "dec_abc12345",
+        "decision": "Use Redis for session caching instead of in-memory store",
+        "confidence": 0.85,
+        "category": "architecture",
+        "stakes": "medium",
+        "timestamp": "2026-02-09T12:00:00Z",
+        "status": "recorded"
+    },
+    "id": 1
+}
+```
+
+> Save the `id` value — you'll need it in step 6.
+
+---
+
+## 3. Query Similar Decisions
+
+Search for decisions related to "caching" to see what's been recorded.
+
+```bash
+curl -s -X POST $CSTP_URL/cstp \
+  -H "Authorization: Bearer $CSTP_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "cstp.queryDecisions",
+    "params": {
+      "query": "caching strategy for web application",
+      "retrievalMode": "hybrid",
+      "limit": 5
+    },
+    "id": 2
+  }' | python3 -m json.tool
+```
+
+**Expected output:**
+
+```json
+{
+    "jsonrpc": "2.0",
+    "result": {
+        "decisions": [
+            {
+                "id": "dec_abc12345",
+                "decision": "Use Redis for session caching instead of in-memory store",
+                "confidence": 0.85,
+                "category": "architecture",
+                "similarity": 0.92,
+                "timestamp": "2026-02-09T12:00:00Z"
+            }
+        ],
+        "total": 1,
+        "retrievalMode": "hybrid"
+    },
+    "id": 2
+}
+```
+
+The decision you just recorded appears with a high similarity score.
+
+---
+
+## 4. Check Guardrails (See a Block)
+
+Try a high-stakes action with low confidence — the guardrails should block it.
+
+```bash
+curl -s -X POST $CSTP_URL/cstp \
+  -H "Authorization: Bearer $CSTP_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "cstp.checkGuardrails",
+    "params": {
+      "action": {
+        "description": "Deploy untested model to production",
+        "category": "architecture",
+        "stakes": "high",
+        "confidence": 0.3
+      }
+    },
+    "id": 3
+  }' | python3 -m json.tool
+```
+
+**Expected output:**
+
+```json
+{
+    "jsonrpc": "2.0",
+    "result": {
+        "allowed": false,
+        "violations": [
+            {
+                "rule": "no-high-stakes-low-confidence",
+                "message": "High-stakes actions require confidence >= 0.5",
+                "stakes": "high",
+                "confidence": 0.3
+            }
+        ]
+    },
+    "id": 3
+}
+```
+
+The `"allowed": false` response means the guardrail fired correctly. An agent receiving this should pause and gather more information before proceeding.
+
+---
+
+## 5. Record Another Decision
+
+Add a second decision so there's enough data for calibration.
+
+```bash
+curl -s -X POST $CSTP_URL/cstp \
+  -H "Authorization: Bearer $CSTP_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "cstp.recordDecision",
+    "params": {
+      "decision": "Use PostgreSQL full-text search instead of Elasticsearch for v1",
+      "confidence": 0.70,
+      "category": "architecture",
+      "stakes": "medium",
+      "context": "Need search functionality but want to avoid operational overhead of a separate Elasticsearch cluster for initial launch.",
+      "reasons": [
+        {"type": "analysis", "text": "PostgreSQL FTS handles our current scale (< 100k docs) without extra infra"},
+        {"type": "elimination", "text": "Elasticsearch adds operational complexity we cannot staff for at launch"}
+      ]
+    },
+    "id": 4
+  }' | python3 -m json.tool
+```
+
+**Expected output:**
+
+```json
+{
+    "jsonrpc": "2.0",
+    "result": {
+        "id": "dec_def67890",
+        "decision": "Use PostgreSQL full-text search instead of Elasticsearch for v1",
+        "confidence": 0.70,
+        "category": "architecture",
+        "stakes": "medium",
+        "timestamp": "2026-02-09T12:05:00Z",
+        "status": "recorded"
+    },
+    "id": 4
+}
+```
+
+---
+
+## 6. Review an Outcome
+
+Go back to the first decision and record what actually happened. Replace `dec_abc12345` with the ID from step 2.
+
+```bash
+curl -s -X POST $CSTP_URL/cstp \
+  -H "Authorization: Bearer $CSTP_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "cstp.reviewOutcome",
+    "params": {
+      "id": "dec_abc12345",
+      "outcome": "success",
+      "result": "Redis caching reduced p99 latency from 450ms to 80ms. Shared state works correctly across 3 instances. No cache-loss incidents in 2 weeks of production use."
+    },
+    "id": 5
+  }' | python3 -m json.tool
+```
+
+**Expected output:**
+
+```json
+{
+    "jsonrpc": "2.0",
+    "result": {
+        "id": "dec_abc12345",
+        "outcome": "success",
+        "result": "Redis caching reduced p99 latency from 450ms to 80ms. Shared state works correctly across 3 instances. No cache-loss incidents in 2 weeks of production use.",
+        "reviewedAt": "2026-02-09T12:10:00Z"
+    },
+    "id": 5
+}
+```
+
+This closes the feedback loop — the system now knows this 0.85-confidence decision turned out well.
+
+---
+
+## 7. Check Calibration
+
+See how well your confidence scores match actual outcomes.
+
+```bash
+curl -s -X POST $CSTP_URL/cstp \
+  -H "Authorization: Bearer $CSTP_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "cstp.getStats",
+    "params": {},
+    "id": 6
+  }' | python3 -m json.tool
+```
+
+**Expected output:**
+
+```json
+{
+    "jsonrpc": "2.0",
+    "result": {
+        "totalDecisions": 2,
+        "reviewedDecisions": 1,
+        "calibration": {
+            "buckets": [
+                {
+                    "range": "0.8-0.9",
+                    "count": 1,
+                    "successRate": 1.0,
+                    "avgConfidence": 0.85
+                }
+            ],
+            "brierScore": 0.02,
+            "overconfidenceIndex": 0.0
+        },
+        "byCategory": {
+            "architecture": 2
+        },
+        "byStakes": {
+            "medium": 2
+        }
+    },
+    "id": 6
+}
+```
+
+With more reviewed decisions, the calibration data becomes meaningful. A `brierScore` closer to 0 means your confidence scores are well-calibrated.
+
+---
+
+## 8. Check Drift
+
+Monitor whether decision patterns are shifting over time.
+
+```bash
+curl -s -X POST $CSTP_URL/cstp \
+  -H "Authorization: Bearer $CSTP_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "cstp.getReasonStats",
+    "params": {},
+    "id": 7
+  }' | python3 -m json.tool
+```
+
+**Expected output:**
+
+```json
+{
+    "jsonrpc": "2.0",
+    "result": {
+        "reasonTypes": {
+            "analysis": {
+                "count": 3,
+                "percentage": 0.60
+            },
+            "pattern": {
+                "count": 1,
+                "percentage": 0.20
+            },
+            "elimination": {
+                "count": 1,
+                "percentage": 0.20
+            }
+        },
+        "totalReasons": 5,
+        "avgReasonsPerDecision": 2.0,
+        "diversityScore": 0.72
+    },
+    "id": 7
+}
+```
+
+A healthy system shows diverse reason types. If every decision relies on a single reason type, the agent may be operating on brittle logic — the `diversityScore` helps surface this.
+
+---
+
+## What's Next?
+
+- **[Decision Protocol](/guide/decision-protocol)** — Understand the full query → check → record → review lifecycle
+- **[Guardrails](/guide/guardrails)** — Configure rules that protect against bad decisions
+- **[MCP Integration](/guide/mcp-integration)** — Connect your AI agent via Model Context Protocol
+- **[Bridge-Definitions](/guide/bridge-definitions)** — Link structure to purpose for richer recall

--- a/website/guide/why-cognition-engines.md
+++ b/website/guide/why-cognition-engines.md
@@ -1,0 +1,93 @@
+# Why Cognition Engines?
+
+AI agents make thousands of decisions. Most tooling treats these as opaque log entries or metrics. Cognition Engines treats them as **first-class artifacts** with structure, feedback, and recall.
+
+Here's how it compares to the tools you already know.
+
+## Decisions Are Artifacts, Not Logs
+
+Observability platforms (Datadog, LangSmith, Langfuse) capture **traces** — what happened, in what order, how long it took. That's useful for debugging, but a trace doesn't tell you *why* an agent chose path A over path B, or whether it would make the same choice again.
+
+Cognition Engines records decisions with:
+
+- **Structured reasons** (typed: analysis, pattern, empirical, intuition, …)
+- **Confidence scores** that become calibration data
+- **Stakes levels** that feed into guardrails
+- **Context** that enables semantic recall later
+
+A decision is a *claim about the world* with attached justification — not a log line.
+
+## Outcome Feedback Loop
+
+Most guardrail and evaluation tools are **one-directional**: they check inputs and flag problems. They don't close the loop.
+
+Cognition Engines supports a full lifecycle:
+
+1. **Record** a decision with confidence
+2. **Review** the outcome when it's known
+3. **Calibrate** — are 0.8-confidence decisions actually succeeding 80% of the time?
+4. **Adjust** — surface overconfidence or systematic blind spots
+
+This is how expert judgment improves. Without outcome tracking, you're flying blind on whether your agent's decision quality is improving or degrading.
+
+## Bridge-Definitions Connect Structure to Purpose
+
+Inspired by Minsky's *Society of Mind* (Ch. 12), bridge-definitions link the **structural form** of a decision to its **functional purpose**:
+
+- *"We chose Redis"* is structure (what)
+- *"We needed shared state across instances"* is function (why)
+
+When an agent searches past decisions, it can search by either axis independently:
+
+- **"What solves shared-state problems?"** → finds the Redis decision by function
+- **"Where else did we use Redis?"** → finds it by structure
+
+Two independent recall paths mean better retrieval. If both paths point to the same answer, confidence goes up — Minsky's parallel-bundle principle (Ch. 18).
+
+Traditional vector search treats the whole decision as a single embedding. Bridge-definitions give you two.
+
+## Deliberation Traces Are Automatic
+
+Many systems require clients to manually instrument their reasoning chains. Cognition Engines captures deliberation traces **from normal API usage** — no client changes needed.
+
+When an agent:
+1. Queries similar past decisions
+2. Checks guardrails
+3. Records a decision
+
+The server automatically links steps 1 and 2 as **inputs** to step 3. The result is a trace showing *what the agent considered before deciding*, built from the calls it was already making.
+
+Zero instrumentation overhead. Zero client SDK changes.
+
+## Built for AI Agents, Not Dashboards
+
+Most decision and governance tools assume a human is in the loop — approval workflows, visual dashboards, manual review queues. Cognition Engines is designed for agents operating autonomously at speed:
+
+| Concern | Dashboard-First Tools | Cognition Engines |
+|---------|----------------------|-------------------|
+| Primary consumer | Human analyst | AI agent |
+| Decision format | Free text / UI form | Structured JSON-RPC |
+| Recall mechanism | Manual search | Semantic + hybrid retrieval |
+| Guardrails | Human approval gates | Programmatic rules, agent-evaluated |
+| Feedback loop | Periodic human review | Continuous outcome tracking |
+| Integration | SDK / UI | JSON-RPC + MCP (7 tools) |
+
+The dashboard exists (for humans who want to inspect agent behavior), but the system is designed API-first for autonomous agents.
+
+## Summary
+
+| Capability | Observability Tools | Guardrail Tools | Cognition Engines |
+|-----------|--------------------|-----------------|--------------------|
+| Capture what happened | ✅ Traces | ❌ | ✅ Decisions |
+| Capture *why* | ❌ | ❌ | ✅ Typed reasons |
+| Block bad actions | ❌ | ✅ Rules | ✅ Guardrails |
+| Learn from outcomes | ❌ | ❌ | ✅ Calibration |
+| Recall past decisions | ❌ | ❌ | ✅ Hybrid search |
+| Dual-axis retrieval | ❌ | ❌ | ✅ Bridge-definitions |
+| Auto deliberation traces | ❌ | ❌ | ✅ Zero-instrument |
+
+Cognition Engines doesn't replace your observability stack — it sits alongside it, giving your agents a structured memory of *what they decided and why*, with feedback that makes future decisions better.
+
+---
+
+**Next:** [Golden Path Walkthrough](/guide/golden-path) — Try it hands-on in 10 minutes.

--- a/website/reference/api.md
+++ b/website/reference/api.md
@@ -98,7 +98,7 @@ A2A agent discovery card.
   "name": "cognition-engines",
   "description": "Decision Intelligence Service",
   "version": "0.9.0",
-  "url": "http://localhost:8100",
+  "url": "http://localhost:9991",
   "capabilities": ["queryDecisions", "checkGuardrails", "recordDecision", "reviewDecision", "getCalibration"],
   "protocol": "cstp",
   "protocolVersion": "0.9.0"
@@ -618,14 +618,14 @@ Since v0.9.0, CSTP exposes decision intelligence capabilities as **MCP tools** f
 
 | Transport | Endpoint | Use Case |
 |-----------|----------|----------|
-| **Streamable HTTP** | `POST`/`GET` `http://host:8100/mcp` | Remote access from any network-reachable MCP client |
+| **Streamable HTTP** | `POST`/`GET` `http://host:9991/mcp` | Remote access from any network-reachable MCP client |
 | **stdio** | `python -m a2a.mcp_server` | Local access or Docker exec |
 
 ### Connecting
 
 ```bash
 # Claude Code — add as remote MCP server
-claude mcp add --transport http cstp-decisions http://your-server:8100/mcp
+claude mcp add --transport http cstp-decisions http://your-server:9991/mcp
 
 # Claude Desktop — add to claude_desktop_config.json (stdio via Docker)
 {
@@ -755,23 +755,23 @@ Error types:
 
 ```bash
 # Query decisions
-curl -X POST http://localhost:8100/cstp \
+curl -X POST http://localhost:9991/cstp \
   -H "Authorization: Bearer myagent:mytoken" \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"cstp.queryDecisions","params":{"query":"authentication approach"},"id":"1"}'
 
 # Check guardrails
-curl -X POST http://localhost:8100/cstp \
+curl -X POST http://localhost:9991/cstp \
   -H "Authorization: Bearer myagent:mytoken" \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"cstp.checkGuardrails","params":{"action":{"description":"Deploy to prod","stakes":"high","context":{"affects_production":true}}},"id":"2"}'
 
 # Record decision
-curl -X POST http://localhost:8100/cstp \
+curl -X POST http://localhost:9991/cstp \
   -H "Authorization: Bearer myagent:mytoken" \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"cstp.recordDecision","params":{"decision":"Use Redis for caching","confidence":0.8,"category":"architecture"},"id":"3"}'
 
 # Health check (no auth)
-curl http://localhost:8100/health
+curl http://localhost:9991/health
 ```

--- a/website/reference/architecture.md
+++ b/website/reference/architecture.md
@@ -391,7 +391,7 @@ sequenceDiagram
 graph TB
     subgraph Docker["Docker Compose"]
         subgraph CSTP["cstp-server (Python 3.11)"]
-            PORT_8100["Port: 8100"]
+            PORT_9991["Port: 9991"]
             EP_CSTP["/cstp — JSON-RPC 2.0"]
             EP_MCP["/mcp — MCP Streamable HTTP"]
             EP_HEALTH["/health"]
@@ -418,7 +418,7 @@ graph TB
 - **Builder stage:** Installs `uv` and Python dependencies from `pyproject.toml`
 - **Runtime stage:** Copies installed packages, app code, creates non-root user
 - **Security:** Runs as `appuser` (non-root), read-only config mounts
-- **MCP:** Both `/cstp` (JSON-RPC) and `/mcp` (MCP Streamable HTTP) are served on port 8100
+- **MCP:** Both `/cstp` (JSON-RPC) and `/mcp` (MCP Streamable HTTP) are served on port 9991
 
 ---
 

--- a/website/reference/configuration.md
+++ b/website/reference/configuration.md
@@ -22,7 +22,7 @@ Cognition Engines supports configuration through three sources (in order of prec
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `CSTP_HOST` | `0.0.0.0` | Server bind address |
-| `CSTP_PORT` | `8100` | Server port |
+| `CSTP_PORT` | `9991` | Server port |
 | `LOG_LEVEL` | `INFO` | `DEBUG`, `INFO`, `WARNING`, `ERROR` |
 
 ### ChromaDB
@@ -60,7 +60,7 @@ Cognition Engines supports configuration through three sources (in order of prec
 ```yaml
 # Server settings
 host: 0.0.0.0
-port: 8100
+port: 9991
 
 # CORS (comma-separated or list)
 cors_origins:

--- a/website/reference/dashboard-guide.md
+++ b/website/reference/dashboard-guide.md
@@ -48,7 +48,7 @@ Dashboard starts on `http://localhost:5001` by default.
 Set environment variables before starting:
 
 ```bash
-$env:DASHBOARD_CSTP_URL = "http://localhost:8100"
+$env:DASHBOARD_CSTP_URL = "http://localhost:9991"
 $env:DASHBOARD_CSTP_TOKEN = "myagent:mysecrettoken"
 $env:DASHBOARD_SECRET_KEY = "your-flask-secret-key"
 $env:DASHBOARD_PORT = "5001"
@@ -61,7 +61,7 @@ python dashboard/app.py
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `DASHBOARD_CSTP_URL` | `http://localhost:8100` | CSTP server URL |
+| `DASHBOARD_CSTP_URL` | `http://localhost:9991` | CSTP server URL |
 | `DASHBOARD_CSTP_TOKEN` | — | Bearer token for CSTP API |
 | `DASHBOARD_SECRET_KEY` | (random) | Flask session secret key |
 | `DASHBOARD_PORT` | `5001` | Dashboard HTTP port |
@@ -136,7 +136,7 @@ Displays calibration metrics computed from reviewed decisions:
 ┌──────────────┐     HTTP/JSON-RPC     ┌──────────────────┐
 │   Dashboard  │  ──────────────────▶  │   CSTP Server    │
 │   (Flask)    │                        │   (FastAPI)      │
-│   Port 5001  │  ◀──────────────────  │   Port 8100      │
+│   Port 5001  │  ◀──────────────────  │   Port 9991      │
 │              │     JSON responses     │                  │
 └──────────────┘                        └──────────────────┘
 ```

--- a/website/reference/installation.md
+++ b/website/reference/installation.md
@@ -42,14 +42,16 @@ cp .env.example .env
 docker compose up -d
 
 # 5. Verify
-curl http://localhost:8100/health
+curl http://localhost:9991/health
 ```
+
+> **Note:** Port 9991 is the default. Override it with the `CSTP_PORT` environment variable.
 
 ### What Gets Started
 
 | Service | Port | Description |
 |---------|------|-------------|
-| `cstp-server` | 8100 | CSTP API server |
+| `cstp-server` | 9991 | CSTP API server |
 | `chromadb` | 8000 | ChromaDB vector database |
 
 ### Docker Compose Details
@@ -59,7 +61,7 @@ services:
   cstp-server:
     build: .
     ports:
-      - "8100:8100"
+      - "9991:9991"
     environment:
       - GEMINI_API_KEY=${GEMINI_API_KEY}
       - CSTP_AUTH_TOKENS=${CSTP_AUTH_TOKENS}
@@ -190,23 +192,23 @@ $env:CHROMA_URL = "http://localhost:8000"
 cstp-server --config config/server.yaml
 
 # Or directly with Python
-python -m uvicorn a2a.server:app --host 0.0.0.0 --port 8100
+python -m uvicorn a2a.server:app --host 0.0.0.0 --port 9991
 
 # Or with the entry point
-python a2a/server.py --config config/server.yaml --port 8100
+python a2a/server.py --config config/server.yaml --port 9991
 ```
 
 ### Step 6: Verify
 
 ```bash
 # Health check
-curl http://localhost:8100/health
+curl http://localhost:9991/health
 
 # Agent card
-curl http://localhost:8100/.well-known/agent.json
+curl http://localhost:9991/.well-known/agent.json
 
 # Query decisions (requires auth)
-curl -X POST http://localhost:8100/cstp `
+curl -X POST http://localhost:9991/cstp `
   -H "Authorization: Bearer myagent:mysecrettoken" `
   -H "Content-Type: application/json" `
   -d '{"jsonrpc":"2.0","method":"cstp.queryDecisions","params":{"query":"test"},"id":"1"}'
@@ -293,7 +295,7 @@ cp -r skills/cognition-engines /path/to/openclaw/workspace/skills/
 cp scripts/cstp.py /path/to/openclaw/workspace/scripts/
 
 # Configure credentials
-echo 'CSTP_URL=http://your-server:8100' >> /path/to/openclaw/workspace/.secrets/cstp.env
+echo 'CSTP_URL=http://your-server:9991' >> /path/to/openclaw/workspace/.secrets/cstp.env
 echo 'CSTP_TOKEN=your-token' >> /path/to/openclaw/workspace/.secrets/cstp.env
 ```
 
@@ -307,14 +309,14 @@ Connect any MCP-compliant agent to CSTP decision intelligence. The MCP server ex
 
 ### Streamable HTTP (Remote)
 
-The CSTP server exposes MCP at `/mcp` on the same port (8100):
+The CSTP server exposes MCP at `/mcp` on the same port (9991):
 
 ```bash
 # Claude Code
-claude mcp add --transport http cstp-decisions http://your-server:8100/mcp
+claude mcp add --transport http cstp-decisions http://your-server:9991/mcp
 
 # Any MCP client — point to:
-http://your-server:8100/mcp
+http://your-server:9991/mcp
 ```
 
 ### stdio (Local / Docker)
@@ -368,7 +370,7 @@ Default ports:
 
 | Service | Default Port | Environment Variable |
 |---------|-------------|---------------------|
-| CSTP Server | 8100 | `CSTP_PORT` |
+| CSTP Server | 9991 | `CSTP_PORT` |
 | ChromaDB | 8000 | `CHROMA_URL` (full URL) |
 | Dashboard | 5001 | `DASHBOARD_PORT` |
 

--- a/website/reference/mcp-quickstart.md
+++ b/website/reference/mcp-quickstart.md
@@ -21,7 +21,7 @@ graph TB
     end
 
     subgraph Transport["Transport Layer"]
-        HTTP["Streamable HTTP<br/>POST/GET :8100/mcp"]
+        HTTP["Streamable HTTP<br/>POST/GET :9991/mcp"]
         STDIO["stdio<br/>python -m a2a.mcp_server"]
     end
 
@@ -65,10 +65,10 @@ Key design principles:
 
 ### Streamable HTTP (Remote)
 
-The CSTP FastAPI server mounts the MCP handler at `/mcp` on port 8100. The endpoint handles both `POST` (tool calls) and `GET` (event streams) on the same path.
+The CSTP FastAPI server mounts the MCP handler at `/mcp` on port 9991. The endpoint handles both `POST` (tool calls) and `GET` (event streams) on the same path.
 
 ```
-http://your-server:8100/mcp
+http://your-server:9991/mcp
 ```
 
 **Requirements:** The CSTP server must be running (Docker or local).
@@ -94,7 +94,7 @@ docker exec -i cstp python -m a2a.mcp_server
 ### Claude Code
 
 ```bash
-claude mcp add --transport http cstp-decisions http://your-server:8100/mcp
+claude mcp add --transport http cstp-decisions http://your-server:9991/mcp
 ```
 
 After adding, CSTP tools appear in Claude Code's tool list automatically.
@@ -122,14 +122,14 @@ Add to your Claude Desktop configuration file (`claude_desktop_config.json`):
 Point OpenClaw's MCP client configuration to the Streamable HTTP endpoint:
 
 ```
-http://your-server:8100/mcp
+http://your-server:9991/mcp
 ```
 
 Or configure stdio transport to launch the MCP server process directly.
 
 ### Generic MCP Client
 
-Any client implementing the [MCP specification](https://modelcontextprotocol.io/) can connect via either transport. The server advertises itself as `cstp-decisions` and exposes 5 tools via the standard `tools/list` method.
+Any client implementing the [MCP specification](https://modelcontextprotocol.io/) can connect via either transport. The server advertises itself as `cstp-decisions` and exposes 7 tools via the standard `tools/list` method.
 
 ---
 
@@ -369,7 +369,7 @@ export DECISIONS_PATH=./decisions
 python -m a2a.mcp_server
 
 # 4. Or start the full server (includes /mcp endpoint)
-python -m uvicorn a2a.server:app --host 0.0.0.0 --port 8100
+python -m uvicorn a2a.server:app --host 0.0.0.0 --port 9991
 ```
 
 ---

--- a/website/reference/modules.md
+++ b/website/reference/modules.md
@@ -166,7 +166,7 @@ Exposes CSTP capabilities as MCP tools for native integration with MCP-compliant
 **Transports:**
 
 - **stdio** — `python -m a2a.mcp_server` (local or `docker exec -i cstp python -m a2a.mcp_server`)
-- **Streamable HTTP** — Mounted at `/mcp` on port 8100 via `StreamableHTTPSessionManager` in `server.py` lifespan
+- **Streamable HTTP** — Mounted at `/mcp` on port 9991 via `StreamableHTTPSessionManager` in `server.py` lifespan
 
 ### 2.3 `mcp_schemas.py` — MCP Input Schemas
 

--- a/website/reference/product-overview.md
+++ b/website/reference/product-overview.md
@@ -55,7 +55,7 @@ The **Cognition State Transfer Protocol** (CSTP v0.9.0) exposes all capabilities
 
 Since v0.9.0, Cognition Engines exposes all decision intelligence capabilities as **MCP tools**, enabling native integration with Claude Desktop, Claude Code, OpenClaw, and any MCP-compliant client. Two transports are supported:
 
-- **Streamable HTTP** — `POST`/`GET` to `/mcp` on the existing CSTP server (port 8100)
+- **Streamable HTTP** — `POST`/`GET` to `/mcp` on the existing CSTP server (port 9991)
 - **stdio** — `python -m a2a.mcp_server` for local or Docker-based access
 
 The MCP layer is a **zero-duplication bridge** — each MCP tool maps 1:1 to an existing CSTP service method.
@@ -77,7 +77,7 @@ The MCP layer is a **zero-duplication bridge** — each MCP tool maps 1:1 to an 
 | Rolling Calibration & Drift Alerts | ✅ Shipped | v0.9.0 |
 | Confidence Variance Detection | ✅ Shipped | v0.9.0 |
 | Hybrid Retrieval (BM25 + Semantic) | ✅ Shipped | v0.9.0 |
-| MCP Server (5 tools, stdio + Streamable HTTP) | ✅ Shipped | v0.9.0 |
+| MCP Server (7 tools, stdio + Streamable HTTP) | ✅ Shipped | v0.9.0 |
 | Bridge-Definitions (F024) | ✅ Shipped | v0.9.1 |
 | Related Decisions (F025) | ✅ Shipped | v0.9.4 |
 | Deliberation Traces (F023) | ✅ Shipped | v0.9.1 |


### PR DESCRIPTION
## Changes

### Port Standardization
- All CSTP server port references changed from `8100` → `9991` (production default)
- Added `CSTP_PORT` env var note in getting-started and installation pages
- Dashboard port `8080` left unchanged (correct, separate service)

### MCP Tool Count
- Corrected from 5 → 7 tools in `mcp-quickstart.md` and `product-overview.md`
- The 7 tools: `query_decisions`, `check_action`, `log_decision`, `review_outcome`, `get_stats`, `get_decision`, `get_reason_stats`

### New Pages
- **Golden Path Walkthrough** (`guide/golden-path.md`) — copy-paste curl commands covering the full decision lifecycle: health check → record → query → guardrail block → review → calibration → drift
- **Why Cognition Engines** (`guide/why-cognition-engines.md`) — comparison with observability/guardrail tools, covering decisions-as-artifacts, outcome feedback loops, bridge-definitions, auto deliberation traces

### Sidebar
- Added both new pages under Guide > Introduction

⚡ Emerson