### PR TITLE
fix(F028): tracker key mismatch for reasoning steps

### DIFF
--- a/a2a/cstp/dispatcher.py
+++ b/a2a/cstp/dispatcher.py
@@ -627,7 +627,7 @@ async def _handle_record_thought(params: dict[str, Any], agent_id: str) -> dict[
         }
 
     # Pre-decision: accumulate in tracker
-    track_reasoning(agent_id, text)
+    track_reasoning(f"rpc:{agent_id}", text)
     return {
         "success": True,
         "mode": "pre-decision",


### PR DESCRIPTION
One-line fix: `track_reasoning` used bare `agent_id` but `auto_attach_deliberation` consumes from `rpc:{agent_id}`. Thoughts were stored but never attached to decisions.

Found during live testing after deploy.