### PR TITLE
docs: F046 Pre-Action Hook + F047 Session Context (Agentic Loop)

### DIFF
--- a/docs/features/F046-pre-action-hook.md
+++ b/docs/features/F046-pre-action-hook.md
@@ -1,0 +1,173 @@
+# F046: Pre-Action Hook API
+
+**Status:** Proposed
+**Priority:** High
+**Category:** Agentic Loop Integration
+
+## Problem
+
+Integrating CSTP into an agent's decision loop currently requires 3 separate API calls before acting:
+1. `queryDecisions` - find relevant past decisions
+2. `checkGuardrails` - validate the action is allowed
+3. `recordDecision` - commit intent before executing
+
+This 3-call overhead discourages adoption. Agents skip steps under time pressure. Our own experience confirms this - the single biggest process failure is skipping the pre-decision query (documented in 4+ violations).
+
+## Solution
+
+A single `cstp.preAction` endpoint that combines query + guardrails + optional record in one round-trip. Designed to be called at the decision point in any agentic loop.
+
+### API
+
+```json
+{
+  "method": "cstp.preAction",
+  "params": {
+    "agent_id": "claude-code",
+    "action": {
+      "description": "Refactor auth module to use JWT instead of sessions",
+      "category": "architecture",
+      "stakes": "high",
+      "confidence": 0.80
+    },
+    "options": {
+      "query_limit": 5,
+      "auto_record": true,
+      "include_patterns": true
+    }
+  }
+}
+```
+
+### Response
+
+```json
+{
+  "result": {
+    "allowed": true,
+    "decision_id": "dec-a3f8b2c1",
+
+    "relevant_decisions": [
+      {
+        "id": "dec-7e2f",
+        "decision": "Chose JWT for API auth in microservice layer",
+        "outcome": "success",
+        "date": "2026-01-15",
+        "pattern": "Stateless auth scales better than session-based",
+        "confidence": 0.90,
+        "similarity": 0.87
+      }
+    ],
+
+    "guardrail_results": [
+      {
+        "name": "no-high-stakes-low-confidence",
+        "status": "pass",
+        "message": null
+      },
+      {
+        "name": "no-production-without-review",
+        "status": "warn",
+        "message": "High-stakes change - ensure code review before merge"
+      }
+    ],
+
+    "calibration_context": {
+      "category_accuracy": 0.91,
+      "category_brier": 0.03,
+      "confidence_tendency": "slightly_underconfident",
+      "suggestion": "Your architecture decisions succeed 91% of the time - confidence of 0.80 may be low"
+    },
+
+    "patterns_summary": [
+      "Stateless auth scales better than session-based (3 confirmations)",
+      "Migration decisions need rollback plan (2 confirmations)"
+    ]
+  }
+}
+```
+
+### Behavior
+
+1. **Query:** Semantic search for similar past decisions (hybrid mode)
+2. **Guardrails:** Run all active guardrails against the proposed action
+3. **Calibration:** Fetch agent's calibration profile for this category
+4. **Patterns:** Extract relevant confirmed patterns from matching decisions
+5. **Record (optional):** If `auto_record: true` and guardrails pass, record the decision immediately and return `decision_id`
+6. **Block:** If any guardrail blocks, return `allowed: false` with reasons. Decision is NOT recorded.
+
+### Blocked Response
+
+```json
+{
+  "result": {
+    "allowed": false,
+    "decision_id": null,
+    "block_reasons": [
+      {
+        "guardrail": "no-high-stakes-low-confidence",
+        "message": "Stakes=high but confidence=0.35. Increase confidence or lower stakes.",
+        "suggestion": "Research more before proceeding, or break into smaller decisions"
+      }
+    ],
+    "relevant_decisions": [...],
+    "calibration_context": {...}
+  }
+}
+```
+
+### MCP Tool Definition
+
+```json
+{
+  "name": "pre_action",
+  "description": "Check if an action is safe and informed before executing. Returns relevant past decisions, guardrail results, calibration context, and optionally records the decision. Call this BEFORE making any significant choice.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "description": { "type": "string", "description": "What you plan to do" },
+      "category": { "type": "string", "enum": ["architecture", "process", "integration", "tooling", "security"] },
+      "stakes": { "type": "string", "enum": ["low", "medium", "high", "critical"] },
+      "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+      "reasons": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "type": { "type": "string" },
+            "text": { "type": "string" }
+          }
+        }
+      },
+      "tags": { "type": "array", "items": { "type": "string" } },
+      "pattern": { "type": "string", "description": "Abstract pattern this decision represents" },
+      "auto_record": { "type": "boolean", "default": true }
+    },
+    "required": ["description", "category", "stakes", "confidence"]
+  }
+}
+```
+
+## Design Principles
+
+- **One call, full context.** Reduce friction to zero - if the agent only makes one CSTP call, this is the one.
+- **Opinionated defaults.** `auto_record: true`, `query_limit: 5`, `include_patterns: true`. Works out of the box.
+- **Fail open or fail closed.** Configurable per deployment. Default: warn on guardrail violations but allow (fail open). Production: block on violations (fail closed).
+- **Idempotent query, non-idempotent record.** If `auto_record: false`, the call is pure query (safe to retry). If `auto_record: true`, it creates a decision (call once).
+
+## Phases
+
+1. **P1:** Core endpoint combining query + guardrails + record
+2. **P2:** Calibration context injection + pattern extraction
+3. **P3:** MCP tool exposure + Claude Desktop/Code integration
+4. **P4:** Configurable fail-open/fail-closed modes
+
+## Integration Points
+
+- F002 (Query): Reuses hybrid query internally
+- F003 (Guardrails): Reuses guardrail evaluation
+- F007 (Record): Reuses decision recording
+- F009 (Calibration): Category-specific calibration context
+- F027 (Quality): Auto-enforces tags + pattern requirement
+- F045 (Graph): Future - include graph-neighbor decisions in results
+- F047 (Session Context): preAction is the per-decision call; F047 is the per-session call

