### PR TITLE
feat(F027): add update_decision MCP tool

### DIFF
--- a/a2a/mcp_schemas.py
+++ b/a2a/mcp_schemas.py
@@ -359,3 +359,21 @@ class GetReasonStatsInput(BaseModel):
         le=50,
         description="Minimum reviewed decisions to include a reason type in stats",
     )
+
+
+class UpdateDecisionInput(BaseModel):
+    """Input for the update_decision tool."""
+
+    id: str = Field(
+        ...,
+        min_length=1,
+        description="Decision ID to update (8-char hex, e.g. 'b02d10ba')",
+    )
+    tags: list[str] | None = Field(
+        default=None,
+        description="Tags to set on the decision (replaces existing)",
+    )
+    pattern: str | None = Field(
+        default=None,
+        description="Abstract pattern this decision represents",
+    )


### PR DESCRIPTION
Adds update_decision as 8th MCP tool. Shares update_decision() from decision_service.py. Supports tags and pattern fields.