### PR TITLE
docs: add F046 and F047 as shipped features in README

### DIFF
--- a/docs/features/F046-pre-action-hook.md
+++ b/docs/features/F046-pre-action-hook.md
@@ -1,6 +1,6 @@
 # F046: Pre-Action Hook API
 
-**Status:** Proposed
+**Status:** Shipped (v0.11.0)
 **Priority:** High
 **Category:** Agentic Loop Integration
 

--- a/docs/features/F047-session-context.md
+++ b/docs/features/F047-session-context.md
@@ -1,6 +1,6 @@
 # F047: Session Context Endpoint
 
-**Status:** Proposed
+**Status:** Shipped (v0.11.0)
 **Priority:** High
 **Category:** Agentic Loop Integration
 

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -28,6 +28,8 @@ All feature specs live in `docs/features/`. One file per feature, consistent nam
 | F025 | Related Decisions | v0.10.0 | *(in changelog, no standalone spec)* |
 | F027 | Decision Quality | v0.10.0 | `F027-decision-quality.md` |
 | F028 | Reasoning Capture | v0.10.0 | *(shipped as part of F023/F027)* |
+| F046 | Pre-Action Hook API | v0.11.0 | `F046-pre-action-hook.md` |
+| F047 | Session Context Endpoint | v0.11.0 | `F047-session-context.md` |
 
 ## Roadmap
 
@@ -51,8 +53,8 @@ All feature specs live in `docs/features/`. One file per feature, consistent nam
 | F043 | Distributed Decision Merge | Beads (steveyegge/beads) | `F043-distributed-merge.md` |
 | F044 | Agent Work Discovery | Beads (steveyegge/beads) | `F044-agent-work-discovery.md` |
 | F045 | Decision Graph Storage Layer | GNN/KG Research (ICML 2025, MemoBrain, Context Graphs) | `F045-graph-storage-layer.md` |
-| F046 | Pre-Action Hook API | Agentic Loop Integration | `F046-pre-action-hook.md` |
-| F047 | Session Context Endpoint | Agentic Loop Integration | `F047-session-context.md` |
+| ~~F046~~ | ~~Pre-Action Hook API~~ | ~~Agentic Loop Integration~~ | *Shipped in v0.11.0* |
+| ~~F047~~ | ~~Session Context Endpoint~~ | ~~Agentic Loop Integration~~ | *Shipped in v0.11.0* |
 | F048 | Multi-Vector-DB Support | Infrastructure | `F048-multi-vectordb.md` |
 
 ## Retired IDs


### PR DESCRIPTION
## Summary
- Add F046 (Pre-Action Hook API) and F047 (Session Context Endpoint) as shipped v0.11.0 features in README
- Add CSTP method documentation with JSON examples for `cstp.preAction` and `cstp.getSessionContext`
- Add dedicated feature sections describing F046 and F047 capabilities
- Update MCP tools count (9→11) and dispatcher method count (10→12)
- Add v0.11.0 row to shipped table and version section
- Update project structure with new service files (`preaction_service.py`, `session_context_service.py`)
- Move F046/F047 from roadmap to shipped in `docs/features/INDEX.md`
- Update feature spec statuses from "Proposed" to "Shipped (v0.11.0)"

## Test plan
- [ ] Verify all markdown renders correctly on GitHub
- [ ] Confirm JSON examples match actual API signatures
- [ ] Check feature index links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)