### PR TITLE
feat: research-driven feature specs (F029-F032)

### DIFF
--- a/docs/features/F029-task-router.md
+++ b/docs/features/F029-task-router.md
@@ -1,0 +1,85 @@
+# F029: Task Router - Centralized Orchestration Intelligence
+
+## Source
+MIT Media Lab / Google Research: "Towards a Science of Scaling Agent Systems" (Feb 4, 2026)
+
+## Key Research Findings
+- Adding more agents often **degrades** performance
+- Centralized orchestration improves parallel task performance by **81%**
+- Independent multi-agent systems amplify errors by **17.2x** vs **4.4x** for centralized
+- "Tool density" and "decomposability" predict optimal architecture with **87% accuracy**
+
+## Overview
+A task classification and routing service that analyzes incoming tasks and recommends the optimal agent architecture (single agent, centralized swarm, or sequential pipeline). Uses task decomposability and tool density metrics to route decisions.
+
+## API
+
+### New RPC Method: `cstp.classifyTask`
+
+```json
+{
+  "method": "cstp.classifyTask",
+  "params": {
+    "task": "Review PR #42 and update documentation",
+    "tools": ["github", "git", "file_read", "file_write"],
+    "constraints": {
+      "maxAgents": 3,
+      "timeoutSeconds": 300
+    }
+  }
+}
+```
+
+### Response
+
+```json
+{
+  "result": {
+    "architecture": "centralized_parallel",
+    "confidence": 0.87,
+    "reasoning": "Task is decomposable into 2 independent subtasks (code review, doc update) with shared tool dependencies (github, git). Centralized orchestration recommended to contain error amplification.",
+    "subtasks": [
+      {"id": 1, "description": "Code review", "tools": ["github", "git", "file_read"], "type": "parallel"},
+      {"id": 2, "description": "Documentation update", "tools": ["github", "file_write"], "type": "parallel"}
+    ],
+    "metrics": {
+      "toolDensity": 0.67,
+      "decomposability": 0.85,
+      "predictedErrorRate": "4.4x"
+    },
+    "alternatives": [
+      {"architecture": "single_agent", "confidence": 0.72, "tradeoff": "Simpler but 39% slower for parallel subtasks"},
+      {"architecture": "peer_mesh", "confidence": 0.31, "tradeoff": "17.2x error amplification risk"}
+    ]
+  }
+}
+```
+
+## Architecture Types
+
+| Type | When | Error Rate | Best For |
+|------|------|-----------|----------|
+| `single_agent` | Low decomposability, few tools | Baseline | Simple, sequential tasks |
+| `centralized_parallel` | High decomposability, shared tools | 4.4x | PR review + docs, research + writing |
+| `sequential_pipeline` | Ordered dependencies | 2-3x | Build → test → deploy |
+| `peer_mesh` | ⚠️ Rarely recommended | 17.2x | Only when tasks are fully independent |
+
+## Implementation Notes
+
+- Decomposability score: Analyze task description for independent subtask markers ("and", "then", "also")
+- Tool density: `shared_tools / total_tools` across subtasks
+- Store classification decisions in CSTP for calibration
+- Learn from outcomes: Which architectures actually succeeded?
+
+## Integration with OpenClaw
+- `sessions_spawn` could use this to decide single vs multi sub-agent
+- Heartbeat could classify queued tasks before execution
+- Dashboard: Show architecture recommendations with confidence
+
+## Acceptance Criteria
+- [ ] `cstp.classifyTask` RPC method implemented
+- [ ] MCP tool `classifyTask` exposed
+- [ ] Tool density and decomposability metrics calculated
+- [ ] Architecture recommendation with confidence score
+- [ ] Historical outcome tracking (which recommendations worked)
+- [ ] Dashboard view showing task classifications

