### PR TITLE
fix: forward format param in get_session_context MCP handler

### DIFF
--- a/a2a/mcp_schemas.py
+++ b/a2a/mcp_schemas.py
@@ -515,3 +515,7 @@ class GetSessionContextInput(BaseModel):
         le=20,
         description="Max ready queue items to return (1-20)",
     )
+    format: Literal["json", "markdown"] = Field(
+        default="markdown",
+        description="Response format: 'json' for structured data, 'markdown' for system prompt injection",
+    )

--- a/a2a/mcp_server.py
+++ b/a2a/mcp_server.py
@@ -878,6 +878,7 @@ async def _handle_get_session_context_mcp(
     params: dict[str, Any] = {
         "decisionsLimit": args.decisions_limit,
         "readyLimit": args.ready_limit,
+        "format": args.format,
     }
     if args.task_description:
         params["taskDescription"] = args.task_description


### PR DESCRIPTION
## Summary

- `GetSessionContextInput` Pydantic schema was missing the `format` field, so MCP clients couldn't request markdown output
- `_handle_get_session_context_mcp` wasn't passing `format` to `SessionContextRequest`, so responses always returned JSON

Adds `format: Literal["json", "markdown"]` (default `"markdown"`) to the schema and forwards it in the handler.

## Test plan

- [x] Full test suite passes (334/335, 1 pre-existing failure unrelated)
- [x] Verified `format` field present in Pydantic schema
- [x] Verified `format` forwarded in MCP handler params dict

🤖 Generated with [Claude Code](https://claude.com/claude-code)