### PR TITLE
feat(F028): reasoning enforcement - quality score + guardrail

### DIFF
--- a/a2a/cstp/decision_service.py
+++ b/a2a/cstp/decision_service.py
@@ -559,9 +559,9 @@ def score_decision_quality(request: "RecordDecisionRequest") -> dict[str, Any]:
     score = 0.0
     suggestions: list[str] = []
 
-    # Pattern provided? (+0.2)
+    # Pattern provided? (+0.15)
     if request.pattern:
-        score += 0.2
+        score += 0.15
     else:
         suggestions.append(
             "Add --pattern for the abstract principle "
@@ -591,9 +591,9 @@ def score_decision_quality(request: "RecordDecisionRequest") -> dict[str, Any]:
     else:
         suggestions.append("No reasons provided - add -r 'type:explanation'")
 
-    # Explicit bridge? (+0.15)
+    # Explicit bridge? (+0.10)
     if request.bridge and request.bridge.has_content():
-        score += 0.15
+        score += 0.10
 
     # Decision text length > 20 chars? (+0.1)
     if len(request.decision) > 20:
@@ -618,6 +618,20 @@ def score_decision_quality(request: "RecordDecisionRequest") -> dict[str, Any]:
     )
     if has_deliberation:
         score += 0.05
+
+    # F028: Reasoning steps in deliberation? (+0.10)
+    has_reasoning = False
+    if request.deliberation and request.deliberation.steps:
+        has_reasoning = any(
+            s.type == "reasoning" for s in request.deliberation.steps
+        )
+    if has_reasoning:
+        score += 0.10
+    else:
+        suggestions.append(
+            "No reasoning captured - use cstp.py think \"your thought process\" "
+            "to record chain-of-thought before recording"
+        )
 
     return {
         "score": round(score, 2),

--- a/a2a/cstp/guardrails_service.py
+++ b/a2a/cstp/guardrails_service.py
@@ -432,13 +432,19 @@ async def evaluate_record_guardrails(
         List of warning dicts (empty if no guardrails triggered).
     """
     delib_input_count = len(request.deliberation.inputs) if request.deliberation else 0
+    has_reasoning = False
+    if request.deliberation and request.deliberation.steps:
+        has_reasoning = any(
+            s.type == "reasoning" for s in request.deliberation.steps
+        )
     record_context = {
         "description": request.decision,
         "category": request.category,
         "stakes": request.stakes,
         "confidence": request.confidence,
         "deliberation_inputs_count": delib_input_count,
-        "has_deliberation": delib_input_count > 0,
+        "has_deliberation": delib_input_count > 0 or has_reasoning,
+        "has_reasoning": has_reasoning,
         "phase": "record",
     }
 

--- a/guardrails/deliberation.yaml
+++ b/guardrails/deliberation.yaml
@@ -17,3 +17,13 @@
     stakes: high
   action: block
   message: "High-stakes decisions require prior deliberation. Run: cstp.py pre \"what you plan to do\" -s high"
+
+# F028: Reasoning Capture Enforcement
+- id: recommend-reasoning
+  description: Decisions with deliberation should include reasoning steps
+  condition:
+    phase: record
+    has_deliberation: true
+    has_reasoning: false
+  action: warn
+  message: "Deliberation detected but no reasoning captured. Use cstp.py think \"your thought process\" to record chain-of-thought"


### PR DESCRIPTION
Three-layer enforcement for chain-of-thought capture:

1. **Quality score**: +0.10 for reasoning steps (weights rebalanced to max 1.0)
2. **Guardrail**: `recommend-reasoning` warns when deliberation exists but no reasoning steps
3. **AGENTS.md**: `think` step added to decision workflow (separate commit)

Decisions with `cstp.py think` now score 10% higher. Decisions with queries/checks but no reasoning get a nudge.