--- a/docs/features/F030-circuit-breaker-guardrails.md
+++ b/docs/features/F030-circuit-breaker-guardrails.md
@@ -1,0 +1,121 @@
+# F030: Circuit Breaker Guardrails
+
+## Source
+- AutoGPT.net: "How AI Agents Navigate Financial Transactions Autonomously" (Feb 11, 2026)
+- ai16z/elizaOS: Trust-scored autonomous trading with kill switches
+- Existing CSTP guardrails (block/warn/allow)
+
+## Overview
+Evolve guardrails from static rules into dynamic circuit breakers that trip based on real-time failure patterns, automatically escalate, and require explicit reset. Inspired by distributed systems circuit breaker patterns (Hystrix, Resilience4j) applied to agent decision-making.
+
+## Current State
+Guardrails today are stateless: each check is independent. A guardrail doesn't know that the last 5 decisions in this category all failed. It can't detect cascading failures or escalate.
+
+## Circuit Breaker States
+
+```
+CLOSED (normal) → failures exceed threshold → OPEN (blocked)
+    ↑                                            |
+    └── manual reset or cooldown ← HALF_OPEN (probe) ←┘
+```
+
+| State | Behavior |
+|-------|----------|
+| `CLOSED` | Normal operation. Decisions flow through. Failures tracked. |
+| `OPEN` | All decisions in scope blocked. Agent notified. Human alert sent. |
+| `HALF_OPEN` | Single probe decision allowed. Success → CLOSED. Failure → OPEN. |
+
+## API
+
+### New RPC Method: `cstp.getCircuitState`
+
+```json
+{
+  "method": "cstp.getCircuitState",
+  "params": {
+    "scope": "category:tooling"
+  }
+}
+```
+
+### Response
+
+```json
+{
+  "result": {
+    "scope": "category:tooling",
+    "state": "closed",
+    "failureCount": 2,
+    "failureThreshold": 5,
+    "lastFailure": "2026-02-11T12:00:00Z",
+    "windowMs": 3600000,
+    "cooldownMs": 1800000
+  }
+}
+```
+
+### Enhanced `cstp.checkGuardrails` Response
+
+```json
+{
+  "result": {
+    "allowed": false,
+    "violations": [{
+      "guardrail": "category-tooling-breaker",
+      "type": "circuit_breaker",
+      "state": "open",
+      "message": "Circuit breaker OPEN: 5/5 recent tooling decisions failed. Cooldown: 22m remaining.",
+      "failureRate": 1.0,
+      "recentFailures": ["dec_abc", "dec_def", "dec_ghi"],
+      "action": "block",
+      "resetAt": "2026-02-11T13:30:00Z"
+    }]
+  }
+}
+```
+
+## Configuration
+
+```yaml
+circuit_breakers:
+  - scope: "category:tooling"
+    failure_threshold: 5
+    window_ms: 3600000        # 1 hour window
+    cooldown_ms: 1800000      # 30 min cooldown before half-open
+    notify: true               # Alert human when tripped
+    
+  - scope: "stakes:high"
+    failure_threshold: 3       # Lower threshold for high-stakes
+    window_ms: 86400000        # 24 hour window
+    cooldown_ms: 3600000       # 1 hour cooldown
+    notify: true
+    
+  - scope: "agent:code-reviewer"
+    failure_threshold: 4
+    window_ms: 7200000
+    cooldown_ms: 900000
+```
+
+## Scopes
+- `category:<name>` - per decision category
+- `stakes:<level>` - per stakes level
+- `agent:<id>` - per agent identity
+- `tag:<name>` - per decision tag
+- `global` - all decisions
+
+## Integration with Existing Guardrails
+- Circuit breakers are a new guardrail **type** alongside `block`/`warn`/`allow`
+- `cstp.checkGuardrails` automatically checks circuit breaker state
+- Failed decisions (via `cstp.reviewDecision` with `outcome: failure`) increment failure counters
+- Successful outcomes decrement or reset counters
+
+## Acceptance Criteria
+- [ ] Circuit breaker state machine (closed/open/half-open)
+- [ ] Configurable per scope (category, stakes, agent, tag)
+- [ ] Automatic tripping on failure threshold
+- [ ] Cooldown period with half-open probe
+- [ ] Integration with `cstp.checkGuardrails`
+- [ ] Notification on state change (open/closed)
+- [ ] Dashboard view showing breaker states
+- [ ] `cstp.resetCircuit` RPC for manual reset
+- [ ] MCP tool exposure

