### PR TITLE
docs: update 4 pages for record-at-start workflow + new tools

### DIFF
--- a/website/guide/decision-protocol.md
+++ b/website/guide/decision-protocol.md
@@ -1,8 +1,8 @@
 # Decision Protocol
 
-The core workflow that every agent follows. The server auto-captures everything.
+The core workflow that every agent follows. Record early, update as you go.
 
-## The Three Steps
+## The Five Steps
 
 ### Step 1: Query Similar Decisions
 
@@ -27,29 +27,72 @@ cstp.py check -d "deploy retry logic to production" -s high -f 0.85
 
 If blocked, the response tells you why and what to fix.
 
-### Step 3: Record the Decision
+### Step 3: Record the Decision (immediately)
 
-Log what you decided, why, and with what confidence.
+Log your intent right away. This captures the deliberation trace from steps 1-2.
 
 ```bash
 cstp.py record \
-  -d "Added exponential backoff with jitter" \
+  -d "Plan: Add exponential backoff with jitter" \
   -f 0.85 \
   -c architecture \
   -s medium \
   -r "analysis:Backoff handles transient failures" \
-  -r "empirical:Similar pattern succeeded in order-service"
+  -r "empirical:Similar pattern succeeded in order-service" \
+  --tag retry --tag resilience \
+  --pattern "Use exponential backoff for transient external failures"
+```
+
+**Record now, update later.** Save the returned decision ID.
+
+### Step 4: Think During Work
+
+Capture your reasoning as you work. Each thought appends to the decision's deliberation trace.
+
+```bash
+cstp.py think --id <decision_id> "Exploring constant vs exponential backoff"
+cstp.py think --id <decision_id> "Exponential with jitter prevents thundering herd"
+```
+
+### Step 5: Update When Done
+
+Finalize the decision with what you actually did.
+
+```bash
+cstp.py update <decision_id> \
+  -d "Added exponential backoff with jitter for API retries" \
+  --context "Implemented in retry_handler.py. Max 3 retries, base 1s, jitter +/-25%."
 ```
 
 ## What Happens Automatically
 
-When you follow query -> check -> record, three features fire:
+When you follow query -> check -> record, four features fire:
 
 | Feature | What It Does | Response Field |
 |---------|-------------|----------------|
-| **Deliberation Traces** | Links your queries and checks to the decision | `deliberation_auto: true` |
+| **Deliberation Traces** | Links your queries, checks, and reasoning to the decision | `deliberation_auto: true` |
 | **Bridge-Definitions** | Extracts structure/function from your text | `bridge_auto: true` |
 | **Related Decisions** | Links decisions found in queries | `related_count: N` |
+| **Quality Score** | Measures recording completeness (0.0-1.0) | `quality.score` |
+
+## Why Record Early?
+
+Deliberation inputs (queries, checks, thoughts) accumulate per agent. When you call `record`, the server attaches them and clears the tracker. If you wait too long:
+
+- Inputs from one decision bleed into the next
+- Quality drops because deliberation is missing
+- The trace doesn't reflect your actual process
+
+Recording early with `"Plan: ..."` captures everything, then `update` refines it.
+
+## Tags and Patterns
+
+Every decision should include:
+
+- **Tags** (`--tag`): Reusable keywords for filtering. Examples: `caching`, `security`, `api`, `config`.
+- **Pattern** (`--pattern`): The abstract principle. "Use stateless infrastructure for horizontal scaling" — not "Used Redis".
+
+Think at two levels: what you *did* (operational) and what *principle* it represents (conceptual).
 
 ## Reason Types
 

--- a/website/reference/api.md
+++ b/website/reference/api.md
@@ -450,7 +450,127 @@ Retrieve full decision record including bridge definition and deliberation trace
 
 ---
 
-### `cstp.getReasonStats` — Reason Analytics
+### `cstp.updateDecision` - Update Existing Decision
+
+Update fields on an existing decision. Use after recording to finalize with actual outcomes.
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | ✅ | Decision ID |
+| `updates` | object | ✅ | Fields to update |
+
+**Allowed update fields:** `decision`, `confidence`, `context`, `tags`, `pattern`, `reasons`, `bridge`
+
+> **Note:** `deliberation` is intentionally excluded - it's append-only via `recordThought`.
+
+**Example request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "cstp.updateDecision",
+  "params": {
+    "id": "dec_abc123",
+    "updates": {
+      "decision": "Used Redis with connection pooling",
+      "confidence": 0.90,
+      "context": "Deployed successfully. Latency improved 5x.",
+      "tags": ["caching", "redis", "infrastructure"]
+    }
+  },
+  "id": 1
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "success": true,
+    "id": "dec_abc123",
+    "applied": ["decision", "confidence", "context", "tags"],
+    "indexed": true
+  },
+  "id": 1
+}
+```
+
+---
+
+### `cstp.recordThought` - Capture Reasoning Steps
+
+Record chain-of-thought reasoning. Pre-decision mode accumulates in the tracker; post-decision mode appends to an existing decision's trace.
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `text` | string | ✅ | Reasoning text |
+| `decision_id` | string | ❌ | If set, appends to existing decision (post-decision mode) |
+
+**Pre-decision example (no decision_id):**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "cstp.recordThought",
+  "params": {
+    "text": "Considering Redis vs Memcached - Redis has persistence"
+  },
+  "id": 1
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "success": true,
+    "mode": "pre-decision",
+    "agent_id": "emerson"
+  },
+  "id": 1
+}
+```
+
+**Post-decision example (with decision_id):**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "cstp.recordThought",
+  "params": {
+    "text": "Redis chosen - persistence and pub/sub clinched it",
+    "decision_id": "dec_abc123"
+  },
+  "id": 1
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "success": true,
+    "mode": "post-decision",
+    "decision_id": "dec_abc123",
+    "step_number": 4
+  },
+  "id": 1
+}
+```
+
+---
+
+### `cstp.getReasonStats` - Reason Analytics
 
 Analyze success rates and diversity of decision reasons.
 

--- a/website/reference/cli.md
+++ b/website/reference/cli.md
@@ -104,16 +104,16 @@ python scripts/cstp.py check -d "deploy to prod" -s high -f 0.9
 
 ### `cstp.py record`
 
-Record a decision.
+Record a decision. Record early to capture deliberation inputs.
 
 ```bash
 python scripts/cstp.py record \
