### PR TITLE
docs: update MCP integration with Claude Code/Desktop setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,7 +564,8 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
 
 ```bash
 # MCP endpoint (handles POST for tools and GET for events):
-http://localhost:9991/mcp
+# Default port is 8100; override with CSTP_PORT env var
+http://localhost:8100/mcp
 ```
 
 ### Stdio Transport
@@ -578,8 +579,8 @@ python -m a2a.mcp_server
 1. **Session start**: Call `get_session_context` to load cognitive context
 2. **Each decision**: Call `pre_action` before acting (query + guardrails + record in one call)
 3. **During work**: Call `record_thought` to capture reasoning
-4. **After work**: Call `update_decision` to finalize the decision with outcome
-5. **Later**: Call `review_outcome` when you know the result
+4. **After work**: Call `update_decision` to finalize the decision text and context
+5. **Later**: Call `review_outcome` to record success/failure for calibration
 
 ## Deliberation Traces (F023) & Reasoning Capture (F028)
 

--- a/website/guide/mcp-integration.md
+++ b/website/guide/mcp-integration.md
@@ -42,9 +42,9 @@ Decision point → pre_action (query + guardrails + record in one call)
        ↓
 During work → record_thought (capture reasoning)
        ↓
-After work → update_decision (finalize with outcome details)
+After work → update_decision (finalize decision text and context)
        ↓
-Later → review_outcome (log success/failure for calibration)
+Later → review_outcome (record success/failure for calibration)
 ```
 
 ## Claude Code CLI

--- a/website/reference/mcp-quickstart.md
+++ b/website/reference/mcp-quickstart.md
@@ -266,8 +266,8 @@ Full cognitive context for session start or task switch. Returns agent profile, 
 1. Session start    → get_session_context (load context into system prompt)
 2. Decision point   → pre_action (gate + record + get relevant history)
 3. During work      → record_thought (capture reasoning)
-4. After work       → update_decision (finalize with outcome details)
-5. Later            → review_outcome (log success/failure for calibration)
+4. After work       → update_decision (finalize decision text and context)
+5. Later            → review_outcome (record success/failure for calibration)
 ```
 
 ---


### PR DESCRIPTION
Updates the MCP Server section in README:

1. **Claude Code CLI config** using `mcp-remote` via npx (+ Windows variant with `cmd /c`)
2. **Claude Desktop config** with same approach
3. **Tools reorganized** into Primary (`pre_action`, `get_session_context`) and Granular (9 low-level tools)
4. **Recommended 5-step workflow** (session context → pre_action → record_thought → update → review)
5. **Port updated** to 9991 (actual deployed port)