--- a/docs/features/F031-source-trust-scoring.md
+++ b/docs/features/F031-source-trust-scoring.md
@@ -1,0 +1,126 @@
+# F031: Source Trust Scoring
+
+## Source
+- ai16z/elizaOS: "Trust Scores" to filter social signals for autonomous trading
+- Minsky Ch 18: Parallel bundles - weight evidence by source reliability
+- CSTP calibration: We already track decision accuracy, extend to source tracking
+
+## Overview
+Assign and maintain trust scores for information sources referenced in decisions. When querying past decisions, weight results by the reliability of their sources. Enables agents to distinguish high-signal from low-signal information and make better-calibrated decisions.
+
+## Problem
+Today, all decisions are treated equally in retrieval regardless of where their information came from. A decision based on peer-reviewed research and one based on a random tweet have the same weight. We need source provenance.
+
+## API
+
+### Recording Source Attribution
+
+Enhanced `cstp.recordDecision`:
+
+```json
+{
+  "method": "cstp.recordDecision",
+  "params": {
+    "decision": "Adopted HSM architecture for long-context processing",
+    "confidence": 0.85,
+    "category": "architecture",
+    "stakes": "high",
+    "sources": [
+      {"id": "arxiv:2602.01234", "type": "paper", "name": "Hierarchical Shift Mixing", "url": "https://arxiv.org/abs/2602.01234"},
+      {"id": "mit-media-lab", "type": "institution", "name": "MIT Media Lab"},
+      {"id": "moltbook:user123", "type": "social", "name": "happy_milvus"}
+    ]
+  }
+}
+```
+
+### New RPC Method: `cstp.getSourceTrust`
+
+```json
+{
+  "method": "cstp.getSourceTrust",
+  "params": {
+    "sourceId": "moltbook:user123"
+  }
+}
+```
+
+### Response
+
+```json
+{
+  "result": {
+    "sourceId": "moltbook:user123",
+    "type": "social",
+    "name": "happy_milvus",
+    "trustScore": 0.72,
+    "decisionsReferenced": 8,
+    "successRate": 0.75,
+    "lastReferenced": "2026-02-10T15:00:00Z",
+    "breakdown": {
+      "accuracy": 0.75,
+      "recency": 0.80,
+      "consistency": 0.65
+    }
+  }
+}
+```
+
+### Enhanced Query Results
+
+`cstp.queryDecisions` response includes source trust:
+
+```json
+{
+  "result": {
+    "decisions": [{
+      "id": "dec_abc",
+      "decision": "...",
+      "sourceWeightedScore": 0.91,
+      "sources": [
+        {"id": "arxiv:2602.01234", "trustScore": 0.95},
+        {"id": "moltbook:user123", "trustScore": 0.72}
+      ]
+    }]
+  }
+}
+```
+
+## Trust Score Computation
+
+```
+trustScore = w1 * accuracy + w2 * recency + w3 * consistency
+
+accuracy   = successful_outcomes / total_outcomes (from decisions referencing this source)
+recency    = decay_factor(days_since_last_reference)
+consistency = 1 - stddev(outcome_scores)
+```
+
+Default weights: `w1=0.5, w2=0.2, w3=0.3`
+
+## Source Types
+
+| Type | Example | Initial Trust | Notes |
+|------|---------|--------------|-------|
+| `paper` | arXiv, journals | 0.80 | High baseline, peer-reviewed |
+| `institution` | MIT, Google Research | 0.75 | Track record weighted |
+| `documentation` | Official docs, RFCs | 0.85 | Authoritative |
+| `social` | Moltbook, Twitter | 0.50 | Starts neutral, earned |
+| `agent` | Minski, CodeReviewer | 0.70 | Track by agent ID |
+| `empirical` | Own experiments | 0.90 | Direct evidence |
+
+## Use Cases
+- **Moltbook engagement:** Weight posts by author trust score before engaging
+- **Research briefings:** Flag stories from low-trust sources
+- **Decision retrieval:** Surface high-trust decisions first
+- **Agent collaboration:** Track which sub-agents give reliable reviews
+
+## Acceptance Criteria
+- [ ] `sources` field on `cstp.recordDecision`
+- [ ] `cstp.getSourceTrust` RPC method
+- [ ] `cstp.listSources` RPC method (with filters)
+- [ ] Trust score computation from decision outcomes
+- [ ] Source-weighted query results in `cstp.queryDecisions`
+- [ ] MCP tools exposed
+- [ ] Dashboard: Source trust leaderboard
+- [ ] Automatic trust decay for stale sources