-  -d "Use PostgreSQL" \
+  -d "Plan: Use PostgreSQL for persistence" \
   -c architecture \
   -s high \
   -f 0.85 \
-  --structure "PostgreSQL" \
-  --function "Relational persistence"
+  --tag database --tag infrastructure \
+  --pattern "Choose ACID-compliant stores for transactional data"
 ```
 
 **Options:**
@@ -125,12 +125,57 @@ python scripts/cstp.py record \
 | `-s`, `--stakes` | Stakes: low, medium, high, critical |
 | `-f`, `--confidence` | Confidence (0.0-1.0) |
 | `--context` | Context description |
-| `-r`, `--reason` | Add reason (type:text) |
+| `-r`, `--reason` | Add reason (type:text, repeatable) |
+| `--tag`, `-t` | Reusable keyword tag (repeatable) |
+| `--pattern` | Abstract pattern this decision represents |
+| `--project` | Project (owner/repo) |
+| `--pr` | PR number |
 | `--structure` | Bridge: structure/pattern |
 | `--function` | Bridge: function/purpose |
 | `--tolerance` | Bridge: features that don't matter |
 | `--enforcement` | Bridge: features that must be present |
 | `--prevention` | Bridge: features that must be absent |
+
+### `cstp.py think`
+
+Record a chain-of-thought reasoning step. Pre-decision mode (no `--id`) accumulates in the tracker; post-decision mode (`--id`) appends to an existing decision's trace.
+
+```bash
+# Pre-decision: captured automatically when you record
+python scripts/cstp.py think "Considering Redis vs Memcached for caching"
+
+# Post-decision: appends to existing decision trace
+python scripts/cstp.py think --id <ID> "Redis chosen because it supports persistence"
+```
+
+### `cstp.py update`
+
+Update an existing decision's fields. Use after recording to finalize with actual outcomes.
+
+```bash
+python scripts/cstp.py update <ID> \
+  -d "Used PostgreSQL with connection pooling" \
+  --context "Deployed with PgBouncer. 3 replicas." \
+  --tag database --tag infrastructure --tag pgbouncer
+```
+
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `-d`, `--decision` | Updated decision text |
+| `-f`, `--confidence` | Updated confidence (0.0-1.0) |
+| `--context` | Updated context |
+| `--tag`, `-t` | Tags (repeatable, replaces existing) |
+| `--pattern` | Abstract pattern |
+
+### `cstp.py pre`
+
+Pre-decision helper: runs query + guardrail check in one call. Use before recording.
+
+```bash
+python scripts/cstp.py pre "deploy retry logic to production" -s high -f 0.85
+```
 
 ### `cstp.py get`
 

--- a/website/reference/mcp-quickstart.md
+++ b/website/reference/mcp-quickstart.md
@@ -129,7 +129,7 @@ Or configure stdio transport to launch the MCP server process directly.
 
 ### Generic MCP Client
 
-Any client implementing the [MCP specification](https://modelcontextprotocol.io/) can connect via either transport. The server advertises itself as `cstp-decisions` and exposes 7 tools via the standard `tools/list` method.
+Any client implementing the [MCP specification](https://modelcontextprotocol.io/) can connect via either transport. The server advertises itself as `cstp-decisions` and exposes 9 tools via the standard `tools/list` method.
 
 ---
 
@@ -383,3 +383,7 @@ python -m uvicorn a2a.server:app --host 0.0.0.0 --port 9991
 | `log_decision` | `cstp.recordDecision` | `a2a/cstp/decision_service.py` |
 | `review_outcome` | `cstp.reviewDecision` | `a2a/cstp/decision_service.py` |
 | `get_stats` | `cstp.getCalibration` | `a2a/cstp/calibration_service.py` |
+| `get_decision` | `cstp.getDecision` | `a2a/cstp/decision_service.py` |
+| `get_reason_stats` | `cstp.getReasonStats` | `a2a/cstp/reason_stats_service.py` |
+| `update_decision` | `cstp.updateDecision` | `a2a/cstp/decision_service.py` |
+| `record_thought` | `cstp.recordThought` | `a2a/cstp/deliberation_tracker.py` |


### PR DESCRIPTION
Updates 4 website pages to reflect the record-at-start workflow and new tools shipped today.

**Decision Protocol** (rewritten):
- 3 steps -> 5 steps: query, check, record, think, update
- Added "Why Record Early?" section explaining deliberation tracker behavior
- Added Tags and Patterns guidance

**CLI Reference:**
- Added `think`, `update`, `pre` commands
- Added `--tag`, `--pattern`, `--project`, `--pr` flags to `record`

**API Reference:**
- Added `cstp.updateDecision` with full request/response examples
- Added `cstp.recordThought` with pre/post-decision mode examples

**MCP Quickstart:**
- 7 -> 9 tools
- Added `update_decision` + `record_thought` to tool-to-method mapping table