### PR TITLE
fix: update base path for custom domain cognition-engines.ai

### DIFF
--- a/website/.vitepress/config.mjs
+++ b/website/.vitepress/config.mjs
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitepress'
 export default defineConfig({
   title: 'Cognition Engines',
   description: 'Decision Intelligence for AI Agents',
-  base: '/cognition-agent-decisions/',
+  base: '/',
   appearance: 'dark',
 
   head: [

--- a/website/public/CNAME
+++ b/website/public/CNAME
@@ -1,0 +1,1 @@
+cognition-engines.ai


### PR DESCRIPTION
Fixes 404 on CSS/assets when using custom domain.

**Root cause:** VitePress `base` was set to `/cognition-agent-decisions/` (repo name for GitHub Pages default URL). With custom domain `cognition-engines.ai`, assets are served from root.

**Changes:**
- `website/.vitepress/config.mjs`: `base: "/cognition-agent-decisions/"` → `base: "/"`
- `website/public/CNAME`: Added to persist custom domain across GitHub Pages deploys

After merge + deploy, `https://cognition-engines.ai/assets/style.BEZbAJwt.css` will resolve correctly.