--- a/docs/features/F032-error-amplification-tracking.md
+++ b/docs/features/F032-error-amplification-tracking.md
@@ -1,0 +1,138 @@
+# F032: Error Amplification Tracking
+
+## Source
+MIT Media Lab / Google Research: "Towards a Science of Scaling Agent Systems" (Feb 4, 2026)
+- Independent multi-agent: **17.2x** error amplification
+- Centralized multi-agent: **4.4x** error amplification
+- Single agent: **1x** baseline
+
+## Overview
+Track error propagation chains across multi-agent decision sequences. When a sub-agent's decision leads to a downstream failure, trace the causal chain back to identify amplification patterns. Enables the system to detect when agent collaboration is making things worse, not better.
+
+## Problem
+Today we track individual decision outcomes but not causal chains. If CodeReviewer approves a PR, DocsAgent updates docs based on it, and the feature turns out broken - we mark each decision independently. We can't see that the review failure **amplified** into a docs failure.
+
+## API
+
+### Decision Lineage
+
+Enhanced `cstp.recordDecision`:
+
+```json
+{
+  "method": "cstp.recordDecision",
+  "params": {
+    "decision": "Updated docs based on PR #42 review",
+    "confidence": 0.85,
+    "parentDecisionId": "dec_abc",
+    "agentId": "docs-agent",
+    "context": "CodeReviewer approved PR #42 (dec_abc). Updating docs accordingly."
+  }
+}
+```
+
+### New RPC Method: `cstp.getAmplificationChain`
+
+```json
+{
+  "method": "cstp.getAmplificationChain",
+  "params": {
+    "decisionId": "dec_abc"
+  }
+}
+```
+
+### Response
+
+```json
+{
+  "result": {
+    "root": {
+      "id": "dec_abc",
+      "agent": "code-reviewer",
+      "decision": "Approved PR #42",
+      "outcome": "failure"
+    },
+    "chain": [
+      {
+        "id": "dec_def",
+        "agent": "docs-agent",
+        "decision": "Updated docs for PR #42",
+        "outcome": "failure",
+        "amplification": "inherited"
+      },
+      {
+        "id": "dec_ghi",
+        "agent": "main",
+        "decision": "Merged PR #42",
+        "outcome": "failure",
+        "amplification": "cascaded"
+      }
+    ],
+    "metrics": {
+      "chainLength": 3,
+      "amplificationFactor": 3.0,
+      "affectedAgents": ["code-reviewer", "docs-agent", "main"],
+      "architecture": "sequential_pipeline"
+    }
+  }
+}
+```
+
+### New RPC Method: `cstp.getAmplificationStats`
+
+```json
+{
+  "method": "cstp.getAmplificationStats",
+  "params": {
+    "windowDays": 30
+  }
+}
+```
+
+### Response
+
+```json
+{
+  "result": {
+    "averageAmplification": 2.3,
+    "maxChainLength": 5,
+    "totalChains": 12,
+    "byArchitecture": {
+      "single_agent": {"count": 45, "avgAmplification": 1.0},
+      "sequential_pipeline": {"count": 8, "avgAmplification": 2.8},
+      "centralized_parallel": {"count": 4, "avgAmplification": 1.6}
+    },
+    "topAmplifiers": [
+      {"agent": "code-reviewer", "rootFailures": 3, "totalDownstream": 7}
+    ],
+    "recommendation": "CodeReviewer decisions are the most common root of amplification chains. Consider adding a second reviewer for high-stakes PRs."
+  }
+}
+```
+
+## Data Model
+
+```yaml
+# Added to decision records
+parent_decision_id: "dec_abc"   # Decision this depends on
+agent_id: "docs-agent"          # Which agent made this
+chain_id: "chain_001"           # Group linked decisions
+```
+
+## Integration
+- When `cstp.reviewDecision` marks a decision as failed, scan for child decisions
+- Automatically propagate "inherited failure" markers down the chain
+- Circuit breakers (F030) can trip based on amplification factor, not just failure count
+- Task router (F029) can use historical amplification data to avoid bad architectures
+
+## Acceptance Criteria
+- [ ] `parentDecisionId` field on `cstp.recordDecision`
+- [ ] `agentId` field on `cstp.recordDecision`
+- [ ] Chain detection on failure review
+- [ ] `cstp.getAmplificationChain` RPC method
+- [ ] `cstp.getAmplificationStats` RPC method
+- [ ] Amplification factor calculation
+- [ ] Dashboard: Chain visualization (Mermaid)
+- [ ] MCP tools exposed
+- [ ] Integration with circuit breakers (F030)


### PR DESCRIPTION
## Source

Multi-Agent Research Briefing - Feb 11, 2026

## Features

### F029 - Task Router
Classify tasks by decomposability + tool density → recommend agent architecture.
- MIT/Google: centralized orchestration = +81% for parallel tasks, 4.4x vs 17.2x error rate
- New RPC: `cstp.classifyTask`
- Outputs: architecture recommendation, subtask breakdown, confidence

### F030 - Circuit Breaker Guardrails
Stateful guardrails with closed/open/half-open states.
- Trip on failure patterns, auto-escalate, require explicit reset
- Scoped per category, stakes, agent, or tag
- Integrates with existing `cstp.checkGuardrails`

### F031 - Source Trust Scoring
Track reliability of information sources across decisions.
- Score based on accuracy, recency, consistency
- Weight query results by source trust
- Source types: paper, institution, social, agent, empirical

### F032 - Error Amplification Tracking
Causal chains across multi-agent decision sequences.
- Detect when collaboration amplifies rather than contains errors
- Per-architecture amplification stats
- Integrates with F030 circuit breakers