--- a/docs/features/F047-session-context.md
+++ b/docs/features/F047-session-context.md
@@ -1,0 +1,191 @@
+# F047: Session Context Endpoint
+
+**Status:** Proposed
+**Priority:** High
+**Category:** Agentic Loop Integration
+
+## Problem
+
+Agents starting a new session have no cognitive context. They don't know:
+- What decisions were made previously in this domain
+- What their calibration profile looks like (am I overconfident? in which areas?)
+- What guardrails are active
+- What cognitive maintenance is overdue (unreviewed decisions, calibration drift)
+
+Loading this context requires multiple API calls and manual system prompt construction. Most frameworks don't bother - agents start cold every time.
+
+## Solution
+
+A single `cstp.getSessionContext` endpoint that returns everything an agent needs to be cognitively aware at session start. Designed for injection into system prompts or agent initialization.
+
+### API
+
+```json
+{
+  "method": "cstp.getSessionContext",
+  "params": {
+    "agent_id": "claude-code",
+    "task_description": "Build authentication service for user API",
+    "include": ["decisions", "guardrails", "calibration", "ready", "patterns", "contradictions"],
+    "decisions_limit": 10,
+    "ready_limit": 5,
+    "format": "markdown"
+  }
+}
+```
+
+### Response (format: "json")
+
+```json
+{
+  "result": {
+    "agent_profile": {
+      "agent_id": "claude-code",
+      "total_decisions": 47,
+      "reviewed": 32,
+      "overall_accuracy": 0.94,
+      "brier_score": 0.028,
+      "tendency": "slightly_underconfident",
+      "strongest_category": "tooling",
+      "weakest_category": "security",
+      "active_since": "2026-01-15"
+    },
+
+    "relevant_decisions": [
+      {
+        "id": "dec-7e2f",
+        "decision": "Chose JWT for API auth",
+        "outcome": "success",
+        "date": "2026-01-15",
+        "pattern": "Stateless auth scales better",
+        "tags": ["auth", "jwt", "architecture"]
+      }
+    ],
+
+    "active_guardrails": [
+      {
+        "name": "no-high-stakes-low-confidence",
+        "description": "Block if stakes=high and confidence < 0.5",
+        "action": "block"
+      },
+      {
+        "name": "no-production-without-review",
+        "description": "Require code review for production changes",
+        "action": "warn"
+      }
+    ],
+
+    "calibration_by_category": {
+      "architecture": { "accuracy": 0.93, "brier": 0.03, "decisions": 18, "tendency": "well_calibrated" },
+      "security": { "accuracy": 0.80, "brier": 0.08, "decisions": 5, "tendency": "overconfident" }
+    },
+
+    "ready_queue": [
+      {
+        "type": "review_outcome",
+        "priority": "high",
+        "decision_id": "dec-b1c2",
+        "reason": "Architecture decision from 12 days ago, no outcome recorded"
+      }
+    ],
+
+    "confirmed_patterns": [
+      { "pattern": "Stateless auth scales better than session-based", "confirmations": 3, "category": "architecture" },
+      { "pattern": "Always validate input at API boundary", "confirmations": 5, "category": "security" }
+    ],
+
+    "active_contradictions": []
+  }
+}
+```
+
+### Response (format: "markdown")
+
+When `format: "markdown"`, returns a pre-formatted block ready for system prompt injection:
+
+```json
+{
+  "result": {
+    "markdown": "## CSTP Decision Context\n\n### Your Profile\n- 47 decisions logged, 94% accuracy, Brier 0.028\n- ⚠️ Tendency: slightly underconfident (raise confidence in architecture)\n- ⚠️ Weak area: security (80% accuracy, 5 decisions)\n\n### Relevant Past Decisions\n| Decision | Outcome | Date | Pattern |\n|----------|---------|------|---------|\n| Chose JWT for API auth | ✅ success | 2026-01-15 | Stateless auth scales better |\n...\n\n### Active Guardrails\n- 🚫 no-high-stakes-low-confidence: Block if stakes=high, confidence < 0.5\n- ⚠️ no-production-without-review: Warn on production changes without review\n\n### Pending Tasks\n- ❗ Review outcome for dec-b1c2 (architecture, 12 days overdue)\n\n### Confirmed Patterns\n- Stateless auth scales better (3x confirmed)\n- Always validate input at API boundary (5x confirmed)\n\n### Decision Protocol\nUse `pre_action` tool before any significant decision.\nInclude: confidence, category, stakes, 2+ reasons, tags, pattern."
+  }
+}
+```
+
+### Use Cases
+
+**1. Claude Code CLI - system prompt injection:**
+```markdown
+# In CLAUDE.md (auto-generated or templated)
+{{cstp_session_context}}
+```
+
+A build script or pre-hook calls `getSessionContext` and injects the markdown into CLAUDE.md before the session starts.
+
+**2. OpenClaw - agent initialization:**
+```python
+# In agent startup
+context = await cstp.get_session_context(
+    agent_id="emerson",
+    task_description=current_task,
+    format="markdown"
+)
+system_prompt += context["markdown"]
+```
+
+**3. LangChain / CrewAI / AutoGen:**
+```python
+# As a tool or system message
+context = cstp_client.get_session_context(agent_id="agent-1", task="...")
+agent = Agent(system_message=base_prompt + context.markdown)
+```
+
+**4. Periodic refresh (long sessions):**
+Call `getSessionContext` every N turns to refresh decisions and ready queue as the session evolves.
+
+### MCP Tool Definition
+
+```json
+{
+  "name": "get_session_context",
+  "description": "Get full cognitive context for this session: relevant past decisions, calibration profile, active guardrails, pending tasks, and confirmed patterns. Call at session start or when switching tasks.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "task_description": { "type": "string", "description": "What you're working on this session" },
+      "include": {
+        "type": "array",
+        "items": { "type": "string", "enum": ["decisions", "guardrails", "calibration", "ready", "patterns", "contradictions"] },
+        "default": ["decisions", "guardrails", "calibration", "ready", "patterns"]
+      },
+      "decisions_limit": { "type": "integer", "default": 10 },
+      "ready_limit": { "type": "integer", "default": 5 },
+      "format": { "type": "string", "enum": ["json", "markdown"], "default": "markdown" }
+    },
+    "required": ["task_description"]
+  }
+}
+```
+
+## Design Principles
+
+- **Session-level, not decision-level.** F046 (preAction) is called per decision. F047 is called once at session start (or on task switch).
+- **Markdown-first.** Most agent frameworks inject context as text. The markdown format is ready to paste into any system prompt.
+- **Progressive disclosure.** The `include` array lets lightweight agents request only what they need. Full context for complex agents, just guardrails for simple ones.
+- **Framework-agnostic.** JSON-RPC + MCP. Works with Claude Code, OpenClaw, LangChain, CrewAI, raw curl.
+
+## Phases
+
+1. **P1:** Core endpoint - decisions + guardrails + calibration
+2. **P2:** Ready queue + patterns + contradictions
+3. **P3:** Markdown formatting + MCP tool
+4. **P4:** Auto-refresh middleware for long sessions
+
+## Integration Points
+
+- F002 (Query): Task-scoped decision retrieval
+- F003 (Guardrails): Active guardrail listing
+- F009 (Calibration): Per-agent, per-category calibration
+- F027 (Quality): Confirmed patterns from quality-scored decisions
+- F044 (Work Discovery): Ready queue integration
+- F045 (Graph): Graph-neighbor decisions in context
+- F046 (Pre-Action): Session context is the complement - F047 loads context, F046 gates individual decisions

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -51,6 +51,8 @@ All feature specs live in `docs/features/`. One file per feature, consistent nam
 | F043 | Distributed Decision Merge | Beads (steveyegge/beads) | `F043-distributed-merge.md` |
 | F044 | Agent Work Discovery | Beads (steveyegge/beads) | `F044-agent-work-discovery.md` |
 | F045 | Decision Graph Storage Layer | GNN/KG Research (ICML 2025, MemoBrain, Context Graphs) | `F045-graph-storage-layer.md` |
+| F046 | Pre-Action Hook API | Agentic Loop Integration | `F046-pre-action-hook.md` |
+| F047 | Session Context Endpoint | Agentic Loop Integration | `F047-session-context.md` |
 
 ## Retired IDs
 


### PR DESCRIPTION
## Agentic Loop Integration

Two features that make CSTP a **cognitive middleware** for any agent framework:

### F046: Pre-Action Hook
Single API call at decision time: query + guardrails + record.
- Reduces 3 calls to 1 (the #1 reason agents skip the workflow)
- Returns: relevant decisions, guardrail results, calibration context, confirmed patterns
- `auto_record: true` commits intent before execution
- MCP tool: `pre_action`

### F047: Session Context
Full cognitive context for system prompt injection at session start.
- Agent profile (accuracy, Brier, tendencies)
- Relevant past decisions scoped to current task
- Active guardrails
- Calibration by category ("you are overconfident in security")
- Ready queue (overdue reviews, drift)
- Confirmed patterns
- Output: JSON or **ready-to-inject markdown**
- MCP tool: `get_session_context`

### The Loop
```
Session start → F047 (load context into system prompt)
  ↓
Decision point → F046 (gate + record + get relevant history)
  ↓
Execution → recordThought (capture reasoning)
  ↓
Completion → updateDecision (reflect on outcome)
  ↓
Next session → F047 (agent is now smarter)
```

### Framework Support
JSON-RPC + MCP. Works with: Claude Code, Claude Desktop, OpenClaw, LangChain, CrewAI, AutoGen, raw curl.

**Docs-only change.**