### PR TITLE
docs: add all feature specs to website

### DIFF
--- a/website/.vitepress/config.mjs
+++ b/website/.vitepress/config.mjs
@@ -89,17 +89,97 @@ export default withMermaid(defineConfig({
         }
       ],
       '/specs/': [
+        { text: 'Overview', link: '/specs/' },
         {
-          text: 'Feature Specs',
+          text: 'v0.8.0 (F001–F011)',
+          collapsed: true,
           items: [
-            { text: 'Overview', link: '/specs/' },
+            { text: 'F001 - CSTP Server', link: '/specs/f001-cstp-server' },
+            { text: 'F002 - Query Decisions', link: '/specs/f002-query-decisions' },
+            { text: 'F003 - Check Guardrails', link: '/specs/f003-check-guardrails' },
+            { text: 'F004 - Announce Intent', link: '/specs/f004-announce-intent' },
+            { text: 'F005 - CSTP Client', link: '/specs/f005-cstp-client' },
+            { text: 'F006 - Docker Deployment', link: '/specs/f006-docker-deployment' },
+            { text: 'F007 - Record Decision', link: '/specs/f007-record-decision' },
+            { text: 'F008 - Review Decision', link: '/specs/f008-review-decision' },
+            { text: 'F009 - Get Calibration', link: '/specs/f009-get-calibration' },
+            { text: 'F010 - Project Context', link: '/specs/f010-project-context' },
+            { text: 'F011 - Web Dashboard', link: '/specs/f011-web-dashboard' },
+          ]
+        },
+        {
+          text: 'v0.9.0 (F019)',
+          collapsed: true,
+          items: [
+            { text: 'F019 - List Guardrails', link: '/specs/f019-list-guardrails' },
+          ]
+        },
+        {
+          text: 'v0.10.0 (F022–F027)',
+          collapsed: true,
+          items: [
             { text: 'F022 - MCP Server', link: '/specs/f022-mcp-server' },
             { text: 'F023 - Deliberation Traces', link: '/specs/f023-deliberation-traces' },
             { text: 'F024 - Bridge-Definitions', link: '/specs/f024-bridge-definitions' },
-            { text: 'F027 - Censor Layer', link: '/specs/f027-censor-layer' },
-            { text: 'F028 - Decomposed Confidence', link: '/specs/f028-decomposed-confidence' },
+            { text: 'F027 - Decision Quality', link: '/specs/f027-decision-quality' },
           ]
-        }
+        },
+        {
+          text: 'v0.11.0 (F046–F047)',
+          items: [
+            { text: 'F046 - Pre-Action Hook', link: '/specs/f046-pre-action-hook' },
+            { text: 'F047 - Session Context', link: '/specs/f047-session-context' },
+          ]
+        },
+        {
+          text: 'Roadmap: Research',
+          collapsed: true,
+          items: [
+            { text: 'F020 - Reasoning Traces', link: '/specs/f020-reasoning-traces' },
+            { text: 'F029 - Task Router', link: '/specs/f029-task-router' },
+            { text: 'F030 - Circuit Breaker Guardrails', link: '/specs/f030-circuit-breaker-guardrails' },
+            { text: 'F031 - Source Trust Scoring', link: '/specs/f031-source-trust-scoring' },
+            { text: 'F032 - Error Amplification', link: '/specs/f032-error-amplification-tracking' },
+          ]
+        },
+        {
+          text: 'Roadmap: Minsky',
+          collapsed: true,
+          items: [
+            { text: 'F033 - Censor Layer', link: '/specs/f033-censor-layer' },
+            { text: 'F034 - Decomposed Confidence', link: '/specs/f034-decomposed-confidence' },
+          ]
+        },
+        {
+          text: 'Roadmap: Federation',
+          collapsed: true,
+          items: [
+            { text: 'F035 - Semantic State Transfer', link: '/specs/f035-semantic-state-transfer' },
+            { text: 'F036 - Reasoning Continuity', link: '/specs/f036-reasoning-continuity' },
+            { text: 'F037 - Collective Innovation', link: '/specs/f037-collective-innovation' },
+            { text: 'F038 - Cross-Agent Federation', link: '/specs/f038-cross-agent-federation' },
+            { text: 'F039 - Protocol Stack', link: '/specs/f039-protocol-stack' },
+          ]
+        },
+        {
+          text: 'Roadmap: Beads-Inspired',
+          collapsed: true,
+          items: [
+            { text: 'F040 - Task-Decision Graph', link: '/specs/f040-task-decision-graph' },
+            { text: 'F041 - Memory Compaction', link: '/specs/f041-memory-compaction' },
+            { text: 'F042 - Decision Dependencies', link: '/specs/f042-decision-dependencies' },
+            { text: 'F043 - Distributed Merge', link: '/specs/f043-distributed-merge' },
+            { text: 'F044 - Agent Work Discovery', link: '/specs/f044-agent-work-discovery' },
+            { text: 'F045 - Graph Storage Layer', link: '/specs/f045-graph-storage-layer' },
+          ]
+        },
+        {
+          text: 'Roadmap: Infrastructure',
+          collapsed: true,
+          items: [
+            { text: 'F048 - Multi-Vector-DB', link: '/specs/f048-multi-vectordb' },
+          ]
+        },
       ]
     },
 

--- a/website/specs/f001-cstp-server.md
+++ b/website/specs/f001-cstp-server.md
@@ -1,0 +1,212 @@
+# F001: CSTP Server Infrastructure
+
+| Field | Value |
+|-------|-------|
+| Feature ID | F001 |
+| Status | Draft |
+| Priority | P0 (Foundation) |
+| Depends On | None |
+| Blocks | F002, F003, F004 |
+| Decision | a42a3514 |
+
+---
+
+## Summary
+
+Create the CSTP HTTP server infrastructure with Agent Card support and JSON-RPC 2.0 endpoint.
+
+## Goals
+
+1. FastAPI-based HTTP server
+2. Agent Card endpoint at `/.well-known/agent.json`
+3. JSON-RPC 2.0 handler at `POST /cstp`
+4. Bearer token authentication
+5. Health check endpoint
+
+## Non-Goals
+
+- Method implementations (F002-F004)
+- gRPC support
+- Push notifications
+
+---
+
+## Specification
+
+### Directory Structure
+
+```
+cognition-agent-decisions/
+└── a2a/
+    ├── __init__.py
+    ├── server.py           # FastAPI application
+    ├── agent_card.py       # Agent Card generation
+    ├── jsonrpc.py          # JSON-RPC 2.0 handler
+    ├── auth.py             # Bearer token auth
+    ├── config.py           # Server configuration
+    └── models/
+        ├── __init__.py
+        ├── requests.py     # JSON-RPC request models
+        └── responses.py    # JSON-RPC response models
+```
+
+### Agent Card Endpoint
+
+**GET** `/.well-known/agent.json`
+
+```json
+{
+  "name": "cognition-engines",
+  "description": "Decision intelligence for AI agents",
+  "version": "0.7.0",
+  "url": "https://agent.example.com",
+  "capabilities": {
+    "cstp": {
+      "version": "1.0",
+      "methods": [
+        "cstp.announceIntent",
+        "cstp.queryDecisions",
+        "cstp.checkGuardrails"
+      ]
+    }
+  },
+  "authentication": {
+    "schemes": ["bearer"]
+  }
+}
+```
+
+### JSON-RPC Endpoint
+
+**POST** `/cstp`
+
+**Headers:**
+- `Content-Type: application/json`
+- `Authorization: Bearer <token>`
+
+**Request format:**
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "cstp.<method>",
+  "id": "request-id",
+  "params": { ... }
+}
+```
+
+**Success response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "request-id",
+  "result": { ... }
+}
+```
+
+**Error response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "request-id",
+  "error": {
+    "code": -32601,
+    "message": "Method not found",
+    "data": { ... }
+  }
+}
+```
+
+### Authentication
+
+```python
+# a2a/auth.py
+from fastapi import HTTPException, Header
+
+async def verify_token(authorization: str = Header(...)) -> str:
+    """Verify Bearer token and return agent ID."""
+    if not authorization.startswith("Bearer "):
+        raise HTTPException(401, "Invalid authorization header")
+    
+    token = authorization[7:]
+    agent_id = validate_token(token)  # Check against config
+    
+    if not agent_id:
+        raise HTTPException(401, "Invalid token")
+    
+    return agent_id
+```
+
+### Configuration
+
+```yaml
+# config/server.yaml
+server:
+  host: "0.0.0.0"
+  port: 8100
+  cors_origins: ["*"]
+
+agent:
+  name: "cognition-engines"
+  version: "0.7.0"
+  url: "https://agent.example.com"
+
+auth:
+  enabled: true
+  tokens:
+    - agent: "emerson"
+      token: "${CSTP_TOKEN_EMERSON}"
+    - agent: "claude-ops"
+      token: "${CSTP_TOKEN_CLAUDE}"
+```
+
+### Health Check
+
+**GET** `/health`
+
+```json
+{
+  "status": "healthy",
+  "version": "0.7.0",
+  "uptime_seconds": 3600
+}
+```
+
+---
+
+## Implementation Tasks
+
+- [ ] Create `a2a/` directory structure
+- [ ] Implement `server.py` with FastAPI
+- [ ] Implement `agent_card.py` with Pydantic model
+- [ ] Implement `jsonrpc.py` request/response handling
+- [ ] Implement `auth.py` Bearer token verification
+- [ ] Implement `config.py` with YAML loading
+- [ ] Add health check endpoint
+- [ ] Create `pyproject.toml` optional deps: `[a2a]`
+- [ ] Add CLI: `uv run a2a/server.py --port 8100`
+- [ ] Write tests for server, auth, jsonrpc
+
+---
+
+## Acceptance Criteria
+
+1. `GET /.well-known/agent.json` returns valid Agent Card
+2. `POST /cstp` with valid JSON-RPC returns 200 (stub response)
+3. `POST /cstp` without Bearer token returns 401
+4. `GET /health` returns healthy status
+5. Server starts with `uv run a2a/server.py`
+6. All tests pass
+
+---
+
+## Dependencies
+
+```toml
+# pyproject.toml [project.optional-dependencies]
+a2a = [
+    "fastapi>=0.109.0",
+    "uvicorn>=0.27.0",
+    "pydantic>=2.0.0",
+    "pyyaml>=6.0",
+]
+```

--- a/website/specs/f002-query-decisions.md
+++ b/website/specs/f002-query-decisions.md
@@ -1,0 +1,204 @@
+# F002: cstp.queryDecisions Method
+
+| Field | Value |
+|-------|-------|
+| Feature ID | F002 |
+| Status | Implemented |
+| Priority | P1 |
+| Depends On | F001 (Server Infrastructure) |
+| Blocks | None |
+| Decision | a42a3514 |
+
+---
+
+## Summary
+
+Implement `cstp.queryDecisions` method to enable remote agents to search this agent's decision history via semantic search.
+
+## Goals
+
+1. JSON-RPC method handler for `cstp.queryDecisions`
+2. Wrap existing `query.py` functionality
+3. Filter by category, confidence, date range
+4. Return decision metadata (not raw content)
+5. Rate limiting per agent
+
+## Non-Goals
+
+- Full decision content exposure
+- Write access to decisions
+- Cross-agent federated search (future)
+
+---
+
+## Specification
+
+### Method Signature
+
+**Method:** `cstp.queryDecisions`
+
+### Request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "cstp.queryDecisions",
+  "id": "req-001",
+  "params": {
+    "query": "database migration strategy",
+    "filters": {
+      "category": "architecture",
+      "minConfidence": 0.7,
+      "maxConfidence": 1.0,
+      "dateAfter": "2026-01-01T00:00:00Z",
+      "dateBefore": "2026-12-31T23:59:59Z",
+      "stakes": ["medium", "high"],
+      "status": ["decided", "reviewed"]
+    },
+    "limit": 10,
+    "includeReasons": false
+  }
+}
+```
+
+### Request Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| query | string | ✅ | - | Semantic search query |
+| filters.category | string | ❌ | null | Filter by category |
+| filters.minConfidence | float | ❌ | 0.0 | Minimum confidence |
+| filters.maxConfidence | float | ❌ | 1.0 | Maximum confidence |
+| filters.dateAfter | datetime | ❌ | null | After this date |
+| filters.dateBefore | datetime | ❌ | null | Before this date |
+| filters.stakes | string[] | ❌ | null | Filter by stakes level |
+| filters.status | string[] | ❌ | null | Filter by status |
+| limit | int | ❌ | 10 | Max results (1-50) |
+| includeReasons | bool | ❌ | false | Include reason summary |
+
+### Response
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-001",
+  "result": {
+    "decisions": [
+      {
+        "id": "dec-456",
+        "title": "Use blue-green deployment for DB migration",
+        "category": "architecture",
+        "confidence": 0.9,
+        "stakes": "high",
+        "status": "reviewed",
+        "outcome": "success",
+        "date": "2026-01-20T14:00:00Z",
+        "distance": 0.23,
+        "reasons": ["pattern", "analysis"]
+      }
+    ],
+    "total": 1,
+    "query": "database migration strategy",
+    "queryTimeMs": 45,
+    "agent": "emerson"
+  }
+}
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| decisions | array | Matching decisions |
+| decisions[].id | string | Decision ID (short hash) |
+| decisions[].title | string | Decision summary |
+| decisions[].category | string | Category |
+| decisions[].confidence | float | Confidence 0.0-1.0 |
+| decisions[].stakes | string | Stakes level |
+| decisions[].status | string | Current status |
+| decisions[].outcome | string | Outcome if reviewed |
+| decisions[].date | datetime | Decision timestamp |
+| decisions[].distance | float | Semantic distance (lower = closer) |
+| decisions[].reasons | string[] | Reason types used (if includeReasons) |
+| total | int | Total matches returned |
+| query | string | Original query |
+| queryTimeMs | int | Query execution time |
+| agent | string | Responding agent ID |
+
+### Errors
+
+| Code | Message | When |
+|------|---------|------|
+| -32602 | InvalidParams | Missing query, invalid filters |
+| -32003 | QueryFailed | ChromaDB unavailable |
+| -32002 | RateLimited | Too many requests |
+
+---
+
+## Implementation
+
+### Handler
+
+```python
+# a2a/cstp/dispatcher.py
+
+from .models import QueryDecisionsRequest, QueryDecisionsResponse
+from .query_service import query_decisions
+
+async def _handle_query_decisions(params: dict[str, Any], agent_id: str) -> dict[str, Any]:
+    """Handle cstp.queryDecisions method."""
+    
+    # Parse request
+    request = QueryDecisionsRequest.from_params(params)
+    
+    # Execute query
+    results = await query_decisions(
+        query=request.query,
+        n_results=request.limit,
+        category=request.filters.category,
+        # ...
+    )
+    
+    # Map to response format
+    # ...
+```
+
+### Models
+
+```python
+# a2a/cstp/models.py
+
+from dataclasses import dataclass
+from typing import Any
+
+@dataclass(slots=True)
+class QueryFilters:
+    # ...
+
+@dataclass(slots=True)
+class QueryDecisionsRequest:
+    # ...
+```
+
+---
+
+## Implementation Tasks
+
+- [ ] Create `QueryDecisionsRequest` Pydantic model
+- [ ] Create `QueryDecisionsResponse` Pydantic model
+- [ ] Implement `handle_query_decisions` handler
+- [ ] Add rate limiting per agent
+- [ ] Register method in JSON-RPC dispatcher
+- [ ] Write unit tests
+- [ ] Write integration test with ChromaDB
+
+---
+
+## Acceptance Criteria
+
+1. `cstp.queryDecisions` returns matching decisions
+2. Filters correctly narrow results
+3. Rate limiting blocks excessive requests
+4. Invalid params return -32602 error
+5. ChromaDB failure returns -32003 error
+6. Response time < 500ms for typical queries

--- a/website/specs/f003-check-guardrails.md
+++ b/website/specs/f003-check-guardrails.md
@@ -1,0 +1,291 @@
+# F003: cstp.checkGuardrails Method
+
+| Field | Value |
+|-------|-------|
+| Feature ID | F003 |
+| Status | Implemented |
+| Priority | P1 |
+| Depends On | F001 (Server Infrastructure) |
+| Blocks | None |
+| Decision | a42a3514 |
+
+---
+
+## Summary
+
+Implement `cstp.checkGuardrails` method to enable remote agents to check their intended actions against this agent's guardrails.
+
+## Goals
+
+1. JSON-RPC method handler for `cstp.checkGuardrails`
+2. Wrap existing `check.py` functionality
+3. Evaluate action context against guardrails
+4. Return allow/block with violation details
+5. Audit logging of all checks
+
+## Non-Goals
+
+- Guardrail modification via API
+- Custom guardrail upload
+- Guardrail templates
+
+---
+
+## Specification
+
+### Method Signature
+
+**Method:** `cstp.checkGuardrails`
+
+### Request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "cstp.checkGuardrails",
+  "id": "req-001",
+  "params": {
+    "action": {
+      "description": "Deploy authentication service to production",
+      "category": "architecture",
+      "stakes": "high",
+      "confidence": 0.85,
+      "context": {
+        "affectsProduction": true,
+        "codeReviewCompleted": true,
+        "hasTests": true,
+        "ciPassing": true
+      }
+    },
+    "agent": {
+      "id": "emerson",
+      "url": "https://emerson.example.com"
+    }
+  }
+}
+```
+
+### Request Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| action.description | string | ✅ | - | What the agent wants to do |
+| action.category | string | ❌ | null | Decision category |
+| action.stakes | string | ❌ | "medium" | Stakes level |
+| action.confidence | float | ❌ | null | Agent's confidence |
+| action.context | object | ❌ | {} | Additional context for evaluation |
+| agent.id | string | ❌ | null | Requesting agent ID |
+| agent.url | string | ❌ | null | Requesting agent URL |
+
+### Response (Allowed)
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-001",
+  "result": {
+    "allowed": true,
+    "violations": [],
+    "warnings": [],
+    "evaluated": 5,
+    "evaluatedAt": "2026-02-04T21:00:00Z",
+    "agent": "cognition-engines"
+  }
+}
+```
+
+### Response (Blocked)
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-001",
+  "result": {
+    "allowed": false,
+    "violations": [
+      {
+        "guardrailId": "no-production-without-review",
+        "name": "Production Requires Review",
+        "message": "Production changes require completed code review",
+        "severity": "block",
+        "suggestion": "Complete code review before deploying"
+      }
+    ],
+    "warnings": [
+      {
+        "guardrailId": "prefer-staged-rollout",
+        "name": "Staged Rollout Preferred",
+        "message": "Consider staged rollout for production changes",
+        "severity": "warn",
+        "suggestion": "Deploy to 10% of traffic first"
+      }
+    ],
+    "evaluated": 5,
+    "evaluatedAt": "2026-02-04T21:00:00Z",
+    "agent": "cognition-engines"
+  }
+}
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| allowed | bool | Whether action is allowed |
+| violations | array | Blocking guardrail violations |
+| violations[].guardrailId | string | Guardrail identifier |
+| violations[].name | string | Human-readable name |
+| violations[].message | string | Violation explanation |
+| violations[].severity | string | "block" or "warn" |
+| violations[].suggestion | string | How to resolve |
+| warnings | array | Non-blocking warnings |
+| evaluated | int | Number of guardrails checked |
+| evaluatedAt | datetime | Evaluation timestamp |
+| agent | string | Responding agent ID |
+
+### Errors
+
+| Code | Message | When |
+|------|---------|------|
+| -32602 | InvalidParams | Missing action.description |
+| -32004 | GuardrailEvalFailed | Evaluation error |
+| -32002 | RateLimited | Too many requests |
+
+---
+
+## Implementation
+
+### Handler
+
+```python
+# a2a/cstp/methods.py
+
+from ..models.requests import CheckGuardrailsRequest
+from ..models.responses import CheckGuardrailsResponse
+from skills.cognition_engines.check import evaluate_guardrails
+
+async def handle_check_guardrails(
+    params: CheckGuardrailsRequest,
+    agent_id: str
+) -> CheckGuardrailsResponse:
+    """Handle cstp.checkGuardrails method."""
+    
+    # Rate limit check
+    check_rate_limit(agent_id, "checkGuardrails")
+    
+    # Build evaluation context
+    context = {
+        "category": params.action.category,
+        "stakes": params.action.stakes,
+        "confidence": params.action.confidence,
+        **params.action.context,
+    }
+    
+    # Evaluate against guardrails
+    result = await evaluate_guardrails(context)
+    
+    # Audit log
+    log_guardrail_check(
+        requesting_agent=agent_id,
+        action=params.action.description,
+        allowed=result.allowed,
+        violations=result.violations,
+    )
+    
+    # Map to response
+    violations = [
+        Violation(
+            guardrailId=v.id,
+            name=v.name,
+            message=v.message,
+            severity=v.severity,
+            suggestion=v.suggestion,
+        )
+        for v in result.violations
+        if v.severity == "block"
+    ]
+    
+    warnings = [
+        Violation(
+            guardrailId=v.id,
+            name=v.name,
+            message=v.message,
+            severity=v.severity,
+            suggestion=v.suggestion,
+        )
+        for v in result.violations
+        if v.severity == "warn"
+    ]
+    
+    return CheckGuardrailsResponse(
+        allowed=len(violations) == 0,
+        violations=violations,
+        warnings=warnings,
+        evaluated=result.evaluated,
+        evaluatedAt=datetime.utcnow(),
+        agent=get_agent_name(),
+    )
+```
+
+### Models
+
+```python
+# a2a/models/requests.py
+
+from pydantic import BaseModel, Field
+from typing import Optional, Dict, Any
+
+class ActionContext(BaseModel):
+    description: str = Field(..., min_length=1)
+    category: Optional[str] = None
+    stakes: str = "medium"
+    confidence: Optional[float] = Field(None, ge=0.0, le=1.0)
+    context: Dict[str, Any] = Field(default_factory=dict)
+
+class AgentInfo(BaseModel):
+    id: Optional[str] = None
+    url: Optional[str] = None
+
+class CheckGuardrailsRequest(BaseModel):
+    action: ActionContext
+    agent: Optional[AgentInfo] = None
+```
+
+### Audit Log Format
+
+```json
+{
+  "timestamp": "2026-02-04T21:00:00Z",
+  "event": "guardrail_check",
+  "requesting_agent": "emerson",
+  "action": "Deploy authentication service to production",
+  "allowed": false,
+  "violations": ["no-production-without-review"],
+  "evaluated": 5
+}
+```
+
+---
+
+## Implementation Tasks
+
+- [ ] Create `CheckGuardrailsRequest` Pydantic model
+- [ ] Create `CheckGuardrailsResponse` Pydantic model
+- [ ] Implement `handle_check_guardrails` handler
+- [ ] Add audit logging for checks
+- [ ] Add rate limiting per agent
+- [ ] Register method in JSON-RPC dispatcher
+- [ ] Write unit tests with mock guardrails
+- [ ] Write integration test with real guardrails
+
+---
+
+## Acceptance Criteria
+
+1. `cstp.checkGuardrails` correctly evaluates context
+2. Violations return `allowed: false`
+3. Warnings included but don't block
+4. All checks are audit logged
+5. Rate limiting blocks excessive requests
+6. Invalid params return -32602 error
+7. Response time < 100ms

--- a/website/specs/f004-announce-intent.md
+++ b/website/specs/f004-announce-intent.md
@@ -1,0 +1,332 @@
+# F004: cstp.announceIntent Method
+
+| Field | Value |
+|-------|-------|
+| Feature ID | F004 |
+| Status | Draft |
+| Priority | P1 |
+| Depends On | F001 (Server Infrastructure), F002, F003 |
+| Blocks | None |
+| Decision | a42a3514 |
+
+---
+
+## Summary
+
+Implement `cstp.announceIntent` method to enable agents to announce their intent before taking action and receive feedback from other agents.
+
+## Goals
+
+1. JSON-RPC method handler for `cstp.announceIntent`
+2. Combine query + guardrails in single call
+3. Store received intents for audit trail
+4. Return similar decisions + guardrail status + suggestions
+5. Optional: trigger for agent-to-agent callbacks
+
+## Non-Goals
+
+- Real-time push notifications
+- Intent negotiation/blocking
+- Multi-agent consensus
+
+---
+
+## Specification
+
+### Method Signature
+
+**Method:** `cstp.announceIntent`
+
+### Request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "cstp.announceIntent",
+  "id": "req-001",
+  "params": {
+    "intent": "Deploy authentication service to production",
+    "context": "PR #42 approved, all tests passing, CI green",
+    "category": "architecture",
+    "stakes": "high",
+    "confidence": 0.85,
+    "agent": {
+      "id": "emerson",
+      "url": "https://emerson.example.com"
+    },
+    "correlationId": "550e8400-e29b-41d4-a716-446655440000",
+    "metadata": {
+      "pr_number": 42,
+      "branch": "feat/auth-v2",
+      "commit": "abc123"
+    }
+  }
+}
+```
+
+### Request Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| intent | string | ✅ | - | What the agent intends to do |
+| context | string | ❌ | null | Additional context |
+| category | string | ❌ | null | Decision category |
+| stakes | string | ❌ | "medium" | Stakes level |
+| confidence | float | ❌ | null | Agent's confidence |
+| agent.id | string | ❌ | null | Announcing agent ID |
+| agent.url | string | ❌ | null | Announcing agent URL |
+| correlationId | string | ❌ | auto | ID to correlate responses |
+| metadata | object | ❌ | {} | Additional structured data |
+
+### Response
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-001",
+  "result": {
+    "received": true,
+    "correlationId": "550e8400-e29b-41d4-a716-446655440000",
+    "receivedAt": "2026-02-04T21:00:00Z",
+    
+    "similarDecisions": [
+      {
+        "id": "dec-123",
+        "title": "Deployed auth service v2.1",
+        "outcome": "success",
+        "date": "2026-01-15T10:30:00Z",
+        "distance": 0.18,
+        "notes": "Required 30-min rollback window"
+      },
+      {
+        "id": "dec-456",
+        "title": "Auth service rollback after memory leak",
+        "outcome": "partial",
+        "date": "2026-01-10T08:00:00Z",
+        "distance": 0.25,
+        "notes": "Issue was in connection pooling"
+      }
+    ],
+    
+    "guardrailStatus": {
+      "allowed": true,
+      "violations": [],
+      "warnings": [
+        {
+          "guardrailId": "prefer-staged-rollout",
+          "message": "Consider staged rollout for production changes"
+        }
+      ],
+      "evaluated": 5
+    },
+    
+    "suggestions": [
+      "Similar deploy succeeded with 30-min rollback window",
+      "Consider staged rollout based on past partial failure",
+      "Previous memory leak was in connection pooling"
+    ],
+    
+    "respondingAgent": "cognition-engines"
+  }
+}
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| received | bool | Intent was received |
+| correlationId | string | ID for correlation |
+| receivedAt | datetime | When intent was received |
+| similarDecisions | array | Relevant past decisions |
+| similarDecisions[].id | string | Decision ID |
+| similarDecisions[].title | string | Decision summary |
+| similarDecisions[].outcome | string | Outcome if known |
+| similarDecisions[].date | datetime | Decision date |
+| similarDecisions[].distance | float | Semantic distance |
+| similarDecisions[].notes | string | Relevant notes/lessons |
+| guardrailStatus | object | Guardrail evaluation |
+| guardrailStatus.allowed | bool | Whether allowed |
+| guardrailStatus.violations | array | Blocking violations |
+| guardrailStatus.warnings | array | Non-blocking warnings |
+| guardrailStatus.evaluated | int | Guardrails checked |
+| suggestions | array | AI-generated suggestions |
+| respondingAgent | string | Responding agent ID |
+
+### Errors
+
+| Code | Message | When |
+|------|---------|------|
+| -32602 | InvalidParams | Missing intent |
+| -32003 | QueryFailed | ChromaDB unavailable |
+| -32004 | GuardrailEvalFailed | Evaluation error |
+| -32002 | RateLimited | Too many requests |
+
+---
+
+## Implementation
+
+### Handler
+
+```python
+# a2a/cstp/methods.py
+
+from ..models.requests import AnnounceIntentRequest
+from ..models.responses import AnnounceIntentResponse
+from .methods import handle_query_decisions, handle_check_guardrails
+from .suggestions import generate_suggestions
+
+async def handle_announce_intent(
+    params: AnnounceIntentRequest,
+    agent_id: str
+) -> AnnounceIntentResponse:
+    """Handle cstp.announceIntent method."""
+    
+    # Rate limit check
+    check_rate_limit(agent_id, "announceIntent")
+    
+    # Generate correlation ID if not provided
+    correlation_id = params.correlationId or str(uuid.uuid4())
+    received_at = datetime.utcnow()
+    
+    # Store intent for audit
+    await store_intent(
+        correlation_id=correlation_id,
+        intent=params.intent,
+        context=params.context,
+        agent=agent_id,
+        received_at=received_at,
+    )
+    
+    # Query similar decisions
+    query_result = await handle_query_decisions(
+        QueryDecisionsRequest(
+            query=f"{params.intent} {params.context or ''}",
+            filters=QueryFilters(category=params.category),
+            limit=5,
+            includeReasons=False,
+        ),
+        agent_id=agent_id,
+    )
+    
+    # Check guardrails
+    guardrail_result = await handle_check_guardrails(
+        CheckGuardrailsRequest(
+            action=ActionContext(
+                description=params.intent,
+                category=params.category,
+                stakes=params.stakes,
+                confidence=params.confidence,
+            ),
+        ),
+        agent_id=agent_id,
+    )
+    
+    # Generate suggestions from similar decisions
+    suggestions = generate_suggestions(
+        intent=params.intent,
+        similar_decisions=query_result.decisions,
+        guardrail_warnings=guardrail_result.warnings,
+    )
+    
+    return AnnounceIntentResponse(
+        received=True,
+        correlationId=correlation_id,
+        receivedAt=received_at,
+        similarDecisions=query_result.decisions,
+        guardrailStatus=guardrail_result,
+        suggestions=suggestions,
+        respondingAgent=get_agent_name(),
+    )
+```
+
+### Suggestions Generator
+
+```python
+# a2a/cstp/suggestions.py
+
+def generate_suggestions(
+    intent: str,
+    similar_decisions: List[DecisionSummary],
+    guardrail_warnings: List[Violation],
+) -> List[str]:
+    """Generate actionable suggestions from context."""
+    
+    suggestions = []
+    
+    # Extract lessons from similar decisions
+    for decision in similar_decisions[:3]:
+        if decision.outcome == "success":
+            suggestions.append(
+                f"Similar action succeeded: {decision.title}"
+            )
+        elif decision.outcome == "failure":
+            suggestions.append(
+                f"Warning: Similar action failed: {decision.title}"
+            )
+        elif decision.outcome == "partial":
+            suggestions.append(
+                f"Similar action had issues: {decision.title}"
+            )
+    
+    # Add guardrail-based suggestions
+    for warning in guardrail_warnings:
+        if warning.suggestion:
+            suggestions.append(warning.suggestion)
+    
+    return suggestions[:5]  # Max 5 suggestions
+```
+
+### Intent Storage
+
+```python
+# a2a/cstp/storage.py
+
+async def store_intent(
+    correlation_id: str,
+    intent: str,
+    context: Optional[str],
+    agent: str,
+    received_at: datetime,
+) -> None:
+    """Store received intent for audit trail."""
+    
+    intent_record = {
+        "correlation_id": correlation_id,
+        "intent": intent,
+        "context": context,
+        "agent": agent,
+        "received_at": received_at.isoformat(),
+    }
+    
+    # Store to file (later: database)
+    intent_path = INTENTS_DIR / f"{correlation_id}.json"
+    intent_path.write_text(json.dumps(intent_record, indent=2))
+```
+
+---
+
+## Implementation Tasks
+
+- [ ] Create `AnnounceIntentRequest` Pydantic model
+- [ ] Create `AnnounceIntentResponse` Pydantic model
+- [ ] Implement `handle_announce_intent` handler
+- [ ] Implement `generate_suggestions` helper
+- [ ] Implement intent storage for audit trail
+- [ ] Add rate limiting per agent
+- [ ] Register method in JSON-RPC dispatcher
+- [ ] Write unit tests
+- [ ] Write integration test with full flow
+
+---
+
+## Acceptance Criteria
+
+1. `cstp.announceIntent` returns received confirmation
+2. Similar decisions included in response
+3. Guardrail status included in response
+4. Suggestions generated from context
+5. Intent stored for audit trail
+6. Correlation ID returned (generated if not provided)
+7. Rate limiting blocks excessive requests
+8. Response time < 1000ms (combines query + guardrails)

--- a/website/specs/f005-cstp-client.md
+++ b/website/specs/f005-cstp-client.md
@@ -1,0 +1,344 @@
+# F005: CSTP Client
+
+| Field | Value |
+|-------|-------|
+| Feature ID | F005 |
+| Status | Draft |
+| Priority | P1 |
+| Depends On | F001 (Server Infrastructure) |
+| Blocks | None |
+| Decision | a42a3514 |
+
+---
+
+## Summary
+
+Implement CSTP client library for calling remote agents' CSTP endpoints.
+
+## Goals
+
+1. Python client library for CSTP methods
+2. CLI for manual calls
+3. Auto-retry with backoff
+4. Connection pooling
+5. Agent registry for known agents
+
+## Non-Goals
+
+- Agent discovery service
+- Automatic failover
+- Load balancing
+
+---
+
+## Specification
+
+### Client Library
+
+```python
+# a2a/client.py
+
+from typing import Optional, List
+import httpx
+
+class CstpClient:
+    """Client for calling CSTP endpoints on remote agents."""
+    
+    def __init__(
+        self,
+        agent_url: str,
+        token: str,
+        timeout: float = 30.0,
+        retries: int = 3,
+    ):
+        self.agent_url = agent_url.rstrip("/")
+        self.token = token
+        self.timeout = timeout
+        self.retries = retries
+        self._client = httpx.AsyncClient(
+            timeout=timeout,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    
+    async def query_decisions(
+        self,
+        query: str,
+        category: Optional[str] = None,
+        min_confidence: Optional[float] = None,
+        limit: int = 10,
+    ) -> QueryDecisionsResponse:
+        """Query remote agent's decision history."""
+        ...
+    
+    async def check_guardrails(
+        self,
+        description: str,
+        category: Optional[str] = None,
+        stakes: str = "medium",
+        confidence: Optional[float] = None,
+        context: Optional[dict] = None,
+    ) -> CheckGuardrailsResponse:
+        """Check action against remote agent's guardrails."""
+        ...
+    
+    async def announce_intent(
+        self,
+        intent: str,
+        context: Optional[str] = None,
+        category: Optional[str] = None,
+        stakes: str = "medium",
+        confidence: Optional[float] = None,
+        correlation_id: Optional[str] = None,
+    ) -> AnnounceIntentResponse:
+        """Announce intent to remote agent."""
+        ...
+    
+    async def get_agent_card(self) -> AgentCard:
+        """Fetch remote agent's Agent Card."""
+        ...
+    
+    async def close(self):
+        """Close HTTP client."""
+        await self._client.aclose()
+```
+
+### JSON-RPC Call
+
+```python
+async def _call(
+    self,
+    method: str,
+    params: dict,
+) -> dict:
+    """Make JSON-RPC call with retry."""
+    
+    request = {
+        "jsonrpc": "2.0",
+        "method": method,
+        "id": str(uuid.uuid4()),
+        "params": params,
+    }
+    
+    for attempt in range(self.retries):
+        try:
+            response = await self._client.post(
+                f"{self.agent_url}/cstp",
+                json=request,
+            )
+            response.raise_for_status()
+            
+            result = response.json()
+            
+            if "error" in result:
+                raise CstpError(
+                    code=result["error"]["code"],
+                    message=result["error"]["message"],
+                )
+            
+            return result["result"]
+            
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 429:
+                # Rate limited, backoff
+                await asyncio.sleep(2 ** attempt)
+                continue
+            raise
+        
+        except httpx.RequestError:
+            if attempt < self.retries - 1:
+                await asyncio.sleep(2 ** attempt)
+                continue
+            raise
+    
+    raise CstpError(-32000, "Max retries exceeded")
+```
+
+### Agent Registry
+
+```python
+# a2a/registry.py
+
+from pathlib import Path
+import yaml
+
+class AgentRegistry:
+    """Registry of known CSTP agents."""
+    
+    def __init__(self, config_path: Path):
+        self.config_path = config_path
+        self._agents: Dict[str, AgentConfig] = {}
+        self._load()
+    
+    def _load(self):
+        """Load agents from config file."""
+        if self.config_path.exists():
+            config = yaml.safe_load(self.config_path.read_text())
+            for agent in config.get("agents", []):
+                self._agents[agent["name"]] = AgentConfig(
+                    name=agent["name"],
+                    url=agent["url"],
+                    token=os.environ.get(agent["token_env"]),
+                )
+    
+    def get(self, name: str) -> Optional[AgentConfig]:
+        """Get agent config by name."""
+        return self._agents.get(name)
+    
+    def list(self) -> List[str]:
+        """List known agent names."""
+        return list(self._agents.keys())
+    
+    def client(self, name: str) -> CstpClient:
+        """Get client for named agent."""
+        agent = self.get(name)
+        if not agent:
+            raise ValueError(f"Unknown agent: {name}")
+        return CstpClient(agent.url, agent.token)
+```
+
+### CLI
+
+```bash
+# Query decisions
+uv run a2a/cli.py query "database migration" --agent security-policy
+
+# Check guardrails  
+uv run a2a/cli.py check "Deploy to production" --agent security-policy --stakes high
+
+# Announce intent
+uv run a2a/cli.py announce "Deploy auth service" --agent security-policy --stakes high
+
+# Get agent card
+uv run a2a/cli.py agent-card --agent security-policy
+
+# List known agents
+uv run a2a/cli.py agents
+```
+
+### CLI Implementation
+
+```python
+# a2a/cli.py
+
+import click
+import asyncio
+from .client import CstpClient
+from .registry import AgentRegistry
+
+@click.group()
+def cli():
+    """CSTP Client CLI"""
+    pass
+
+@cli.command()
+@click.argument("query")
+@click.option("--agent", required=True, help="Target agent name or URL")
+@click.option("--category", help="Filter by category")
+@click.option("--limit", default=10, help="Max results")
+def query(query: str, agent: str, category: str, limit: int):
+    """Query remote agent's decisions."""
+    
+    async def run():
+        registry = AgentRegistry(Path("config/agents.yaml"))
+        client = registry.client(agent)
+        
+        try:
+            result = await client.query_decisions(
+                query=query,
+                category=category,
+                limit=limit,
+            )
+            
+            for decision in result.decisions:
+                click.echo(f"- [{decision.id}] {decision.title}")
+                click.echo(f"  Confidence: {decision.confidence:.0%}")
+                click.echo(f"  Distance: {decision.distance:.3f}")
+                click.echo()
+        finally:
+            await client.close()
+    
+    asyncio.run(run())
+
+@cli.command()
+@click.argument("description")
+@click.option("--agent", required=True)
+@click.option("--stakes", default="medium")
+@click.option("--confidence", type=float)
+def check(description: str, agent: str, stakes: str, confidence: float):
+    """Check action against remote guardrails."""
+    
+    async def run():
+        registry = AgentRegistry(Path("config/agents.yaml"))
+        client = registry.client(agent)
+        
+        try:
+            result = await client.check_guardrails(
+                description=description,
+                stakes=stakes,
+                confidence=confidence,
+            )
+            
+            if result.allowed:
+                click.echo("✅ Allowed")
+            else:
+                click.echo("❌ Blocked")
+                for v in result.violations:
+                    click.echo(f"  - {v.guardrailId}: {v.message}")
+        finally:
+            await client.close()
+    
+    asyncio.run(run())
+```
+
+---
+
+## Configuration
+
+### agents.yaml
+
+```yaml
+agents:
+  - name: "security-policy"
+    url: "https://security.example.com"
+    token_env: "CSTP_TOKEN_SECURITY"
+    
+  - name: "claude-ops"
+    url: "https://claude-ops.example.com"
+    token_env: "CSTP_TOKEN_CLAUDE"
+    
+  - name: "local"
+    url: "http://localhost:8100"
+    token_env: "CSTP_TOKEN_LOCAL"
+
+defaults:
+  timeout_seconds: 30
+  retries: 3
+```
+
+---
+
+## Implementation Tasks
+
+- [ ] Create `CstpClient` class
+- [ ] Implement `query_decisions` method
+- [ ] Implement `check_guardrails` method
+- [ ] Implement `announce_intent` method
+- [ ] Implement `get_agent_card` method
+- [ ] Add retry logic with exponential backoff
+- [ ] Create `AgentRegistry` class
+- [ ] Implement CLI commands
+- [ ] Add config file loading
+- [ ] Write unit tests with mocked server
+- [ ] Write integration test against real server
+
+---
+
+## Acceptance Criteria
+
+1. `CstpClient` successfully calls all CSTP methods
+2. Retry logic handles transient failures
+3. Rate limiting (429) triggers backoff
+4. Registry loads agents from config
+5. CLI commands work for all methods
+6. Errors map to `CstpError` exceptions
+7. Connection pooling reuses HTTP client

--- a/website/specs/f006-docker-deployment.md
+++ b/website/specs/f006-docker-deployment.md
@@ -1,0 +1,328 @@
+# F006: Docker Deployment Support
+
+| Field | Value |
+|-------|-------|
+| Feature ID | F006 |
+| Status | Implemented |
+| Priority | P2 |
+| Depends On | F001 (Server Infrastructure) |
+| Blocks | None |
+| Decision | 944b8647 |
+
+---
+
+## Summary
+
+Add Docker support for running the CSTP server as a containerized service, including Dockerfile, docker-compose.yml, and example environment configuration.
+
+## Goals
+
+1. Production-ready Dockerfile with multi-stage build
+2. docker-compose.yml for local development
+3. Example environment file with all required variables
+4. Health check integration
+5. Documentation for deployment
+
+## Non-Goals
+
+- Kubernetes manifests (future)
+- Helm charts (future)
+- CI/CD pipeline integration (separate task)
+
+---
+
+## Implementation Plan
+
+### Phase 1: Core Docker Files
+
+#### 1.1 Dockerfile
+
+```dockerfile
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim AS base
+
+# Set environment variables
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# --- Builder stage ---
+FROM base AS builder
+
+# Install uv for fast dependency resolution
+RUN pip install uv
+
+# Copy dependency files
+COPY pyproject.toml ./
+
+# Install dependencies
+RUN uv pip install --system -e ".[a2a]"
+
+# --- Runtime stage ---
+FROM base AS runtime
+
+# Copy installed packages from builder
+COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
+COPY --from=builder /usr/local/bin /usr/local/bin
+
+# Copy application code
+COPY . .
+
+# Create non-root user
+RUN useradd --create-home --shell /bin/bash appuser && \
+    chown -R appuser:appuser /app
+USER appuser
+
+# Expose port
+EXPOSE 8100
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD curl -f http://localhost:8100/health || exit 1
+
+# Default command
+CMD ["python", "-m", "a2a.server", "--host", "0.0.0.0", "--port", "8100"]
+```
+
+#### 1.2 docker-compose.yml
+
+```yaml
+version: "3.8"
+
+services:
+  cstp-server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: cstp-server
+    ports:
+      - "8100:8100"
+    env_file:
+      - .env
+    environment:
+      - CHROMA_URL=http://chromadb:8000
+    volumes:
+      - ./config:/app/config:ro
+      - ./guardrails:/app/guardrails:ro
+    depends_on:
+      chromadb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8100/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    restart: unless-stopped
+
+  chromadb:
+    image: chromadb/chroma:latest
+    container_name: chromadb
+    ports:
+      - "8000:8000"
+    volumes:
+      - chroma_data:/chroma/chroma
+    environment:
+      - ANONYMIZED_TELEMETRY=false
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/api/v1/heartbeat"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    restart: unless-stopped
+
+volumes:
+  chroma_data:
+```
+
+#### 1.3 .env.example
+
+```bash
+# =============================================================================
+# CSTP Server Configuration
+# =============================================================================
+# Copy this file to .env and fill in the values
+
+# --- Required ---
+
+# Gemini API key for embeddings (text-embedding-004)
+GEMINI_API_KEY=your_gemini_api_key_here
+
+# --- Server Configuration ---
+
+# Server bind address (default: 0.0.0.0)
+CSTP_HOST=0.0.0.0
+
+# Server port (default: 8100)
+CSTP_PORT=8100
+
+# --- ChromaDB Configuration ---
+
+# ChromaDB URL (default: http://chromadb:8000)
+CHROMA_URL=http://chromadb:8000
+
+# ChromaDB auth token (optional)
+# CHROMA_TOKEN=
+
+# --- Authentication ---
+
+# Comma-separated list of agent:token pairs for authentication
+# Format: agent1:token1,agent2:token2
+CSTP_AUTH_TOKENS=emerson:your_secret_token_here
+
+# --- Guardrails Configuration ---
+
+# Colon-separated paths to guardrail directories (optional)
+# GUARDRAILS_PATHS=/app/guardrails:/custom/guardrails
+
+# --- Logging ---
+
+# Log level (DEBUG, INFO, WARNING, ERROR)
+LOG_LEVEL=INFO
+
+# --- Optional: Agent Card ---
+
+# Agent name for discovery
+CSTP_AGENT_NAME=cognition-engines
+
+# Agent description
+CSTP_AGENT_DESCRIPTION=Decision Intelligence Service
+
+# Agent URL (for agent card)
+CSTP_AGENT_URL=http://localhost:8100
+```
+
+### Phase 2: Configuration Updates
+
+#### 2.1 Update config.py to read from environment
+
+```python
+# Support environment variable overrides
+import os
+
+def from_env() -> Config:
+    """Create config from environment variables."""
+    return Config(
+        server=ServerConfig(
+            host=os.getenv("CSTP_HOST", "0.0.0.0"),
+            port=int(os.getenv("CSTP_PORT", "8100")),
+        ),
+        agent=AgentConfig(
+            name=os.getenv("CSTP_AGENT_NAME", "cognition-engines"),
+            description=os.getenv("CSTP_AGENT_DESCRIPTION", "Decision Intelligence"),
+            version="0.7.0",
+            url=os.getenv("CSTP_AGENT_URL", "http://localhost:8100"),
+        ),
+        auth=AuthConfig(
+            enabled=True,
+            tokens=_parse_auth_tokens(os.getenv("CSTP_AUTH_TOKENS", "")),
+        ),
+    )
+
+def _parse_auth_tokens(tokens_str: str) -> list[AuthToken]:
+    """Parse CSTP_AUTH_TOKENS env var."""
+    tokens = []
+    for pair in tokens_str.split(","):
+        if ":" in pair:
+            agent, token = pair.split(":", 1)
+            tokens.append(AuthToken(agent=agent.strip(), token=token.strip()))
+    return tokens
+```
+
+#### 2.2 Update server.py entrypoint
+
+```python
+# Add CLI support for Docker
+if __name__ == "__main__":
+    import argparse
+    
+    parser = argparse.ArgumentParser(description="CSTP Server")
+    parser.add_argument("--host", default=os.getenv("CSTP_HOST", "0.0.0.0"))
+    parser.add_argument("--port", type=int, default=int(os.getenv("CSTP_PORT", "8100")))
+    parser.add_argument("--config", help="Path to config YAML (overrides env)")
+    
+    args = parser.parse_args()
+    run_server(host=args.host, port=args.port, config_path=args.config)
+```
+
+### Phase 3: Documentation
+
+#### 3.1 Update README.md
+
+Add "Docker Deployment" section:
+- Quick start with docker-compose
+- Environment variable reference
+- Production deployment tips
+- Health check endpoints
+
+#### 3.2 Create docs/DOCKER.md
+
+Detailed Docker deployment guide:
+- Building the image
+- Running with docker-compose
+- Running standalone
+- Connecting to external ChromaDB
+- Security considerations
+- Monitoring and logging
+
+---
+
+## Files to Create/Modify
+
+| File | Action | Description |
+|------|--------|-------------|
+| `Dockerfile` | Create | Multi-stage production build |
+| `docker-compose.yml` | Create | Local dev with ChromaDB |
+| `.env.example` | Create | Example environment file |
+| `.dockerignore` | Create | Exclude unnecessary files |
+| `a2a/config.py` | Modify | Add env var support |
+| `a2a/server.py` | Modify | Add CLI entrypoint |
+| `README.md` | Modify | Add Docker quick start |
+| `docs/DOCKER.md` | Create | Full deployment guide |
+
+---
+
+## Environment Variables Reference
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `GEMINI_API_KEY` | ✅ | - | Gemini API key for embeddings |
+| `CSTP_HOST` | ❌ | `0.0.0.0` | Server bind address |
+| `CSTP_PORT` | ❌ | `8100` | Server port |
+| `CHROMA_URL` | ❌ | `http://chromadb:8000` | ChromaDB endpoint |
+| `CHROMA_TOKEN` | ❌ | - | ChromaDB auth token |
+| `CSTP_AUTH_TOKENS` | ✅ | - | Agent authentication tokens |
+| `GUARDRAILS_PATHS` | ❌ | - | Custom guardrail directories |
+| `LOG_LEVEL` | ❌ | `INFO` | Logging verbosity |
+| `CSTP_AGENT_NAME` | ❌ | `cognition-engines` | Agent card name |
+| `CSTP_AGENT_DESCRIPTION` | ❌ | - | Agent card description |
+| `CSTP_AGENT_URL` | ❌ | - | Agent card URL |
+
+---
+
+## Acceptance Criteria
+
+1. `docker build .` succeeds
+2. `docker-compose up` starts server + ChromaDB
+3. Health check passes at `/health`
+4. Authentication works with env-configured tokens
+5. Guardrails load from mounted volume
+6. Queries work against ChromaDB
+7. Graceful shutdown on SIGTERM
+
+---
+
+## Estimated Effort
+
+- **Phase 1 (Docker files)**: 1-2 hours
+- **Phase 2 (Config updates)**: 1 hour
+- **Phase 3 (Documentation)**: 1 hour
+
+**Total**: ~4 hours

--- a/website/specs/f007-record-decision.md
+++ b/website/specs/f007-record-decision.md
@@ -1,0 +1,322 @@
+# F007: Record Decision Endpoint
+
+| Field | Value |
+|-------|-------|
+| Feature ID | F007 |
+| Status | Implemented |
+| Priority | P1 |
+| Depends On | F001 (Server Infrastructure) |
+| Blocks | None |
+| Decision | fddb416c |
+
+---
+
+## Summary
+
+Add `cstp.recordDecision` JSON-RPC method to allow remote agents to create and store decisions via the CSTP API, with automatic indexing to ChromaDB for semantic search.
+
+## Goals
+
+1. Create decisions via API (no CLI required)
+2. Auto-generate decision ID and timestamps
+3. Auto-index to ChromaDB for immediate searchability
+4. Support full decision schema (reasons, K-lines, pre-decision protocol)
+5. Return decision ID and file path
+
+## Non-Goals
+
+- Decision updates (future F008)
+- Decision deletion (future F009)
+- Batch recording (future optimization)
+
+---
+
+## API Specification
+
+### Method
+
+`cstp.recordDecision`
+
+### Request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "cstp.recordDecision",
+  "params": {
+    "decision": "Use PostgreSQL for agent memory storage",
+    "confidence": 0.85,
+    "category": "architecture",
+    "stakes": "high",
+    "context": "Choosing database for long-term agent memory",
+    "reasons": [
+      {"type": "analysis", "text": "ACID compliance needed for consistency", "strength": 0.9},
+      {"type": "pattern", "text": "Similar to prior successful database choice", "strength": 0.7}
+    ],
+    "kpiIndicators": ["latency", "consistency"],
+    "mentalState": "deliberate",
+    "reviewIn": "30d",
+    "tags": ["database", "infrastructure"],
+    "preDecision": {
+      "queryRun": true,
+      "similarFound": 2,
+      "guardrailsChecked": true,
+      "guardrailsPassed": true
+    }
+  },
+  "id": 1
+}
+```
+
+### Parameters
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `decision` | string | ✅ | The decision statement |
+| `confidence` | float | ✅ | Confidence level (0.0-1.0) |
+| `category` | string | ✅ | Category: architecture, process, integration, tooling, security |
+| `stakes` | string | ❌ | Stakes level: low, medium, high, critical (default: medium) |
+| `context` | string | ❌ | Background/situation being decided |
+| `reasons` | array | ❌ | Array of reason objects |
+| `reasons[].type` | string | ✅ | Reason type: authority, analogy, analysis, pattern, intuition |
+| `reasons[].text` | string | ✅ | Reason explanation |
+| `reasons[].strength` | float | ❌ | Reason strength (0.0-1.0, default: 0.8) |
+| `kpiIndicators` | array | ❌ | KPIs affected by this decision |
+| `mentalState` | string | ❌ | State: deliberate, reactive, exploratory, habitual, pressured |
+| `reviewIn` | string | ❌ | Review reminder: 7d, 2w, 1m, etc. |
+| `tags` | array | ❌ | Additional tags for categorization |
+| `preDecision` | object | ❌ | Pre-decision protocol tracking |
+| `preDecision.queryRun` | bool | ❌ | Whether similar decisions were queried |
+| `preDecision.similarFound` | int | ❌ | Number of similar decisions found |
+| `preDecision.guardrailsChecked` | bool | ❌ | Whether guardrails were checked |
+| `preDecision.guardrailsPassed` | bool | ❌ | Whether guardrails passed |
+
+### Response (Success)
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "success": true,
+    "id": "fddb416c",
+    "path": "decisions/2026/02/2026-02-05-decision-fddb416c.yaml",
+    "indexed": true,
+    "timestamp": "2026-02-05T00:45:00Z"
+  },
+  "id": 1
+}
+```
+
+### Response (Error)
+
+```json
+{
+  "jsonrpc": "2.0",
+  "error": {
+    "code": -32602,
+    "message": "Invalid params",
+    "data": {
+      "field": "confidence",
+      "error": "Must be between 0.0 and 1.0"
+    }
+  },
+  "id": 1
+}
+```
+
+---
+
+## Implementation Plan
+
+### Phase 1: Core Service (~2h)
+
+#### 1.1 Create decision_service.py
+
+```
+a2a/cstp/decision_service.py
+```
+
+**Functions:**
+- `generate_decision_id()` — UUID-based short ID
+- `create_decision_yaml(params)` — Build YAML content
+- `write_decision_file(id, yaml)` — Write to decisions/YYYY/MM/
+- `index_decision(path)` — Add to ChromaDB
+- `record_decision(params)` — Main orchestrator
+
+#### 1.2 Add models
+
+```python
+# a2a/cstp/models.py
+
+@dataclass
+class Reason:
+    type: str  # authority, analogy, analysis, pattern, intuition
+    text: str
+    strength: float = 0.8
+
+@dataclass
+class PreDecisionProtocol:
+    query_run: bool = False
+    similar_found: int = 0
+    guardrails_checked: bool = False
+    guardrails_passed: bool = False
+
+@dataclass
+class RecordDecisionRequest:
+    decision: str
+    confidence: float
+    category: str
+    stakes: str = "medium"
+    context: str | None = None
+    reasons: list[Reason] = field(default_factory=list)
+    kpi_indicators: list[str] = field(default_factory=list)
+    mental_state: str | None = None
+    review_in: str | None = None
+    tags: list[str] = field(default_factory=list)
+    pre_decision: PreDecisionProtocol | None = None
+
+@dataclass
+class RecordDecisionResponse:
+    success: bool
+    id: str
+    path: str
+    indexed: bool
+    timestamp: str
+```
+
+### Phase 2: Dispatcher Integration (~1h)
+
+#### 2.1 Update dispatcher.py
+
+```python
+async def _handle_record_decision(self, params: dict) -> dict:
+    request = RecordDecisionRequest.from_dict(params)
+    result = await record_decision(request)
+    return result.to_dict()
+```
+
+#### 2.2 Register method
+
+```python
+self._methods["cstp.recordDecision"] = self._handle_record_decision
+```
+
+### Phase 3: Configuration (~30m)
+
+#### 3.1 Environment variables
+
+```bash
+# Path where decisions are stored
+DECISIONS_PATH=/app/decisions
+
+# ChromaDB collection for indexing
+CHROMA_COLLECTION=decisions_gemini
+```
+
+#### 3.2 Update config.py
+
+```python
+@dataclass
+class DecisionsConfig:
+    path: Path = Path("decisions")
+    chroma_collection: str = "decisions_gemini"
+```
+
+### Phase 4: Tests (~1h)
+
+#### 4.1 Unit tests
+
+```
+tests/test_decision_service.py
+tests/test_f007_record_decision.py
+```
+
+**Test cases:**
+- Valid decision creation
+- Missing required fields
+- Invalid confidence range
+- Invalid category
+- Reason validation
+- File path generation
+- YAML format verification
+
+#### 4.2 Integration tests
+
+- End-to-end API call
+- ChromaDB indexing verification
+- Concurrent recording
+
+### Phase 5: Documentation (~30m)
+
+- Update README with new endpoint
+- Update docs/CSTP-v0.7.0-DESIGN.md
+- Add examples to docs/DOCKER.md
+
+---
+
+## Files to Create/Modify
+
+| File | Action | Description |
+|------|--------|-------------|
+| `a2a/cstp/decision_service.py` | Create | Core recording logic |
+| `a2a/cstp/models.py` | Modify | Add request/response models |
+| `a2a/cstp/dispatcher.py` | Modify | Register new method |
+| `a2a/config.py` | Modify | Add decisions config |
+| `tests/test_decision_service.py` | Create | Unit tests |
+| `tests/test_f007_record_decision.py` | Create | Integration tests |
+| `README.md` | Modify | Document new endpoint |
+
+---
+
+## Security Considerations
+
+1. **Input validation** — Sanitize all string inputs
+2. **Path traversal** — Ensure decision paths stay within decisions/
+3. **Rate limiting** — Consider adding rate limits (future)
+4. **Agent attribution** — Record which agent created the decision
+
+---
+
+## Error Codes
+
+| Code | Message | Cause |
+|------|---------|-------|
+| -32602 | Invalid params | Missing/invalid field |
+| -32603 | Internal error | File write or indexing failed |
+| -32001 | Storage error | Cannot write to decisions path |
+| -32002 | Indexing error | ChromaDB indexing failed |
+
+---
+
+## Acceptance Criteria
+
+1. ✅ `cstp.recordDecision` creates valid YAML file
+2. ✅ Decision immediately searchable via `cstp.queryDecisions`
+3. ✅ All required fields validated
+4. ✅ Optional fields handled correctly
+5. ✅ Error responses include helpful details
+6. ✅ Agent ID from auth recorded in decision
+7. ✅ File path follows YYYY/MM/ structure
+
+---
+
+## Estimated Effort
+
+| Phase | Time |
+|-------|------|
+| Core Service | 2h |
+| Dispatcher Integration | 1h |
+| Configuration | 30m |
+| Tests | 1h |
+| Documentation | 30m |
+| **Total** | **~5h** |
+
+---
+
+## Future Enhancements
+
+- **F008**: updateDecision — Add outcome, review decision
+- **F009**: deleteDecision — Remove decision (with audit)
+- **F010**: listDecisions — Paginated listing with filters
+- Batch recording for bulk imports
+- Webhooks for decision events

--- a/website/specs/f008-review-decision.md
+++ b/website/specs/f008-review-decision.md
@@ -1,0 +1,284 @@
+# F008: Review Decision Endpoint
+
+| Field | Value |
+|-------|-------|
+| Feature ID | F008 |
+| Status | Implemented |
+| Priority | P1 |
+| Depends On | F007 (Record Decision) |
+| Blocks | F009 (Calibration) |
+| Decision | 30d70c34 |
+
+---
+
+## Summary
+
+Add `cstp.reviewDecision` JSON-RPC method to record outcomes for existing decisions, enabling the feedback loop for calibration and learning.
+
+## Goals
+
+1. Add outcome data to existing decisions
+2. Support partial updates (don't require all fields)
+3. Trigger re-indexing with outcome metadata
+4. Track review timestamps
+5. Enable lessons capture
+
+## Non-Goals
+
+- Decision deletion (future)
+- Bulk review (future)
+- Automatic outcome detection (future enhancement)
+
+---
+
+## API Specification
+
+### Method
+
+`cstp.reviewDecision`
+
+### Request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "cstp.reviewDecision",
+  "params": {
+    "id": "fddb416c",
+    "outcome": "success",
+    "actualResult": "Redis caching reduced latency by 40%",
+    "lessons": "Should have considered cluster mode from the start",
+    "notes": "Will apply clustering in next iteration"
+  },
+  "id": 1
+}
+```
+
+### Parameters
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | ✅ | Decision ID to review |
+| `outcome` | string | ✅ | Outcome: `success`, `partial`, `failure`, `abandoned` |
+| `actualResult` | string | ❌ | What actually happened |
+| `lessons` | string | ❌ | Lessons learned for future |
+| `notes` | string | ❌ | Additional notes |
+| `affectedKpis` | object | ❌ | KPI impacts: `{"latency": -0.4, "cost": 0.1}` |
+
+### Response (Success)
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "success": true,
+    "id": "fddb416c",
+    "path": "decisions/2026/02/2026-02-05-decision-fddb416c.yaml",
+    "status": "reviewed",
+    "reviewedAt": "2026-02-12T14:30:00Z",
+    "reindexed": true
+  },
+  "id": 1
+}
+```
+
+### Response (Error - Decision Not Found)
+
+```json
+{
+  "jsonrpc": "2.0",
+  "error": {
+    "code": -32004,
+    "message": "Decision not found",
+    "data": {"id": "invalid123"}
+  },
+  "id": 1
+}
+```
+
+---
+
+## Implementation Plan
+
+### Phase 1: Decision Lookup (~1h)
+
+#### 1.1 Add find_decision function
+
+```python
+# a2a/cstp/decision_service.py
+
+async def find_decision(decision_id: str, decisions_path: str | None = None) -> tuple[Path, dict] | None:
+    """Find a decision by ID.
+    
+    Searches decisions directory for matching ID.
+    Returns (path, data) or None if not found.
+    """
+    base = Path(decisions_path or DECISIONS_PATH)
+    
+    # Search pattern: decisions/YYYY/MM/*-decision-{id}.yaml
+    for year_dir in base.iterdir():
+        if not year_dir.is_dir():
+            continue
+        for month_dir in year_dir.iterdir():
+            if not month_dir.is_dir():
+                continue
+            for file in month_dir.glob(f"*-decision-{decision_id}.yaml"):
+                with open(file) as f:
+                    data = yaml.safe_load(f)
+                return (file, data)
+    
+    return None
+```
+
+### Phase 2: Review Service (~1.5h)
+
+#### 2.1 Add review models
+
+```python
+@dataclass
+class ReviewDecisionRequest:
+    id: str
+    outcome: str  # success, partial, failure, abandoned
+    actual_result: str | None = None
+    lessons: str | None = None
+    notes: str | None = None
+    affected_kpis: dict[str, float] | None = None
+
+@dataclass
+class ReviewDecisionResponse:
+    success: bool
+    id: str
+    path: str
+    status: str
+    reviewed_at: str
+    reindexed: bool
+```
+
+#### 2.2 Add review_decision function
+
+```python
+async def review_decision(
+    request: ReviewDecisionRequest,
+    decisions_path: str | None = None,
+) -> ReviewDecisionResponse:
+    """Add outcome data to an existing decision."""
+    
+    # Find decision
+    result = await find_decision(request.id, decisions_path)
+    if not result:
+        raise ValueError(f"Decision not found: {request.id}")
+    
+    path, data = result
+    now = datetime.now(UTC)
+    
+    # Update decision data
+    data["status"] = "reviewed"
+    data["outcome"] = request.outcome
+    data["reviewed_at"] = now.isoformat()
+    
+    if request.actual_result:
+        data["actual_result"] = request.actual_result
+    if request.lessons:
+        data["lessons"] = request.lessons
+    if request.notes:
+        data["review_notes"] = request.notes
+    if request.affected_kpis:
+        data["affected_kpis"] = request.affected_kpis
+    
+    # Write updated YAML
+    with open(path, "w") as f:
+        yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+    
+    # Re-index with outcome metadata
+    reindexed = await reindex_decision(request.id, data)
+    
+    return ReviewDecisionResponse(
+        success=True,
+        id=request.id,
+        path=str(path),
+        status="reviewed",
+        reviewed_at=now.isoformat(),
+        reindexed=reindexed,
+    )
+```
+
+### Phase 3: Dispatcher Integration (~30m)
+
+```python
+async def _handle_review_decision(params: dict[str, Any], agent_id: str) -> dict[str, Any]:
+    request = ReviewDecisionRequest.from_dict(params)
+    
+    valid_outcomes = {"success", "partial", "failure", "abandoned"}
+    if request.outcome not in valid_outcomes:
+        raise ValueError(f"outcome must be one of {valid_outcomes}")
+    
+    response = await review_decision(request)
+    return response.to_dict()
+
+# Register
+dispatcher.register("cstp.reviewDecision", _handle_review_decision)
+```
+
+### Phase 4: Tests (~1h)
+
+**Test cases:**
+- Review existing decision successfully
+- Decision not found error
+- Invalid outcome error
+- Partial update (only required fields)
+- Full update (all fields)
+- Re-indexing updates metadata
+
+---
+
+## Files to Create/Modify
+
+| File | Action | Description |
+|------|--------|-------------|
+| `a2a/cstp/decision_service.py` | Modify | Add find_decision, review_decision |
+| `a2a/cstp/models.py` | Modify | Add ReviewDecisionRequest/Response |
+| `a2a/cstp/dispatcher.py` | Modify | Register new method |
+| `tests/test_decision_service.py` | Modify | Add review tests |
+| `tests/test_f008_review_decision.py` | Create | Integration tests |
+
+---
+
+## YAML Schema After Review
+
+```yaml
+id: fddb416c
+summary: "Use Redis for caching"
+decision: "Use Redis for caching"
+category: architecture
+confidence: 0.85
+stakes: high
+status: reviewed              # Changed from "pending"
+date: "2026-02-05T00:48:00Z"
+context: "Choosing cache layer"
+reasons:
+  - type: analysis
+    text: "Fast lookups needed"
+    strength: 0.9
+
+# Added by review
+outcome: success              # success | partial | failure | abandoned
+reviewed_at: "2026-02-12T14:30:00Z"
+actual_result: "Latency reduced 40%"
+lessons: "Should have considered clustering"
+review_notes: "Will add clustering next sprint"
+affected_kpis:
+  latency: -0.4
+  cost: 0.1
+```
+
+---
+
+## Estimated Effort
+
+| Phase | Time |
+|-------|------|
+| Decision Lookup | 1h |
+| Review Service | 1.5h |
+| Dispatcher Integration | 30m |
+| Tests | 1h |
+| **Total** | **~4h** |

--- a/website/specs/f009-get-calibration.md
+++ b/website/specs/f009-get-calibration.md
@@ -1,0 +1,512 @@
+# F009: Get Calibration Endpoint
+
+| Field | Value |
+|-------|-------|
+| Feature ID | F009 |
+| Status | Implemented |
+| Priority | P1 |
+| Depends On | F008 (Review Decision) |
+| Blocks | None |
+| Decision | 30d70c34 |
+
+---
+
+## Summary
+
+Add `cstp.getCalibration` JSON-RPC method to retrieve confidence calibration statistics, enabling agents to understand their decision-making accuracy and adjust future confidence levels.
+
+## Goals
+
+1. Calculate Brier scores for reviewed decisions
+2. Break down accuracy by confidence level
+3. Identify over/under-confidence patterns
+4. Filter by category, stakes, time range
+5. Provide actionable recommendations
+
+## Non-Goals
+
+- Real-time calibration updates (batch calculation)
+- Cross-agent calibration comparison (future)
+- Automatic confidence adjustment (agent decides)
+
+---
+
+## API Specification
+
+### Method
+
+`cstp.getCalibration`
+
+### Request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "cstp.getCalibration",
+  "params": {
+    "filters": {
+      "agent": "emerson",
+      "category": "architecture",
+      "minDecisions": 5,
+      "since": "2026-01-01"
+    },
+    "groupBy": "confidenceBucket"
+  },
+  "id": 1
+}
+```
+
+### Parameters
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `filters` | object | ❌ | Filter criteria |
+| `filters.agent` | string | ❌ | Filter by agent ID (from `recorded_by`) |
+| `filters.category` | string | ❌ | Filter by category |
+| `filters.stakes` | string | ❌ | Filter by stakes level |
+| `filters.since` | string | ❌ | ISO date, only decisions after |
+| `filters.until` | string | ❌ | ISO date, only decisions before |
+| `filters.minDecisions` | int | ❌ | Minimum decisions for stats (default: 5) |
+| `groupBy` | string | ❌ | Group by: `confidenceBucket`, `category`, `stakes`, `agent` |
+
+### Response (Success)
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "overall": {
+      "brierScore": 0.18,
+      "accuracy": 0.72,
+      "totalDecisions": 45,
+      "reviewedDecisions": 38,
+      "calibrationGap": -0.08,
+      "interpretation": "slightly_overconfident"
+    },
+    "byConfidenceBucket": [
+      {
+        "bucket": "0.9-1.0",
+        "decisions": 12,
+        "successRate": 0.75,
+        "expectedRate": 0.95,
+        "gap": -0.20,
+        "interpretation": "overconfident"
+      },
+      {
+        "bucket": "0.7-0.9",
+        "decisions": 18,
+        "successRate": 0.78,
+        "expectedRate": 0.80,
+        "gap": -0.02,
+        "interpretation": "well_calibrated"
+      },
+      {
+        "bucket": "0.5-0.7",
+        "decisions": 8,
+        "successRate": 0.62,
+        "expectedRate": 0.60,
+        "gap": 0.02,
+        "interpretation": "well_calibrated"
+      }
+    ],
+    "recommendations": [
+      {
+        "type": "confidence_adjustment",
+        "message": "When you feel 90%+ confident, outcomes suggest ~75%. Consider 75-80% instead.",
+        "severity": "warning"
+      },
+      {
+        "type": "strength",
+        "message": "Your 70-90% confidence range is well calibrated. Trust this range.",
+        "severity": "info"
+      }
+    ],
+    "queryTime": "2026-02-12T14:30:00Z"
+  },
+  "id": 1
+}
+```
+
+### Response (Insufficient Data)
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "overall": null,
+    "byConfidenceBucket": [],
+    "recommendations": [
+      {
+        "type": "insufficient_data",
+        "message": "Only 3 reviewed decisions. Need at least 5 for calibration stats.",
+        "severity": "info"
+      }
+    ],
+    "queryTime": "2026-02-12T14:30:00Z"
+  },
+  "id": 1
+}
+```
+
+---
+
+## Calibration Metrics
+
+### Brier Score
+Measures prediction accuracy. Lower is better.
+
+```
+Brier = (1/N) × Σ(confidence - outcome)²
+
+Where outcome = 1 for success, 0 for failure
+```
+
+| Brier Score | Interpretation |
+|-------------|----------------|
+| 0.00 - 0.10 | Excellent calibration |
+| 0.10 - 0.20 | Good calibration |
+| 0.20 - 0.30 | Fair calibration |
+| 0.30+ | Poor calibration |
+
+### Calibration Gap
+Difference between stated confidence and actual success rate.
+
+```
+Gap = actual_success_rate - average_confidence
+
+Positive = underconfident (better than you think)
+Negative = overconfident (worse than you think)
+```
+
+### Confidence Buckets
+Group decisions by confidence level:
+- `0.9-1.0`: High confidence
+- `0.7-0.9`: Moderate-high
+- `0.5-0.7`: Moderate
+- `0.0-0.5`: Low confidence
+
+---
+
+## Implementation Plan
+
+### Phase 1: Data Collection (~1h)
+
+#### 1.1 Add get_reviewed_decisions function
+
+```python
+async def get_reviewed_decisions(
+    decisions_path: str | None = None,
+    agent: str | None = None,
+    category: str | None = None,
+    stakes: str | None = None,
+    since: str | None = None,
+    until: str | None = None,
+) -> list[dict]:
+    """Get all reviewed decisions matching filters."""
+    base = Path(decisions_path or DECISIONS_PATH)
+    decisions = []
+    
+    for yaml_file in base.rglob("*-decision-*.yaml"):
+        with open(yaml_file) as f:
+            data = yaml.safe_load(f)
+        
+        # Filter: must be reviewed with outcome
+        if data.get("status") != "reviewed":
+            continue
+        if "outcome" not in data:
+            continue
+        
+        # Apply filters
+        if agent and data.get("recorded_by") != agent:
+            continue
+        if category and data.get("category") != category:
+            continue
+        if stakes and data.get("stakes") != stakes:
+            continue
+        if since and data.get("date", "") < since:
+            continue
+        if until and data.get("date", "") > until:
+            continue
+        
+        decisions.append(data)
+    
+    return decisions
+```
+
+### Phase 2: Calibration Calculation (~2h)
+
+#### 2.1 Add calibration models
+
+```python
+@dataclass
+class ConfidenceBucket:
+    bucket: str
+    decisions: int
+    success_rate: float
+    expected_rate: float
+    gap: float
+    interpretation: str
+
+@dataclass
+class CalibrationResult:
+    brier_score: float
+    accuracy: float
+    total_decisions: int
+    reviewed_decisions: int
+    calibration_gap: float
+    interpretation: str
+
+@dataclass
+class CalibrationRecommendation:
+    type: str
+    message: str
+    severity: str  # info, warning, error
+```
+
+#### 2.2 Add calculate_calibration function
+
+```python
+def calculate_calibration(decisions: list[dict]) -> CalibrationResult | None:
+    """Calculate calibration metrics from reviewed decisions."""
+    if len(decisions) < 5:
+        return None
+    
+    outcomes = []
+    confidences = []
+    
+    for d in decisions:
+        confidence = d.get("confidence", 0.5)
+        outcome = 1.0 if d.get("outcome") == "success" else 0.0
+        
+        # Partial success = 0.5
+        if d.get("outcome") == "partial":
+            outcome = 0.5
+        
+        outcomes.append(outcome)
+        confidences.append(confidence)
+    
+    # Brier score
+    brier = sum((c - o) ** 2 for c, o in zip(confidences, outcomes)) / len(decisions)
+    
+    # Accuracy (binary: success or not)
+    accuracy = sum(1 for o in outcomes if o >= 0.5) / len(decisions)
+    
+    # Calibration gap
+    avg_confidence = sum(confidences) / len(confidences)
+    gap = accuracy - avg_confidence
+    
+    # Interpretation
+    if abs(gap) < 0.05:
+        interpretation = "well_calibrated"
+    elif gap < -0.10:
+        interpretation = "overconfident"
+    elif gap < 0:
+        interpretation = "slightly_overconfident"
+    elif gap > 0.10:
+        interpretation = "underconfident"
+    else:
+        interpretation = "slightly_underconfident"
+    
+    return CalibrationResult(
+        brier_score=round(brier, 3),
+        accuracy=round(accuracy, 3),
+        total_decisions=len(decisions),
+        reviewed_decisions=len(decisions),
+        calibration_gap=round(gap, 3),
+        interpretation=interpretation,
+    )
+```
+
+#### 2.3 Add bucket analysis
+
+```python
+def calculate_buckets(decisions: list[dict]) -> list[ConfidenceBucket]:
+    """Calculate calibration by confidence bucket."""
+    buckets = {
+        "0.9-1.0": {"min": 0.9, "max": 1.0, "decisions": [], "expected": 0.95},
+        "0.7-0.9": {"min": 0.7, "max": 0.9, "decisions": [], "expected": 0.80},
+        "0.5-0.7": {"min": 0.5, "max": 0.7, "decisions": [], "expected": 0.60},
+        "0.0-0.5": {"min": 0.0, "max": 0.5, "decisions": [], "expected": 0.25},
+    }
+    
+    for d in decisions:
+        conf = d.get("confidence", 0.5)
+        for name, bucket in buckets.items():
+            if bucket["min"] <= conf < bucket["max"] or (bucket["max"] == 1.0 and conf == 1.0):
+                bucket["decisions"].append(d)
+                break
+    
+    results = []
+    for name, bucket in buckets.items():
+        if len(bucket["decisions"]) < 3:
+            continue
+        
+        successes = sum(1 for d in bucket["decisions"] if d.get("outcome") == "success")
+        success_rate = successes / len(bucket["decisions"])
+        gap = success_rate - bucket["expected"]
+        
+        if abs(gap) < 0.10:
+            interpretation = "well_calibrated"
+        elif gap < 0:
+            interpretation = "overconfident"
+        else:
+            interpretation = "underconfident"
+        
+        results.append(ConfidenceBucket(
+            bucket=name,
+            decisions=len(bucket["decisions"]),
+            success_rate=round(success_rate, 2),
+            expected_rate=bucket["expected"],
+            gap=round(gap, 2),
+            interpretation=interpretation,
+        ))
+    
+    return results
+```
+
+### Phase 3: Recommendations (~1h)
+
+```python
+def generate_recommendations(
+    overall: CalibrationResult | None,
+    buckets: list[ConfidenceBucket],
+) -> list[CalibrationRecommendation]:
+    """Generate actionable recommendations."""
+    recs = []
+    
+    if overall is None:
+        recs.append(CalibrationRecommendation(
+            type="insufficient_data",
+            message="Need at least 5 reviewed decisions for calibration.",
+            severity="info",
+        ))
+        return recs
+    
+    # Overall calibration feedback
+    if overall.interpretation == "overconfident":
+        recs.append(CalibrationRecommendation(
+            type="confidence_adjustment",
+            message=f"You're overconfident by {abs(overall.calibration_gap)*100:.0f}%. Consider lowering confidence estimates.",
+            severity="warning",
+        ))
+    elif overall.interpretation == "underconfident":
+        recs.append(CalibrationRecommendation(
+            type="confidence_adjustment",
+            message=f"You're underconfident by {overall.calibration_gap*100:.0f}%. Trust yourself more.",
+            severity="info",
+        ))
+    
+    # Bucket-specific feedback
+    for bucket in buckets:
+        if bucket.interpretation == "overconfident" and bucket.gap < -0.15:
+            recs.append(CalibrationRecommendation(
+                type="bucket_warning",
+                message=f"At {bucket.bucket} confidence, actual success is {bucket.success_rate*100:.0f}%. Adjust to ~{bucket.success_rate*100:.0f}%.",
+                severity="warning",
+            ))
+    
+    # Strength recognition
+    well_calibrated = [b for b in buckets if b.interpretation == "well_calibrated"]
+    if well_calibrated:
+        ranges = ", ".join(b.bucket for b in well_calibrated)
+        recs.append(CalibrationRecommendation(
+            type="strength",
+            message=f"Well calibrated in {ranges} range. Trust these estimates.",
+            severity="info",
+        ))
+    
+    return recs
+```
+
+### Phase 4: Dispatcher Integration (~30m)
+
+```python
+async def _handle_get_calibration(params: dict[str, Any], agent_id: str) -> dict[str, Any]:
+    filters = params.get("filters", {})
+    
+    decisions = await get_reviewed_decisions(
+        category=filters.get("category"),
+        stakes=filters.get("stakes"),
+        since=filters.get("since"),
+        until=filters.get("until"),
+    )
+    
+    min_decisions = filters.get("minDecisions", 5)
+    
+    overall = calculate_calibration(decisions) if len(decisions) >= min_decisions else None
+    buckets = calculate_buckets(decisions)
+    recommendations = generate_recommendations(overall, buckets)
+    
+    return {
+        "overall": overall.to_dict() if overall else None,
+        "byConfidenceBucket": [b.to_dict() for b in buckets],
+        "recommendations": [r.to_dict() for r in recommendations],
+        "queryTime": datetime.now(UTC).isoformat(),
+    }
+
+dispatcher.register("cstp.getCalibration", _handle_get_calibration)
+```
+
+### Phase 5: Tests (~1h)
+
+**Test cases:**
+- Calibration with sufficient data
+- Insufficient data response
+- Filter by category
+- Bucket calculations
+- Recommendation generation
+- Edge cases (all success, all failure)
+
+---
+
+## Files to Create/Modify
+
+| File | Action | Description |
+|------|--------|-------------|
+| `a2a/cstp/calibration_service.py` | Create | Calibration calculation logic |
+| `a2a/cstp/decision_service.py` | Modify | Add get_reviewed_decisions |
+| `a2a/cstp/dispatcher.py` | Modify | Register new method |
+| `tests/test_calibration_service.py` | Create | Unit tests |
+| `tests/test_f009_get_calibration.py` | Create | Integration tests |
+
+---
+
+## Integration with Decision Flow
+
+```
+┌────────────────────────────────────────────────────────────┐
+│                                                            │
+│   recordDecision ──▶ reviewDecision ──▶ getCalibration     │
+│        │                    │                  │           │
+│        ▼                    ▼                  ▼           │
+│   "confidence: 0.85"   "outcome: success"   "Brier: 0.18"  │
+│                                                 │           │
+│                                                 ▼           │
+│   ◀─────────────────────────────────────────────           │
+│   Next decision: "Similar decisions had 72% success.       │
+│                   Your 85% confidence may be high."        │
+│                                                            │
+└────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Estimated Effort
+
+| Phase | Time |
+|-------|------|
+| Data Collection | 1h |
+| Calibration Calculation | 2h |
+| Recommendations | 1h |
+| Dispatcher Integration | 30m |
+| Tests | 1h |
+| **Total** | **~5.5h** |
+
+---
+
+## Future Enhancements
+
+- **Category-specific calibration**: "You're overconfident in architecture but well-calibrated in process"
+- **Trend analysis**: "Your calibration improved 15% this month"
+- **Cross-agent comparison**: "Your Brier score is better than 70% of agents"
+- **Active nudging**: Inject calibration warnings into queryDecisions responses

--- a/website/specs/f010-project-context.md
+++ b/website/specs/f010-project-context.md
@@ -1,0 +1,268 @@
+# F010: Project Context and Outcome Attribution
+
+| Field | Value |
+|-------|-------|
+| Feature ID | F010 |
+| Status | Draft |
+| Priority | P1 |
+| Depends On | F007 (Record Decision), F008 (Review Decision) |
+| Blocks | None |
+| Estimated Effort | 5.5h |
+
+## Problem Statement
+
+Currently, decisions lack structured project context. The `context` field is free-form text, making it impossible to:
+- Query decisions by project/PR/feature
+- Automatically link production bugs to review decisions
+- Calculate per-project or per-feature calibration
+
+For code review agents to learn from outcomes, we need structured fields that enable attribution.
+
+## Solution
+
+### Part 1: Extended Schema Fields
+
+Add optional fields to `recordDecision`:
+
+```yaml
+# Project context (all optional)
+project: "owner/repo"              # GitHub repo identifier
+feature: "cstp-feedback-loop"      # Feature/epic name
+pr: 8                              # PR number
+file: "a2a/cstp/decision_service.py"  # File path
+line: 42                           # Line number
+commit: "abc123def"                # Commit SHA (short or full)
+```
+
+### Part 2: Enhanced Query Filters
+
+Update `queryDecisions` to filter by project context:
+
+```json
+{
+  "method": "cstp.queryDecisions",
+  "params": {
+    "query": "error handling",
+    "filters": {
+      "project": "tfatykhov/cognition-agent-decisions",
+      "feature": "cstp-feedback-loop",
+      "pr": 8
+    }
+  }
+}
+```
+
+### Part 3: Enhanced Calibration Filters
+
+Update `getCalibration` to filter by project context:
+
+```json
+{
+  "method": "cstp.getCalibration",
+  "params": {
+    "filters": {
+      "project": "tfatykhov/cognition-agent-decisions",
+      "feature": "cstp-feedback-loop"
+    }
+  }
+}
+```
+
+### Part 4: Outcome Attribution Job
+
+New method or scheduled job that links outcomes to decisions:
+
+```json
+{
+  "method": "cstp.attributeOutcomes",
+  "params": {
+    "project": "tfatykhov/cognition-agent-decisions",
+    "since": "2026-01-01"
+  }
+}
+```
+
+#### Attribution Logic
+
+1. **PR Stability Check** (automatic)
+   - Find PRs merged >14 days ago
+   - If no bugs linked → mark all review findings as `success`
+   
+2. **Bug Linking** (semi-automatic)
+   - When bug reported with file:line reference
+   - Query decisions matching that file:line
+   - If found: mark as `success` (caught) or prompt for review
+   - If not found: record as missed bug
+   
+3. **Git Blame Matching** (automatic)
+   - Parse error stack traces for file:line
+   - git blame to find introducing commit/PR
+   - Match to recorded decisions
+
+## API Changes
+
+### recordDecision (F007) — Extended Params
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| project | string | No | Repository identifier (owner/repo) |
+| feature | string | No | Feature or epic name |
+| pr | integer | No | Pull request number |
+| file | string | No | File path relative to repo root |
+| line | integer | No | Line number in file |
+| commit | string | No | Commit SHA (7+ chars) |
+
+### queryDecisions (F002) — Extended Filters
+
+| Filter | Type | Description |
+|--------|------|-------------|
+| project | string | Filter by repository |
+| feature | string | Filter by feature name |
+| pr | integer | Filter by PR number |
+| hasOutcome | boolean | Only reviewed decisions |
+
+### getCalibration (F009) — Extended Filters
+
+| Filter | Type | Description |
+|--------|------|-------------|
+| project | string | Filter by repository |
+| feature | string | Filter by feature name |
+| groupBy | string | Add "project" and "feature" options |
+
+### attributeOutcomes — New Method
+
+```json
+{
+  "method": "cstp.attributeOutcomes",
+  "params": {
+    "project": "owner/repo",
+    "since": "2026-01-01",
+    "stabilityDays": 14,
+    "dryRun": true
+  }
+}
+```
+
+Response:
+```json
+{
+  "processed": 25,
+  "attributed": {
+    "stable": 20,
+    "bugLinked": 3,
+    "missed": 2
+  },
+  "decisions": [
+    {
+      "id": "abc123",
+      "outcome": "success",
+      "reason": "PR stable for 14 days"
+    }
+  ]
+}
+```
+
+## Implementation Plan
+
+### Phase 1: Schema Extension (1.5h)
+- [ ] Add project context fields to RecordDecisionRequest
+- [ ] Update decision_service.py to persist new fields
+- [ ] Update tests
+
+### Phase 2: Query Filters (1.5h)
+- [ ] Add project/feature/pr filters to QueryDecisionsRequest
+- [ ] Update query_service.py filter logic
+- [ ] Include new fields in ChromaDB metadata
+- [ ] Update tests
+
+### Phase 3: Calibration Filters (1h)
+- [ ] Add project/feature filters to GetCalibrationRequest
+- [ ] Add groupBy options for project/feature
+- [ ] Update calibration_service.py
+- [ ] Update tests
+
+### Phase 4: Attribution Job (1.5h)
+- [ ] Create attribution_service.py
+- [ ] Implement PR stability check
+- [ ] Implement file:line matching
+- [ ] Add cstp.attributeOutcomes method
+- [ ] Update tests
+
+## Example Workflow
+
+### Code Review Agent Records Finding
+
+```json
+{
+  "method": "cstp.recordDecision",
+  "params": {
+    "summary": "P1: Missing null check in user validation",
+    "confidence": 0.9,
+    "category": "code-review",
+    "stakes": "high",
+    "project": "tfatykhov/cognition-agent-decisions",
+    "feature": "cstp-feedback-loop",
+    "pr": 8,
+    "file": "a2a/cstp/decision_service.py",
+    "line": 42,
+    "commit": "abc123d"
+  }
+}
+```
+
+### Two Weeks Later: Attribution Runs
+
+```json
+{
+  "method": "cstp.attributeOutcomes",
+  "params": {
+    "project": "tfatykhov/cognition-agent-decisions"
+  }
+}
+```
+
+Response:
+```json
+{
+  "attributed": {
+    "stable": 15,
+    "bugLinked": 1
+  },
+  "decisions": [
+    {
+      "id": "finding-abc",
+      "outcome": "success",
+      "reason": "PR #8 stable for 14 days, no bugs reported"
+    }
+  ]
+}
+```
+
+### Calibration Check
+
+```json
+{
+  "method": "cstp.getCalibration",
+  "params": {
+    "filters": {
+      "project": "tfatykhov/cognition-agent-decisions",
+      "category": "code-review"
+    }
+  }
+}
+```
+
+## Success Criteria
+
+- [ ] Decisions can be recorded with project context
+- [ ] Queries can filter by project/feature/PR
+- [ ] Calibration can be calculated per project/feature
+- [ ] Attribution job can auto-mark outcomes based on PR stability
+- [ ] File:line matching works for bug attribution
+
+## Future Enhancements
+
+- GitHub webhook for real-time bug linking
+- Automatic git blame integration
+- PR comment parsing for developer feedback
+- Dashboard showing per-project calibration trends

--- a/website/specs/f011-web-dashboard.md
+++ b/website/specs/f011-web-dashboard.md
@@ -1,0 +1,299 @@
+# F011: Web Dashboard
+
+**Status:** Draft  
+**Priority:** P1  
+**Decision ID:** 467c593e  
+
+## Summary
+
+Create a web dashboard for CSTP that allows users to view decisions, review outcomes, and monitor calibration — all through a browser interface.
+
+## Motivation
+
+Currently CSTP is CLI-only (`scripts/cstp.py`). A web dashboard provides:
+- Visual overview of decision history
+- Easier outcome review (click instead of CLI)
+- Calibration trends at a glance
+- Multi-agent decision comparison
+- Accessible to users who prefer GUI over terminal
+
+## Requirements
+
+### Functional
+
+#### F011.1: Decision List View
+- Paginated list of all decisions
+- Columns: ID, summary (truncated), category, stakes, confidence, outcome, created_at
+- Sort by: date (default), confidence, stakes
+- Filter by: category, stakes, outcome status (pending/reviewed), agent
+
+#### F011.2: Decision Detail View
+- Full decision text
+- All metadata (category, stakes, confidence, project context)
+- Outcome section (if reviewed)
+- Edit button to update outcome
+
+#### F011.3: Outcome Review Form
+- Dropdown: success / partial / failure / abandoned
+- Text field: actual_result
+- Text field: lessons (optional)
+- Submit updates decision via CSTP API
+
+#### F011.4: Calibration Dashboard
+- Overall stats: total decisions, reviewed count, Brier score, accuracy
+- Per-category breakdown table
+- Per-agent breakdown (if multi-agent)
+- Simple bar chart for category accuracy (optional, stretch goal)
+
+#### F011.5: Authentication
+- HTTP Basic Auth for MVP
+- Single username/password from environment variables
+- All routes protected
+
+### Non-Functional
+
+#### F011.6: Deployment
+- Separate Docker container
+- Dockerfile in `dashboard/`
+- Environment variables for config:
+  - `CSTP_URL` — CSTP server URL (default: http://cstp:9991)
+  - `CSTP_TOKEN` — API token for dashboard
+  - `DASHBOARD_USER` — Basic auth username
+  - `DASHBOARD_PASS` — Basic auth password
+  - `DASHBOARD_PORT` — Listen port (default: 8080)
+
+#### F011.7: Tech Stack
+- **Backend:** Python 3.11+ with Flask or FastAPI
+- **Frontend:** Server-side rendered HTML (Jinja2 templates)
+- **Styling:** Simple CSS (no build step) — Pico.css or similar minimal framework
+- **No JavaScript frameworks** — keep it simple, progressive enhancement only
+
+## Architecture
+
+```
+┌─────────────────┐     HTTP/JSON-RPC     ┌─────────────────┐
+│   Dashboard     │ ───────────────────▶  │   CSTP Server   │
+│   (Flask)       │                       │   (FastAPI)     │
+│   Port 8080     │ ◀───────────────────  │   Port 9991     │
+└─────────────────┘                       └─────────────────┘
+        │
+        │ Basic Auth
+        ▼
+    Browser
+```
+
+### API Calls (Dashboard → CSTP)
+
+| Dashboard Action | CSTP Method |
+|------------------|-------------|
+| List decisions | `cstp.queryDecisions` with empty query, high limit |
+| Get decision | `cstp.queryDecisions` with ID filter (or new method) |
+| Update outcome | `cstp.reviewDecision` |
+| Get calibration | `cstp.getCalibration` |
+
+### New CSTP Method (Optional)
+
+May need `cstp.listDecisions` for paginated listing without semantic search:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "cstp.listDecisions",
+  "params": {
+    "limit": 50,
+    "offset": 0,
+    "category": "architecture",
+    "hasOutcome": false
+  },
+  "id": 1
+}
+```
+
+## File Structure
+
+```
+dashboard/
+├── Dockerfile
+├── requirements.txt
+├── app.py                 # Flask app entry point
+├── config.py              # Environment config
+├── cstp_client.py         # CSTP API wrapper
+├── templates/
+│   ├── base.html          # Layout with nav
+│   ├── decisions.html     # List view
+│   ├── decision.html      # Detail view
+│   ├── review.html        # Outcome form
+│   └── calibration.html   # Stats dashboard
+└── static/
+    └── style.css          # Minimal custom CSS
+```
+
+## UI Mockups
+
+### Decision List (`/decisions`)
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  CSTP Dashboard                          [Calibration] [Logout]
+├──────────────────────────────────────────────────────────────┤
+│  Decisions (43 total, 28 reviewed)                           │
+│                                                              │
+│  Filter: [Category ▼] [Stakes ▼] [Status ▼] [Agent ▼]       │
+│                                                              │
+│  ┌────────┬──────────────────────────┬──────┬───────┬──────┐│
+│  │ ID     │ Summary                  │ Cat  │ Conf  │ Out  ││
+│  ├────────┼──────────────────────────┼──────┼───────┼──────┤│
+│  │ 467c.. │ Create web dashboard...  │ arch │ 0.85  │  ⏳  ││
+│  │ 85e9.. │ Configure sub-agents...  │ intg │ 0.85  │  ⏳  ││
+│  │ 88c1.. │ Keep CSTP in TOOLS.md... │ proc │ 0.85  │  ✅  ││
+│  └────────┴──────────────────────────┴──────┴───────┴──────┘│
+│                                                              │
+│  [← Prev]  Page 1 of 3  [Next →]                            │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### Decision Detail (`/decisions/<id>`)
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  ← Back to list                                              │
+├──────────────────────────────────────────────────────────────┤
+│  Decision: 467c593e                                          │
+│                                                              │
+│  Summary:                                                    │
+│  Create web dashboard for CSTP as separate Docker service    │
+│  with basic auth, decision viewing, and outcome review       │
+│                                                              │
+│  ┌─────────────┬─────────────────────────────────────────┐  │
+│  │ Category    │ architecture                            │  │
+│  │ Stakes      │ medium                                  │  │
+│  │ Confidence  │ 0.85                                    │  │
+│  │ Created     │ 2026-02-05 19:18:00                     │  │
+│  │ Agent       │ emerson                                 │  │
+│  └─────────────┴─────────────────────────────────────────┘  │
+│                                                              │
+│  Outcome: ⏳ Pending review                                  │
+│                                                              │
+│  [Review Outcome]                                            │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### Review Form (`/decisions/<id>/review`)
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Review Decision: 467c593e                                   │
+├──────────────────────────────────────────────────────────────┤
+│                                                              │
+│  Outcome:  [success ▼]                                       │
+│            ○ success                                         │
+│            ○ partial                                         │
+│            ○ failure                                         │
+│            ○ abandoned                                       │
+│                                                              │
+│  What happened:                                              │
+│  ┌──────────────────────────────────────────────────────┐   │
+│  │ Dashboard deployed, working well...                  │   │
+│  └──────────────────────────────────────────────────────┘   │
+│                                                              │
+│  Lessons learned (optional):                                 │
+│  ┌──────────────────────────────────────────────────────┐   │
+│  │ Pico.css saved time, no build step was the right...  │   │
+│  └──────────────────────────────────────────────────────┘   │
+│                                                              │
+│  [Cancel]  [Submit Review]                                   │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### Calibration (`/calibration`)
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Calibration Dashboard                                       │
+├──────────────────────────────────────────────────────────────┤
+│                                                              │
+│  Overall Stats                                               │
+│  ┌────────────────┬────────────────┬────────────────┐       │
+│  │ Total: 43      │ Reviewed: 28   │ Pending: 15    │       │
+│  │ Brier: 0.04    │ Accuracy: 91%  │ Status: ✅     │       │
+│  └────────────────┴────────────────┴────────────────┘       │
+│                                                              │
+│  By Category                                                 │
+│  ┌──────────────┬─────────┬──────────┬──────────┐          │
+│  │ Category     │ Count   │ Accuracy │ Brier    │          │
+│  ├──────────────┼─────────┼──────────┼──────────┤          │
+│  │ architecture │ 12      │ 92%      │ 0.03     │          │
+│  │ process      │ 18      │ 89%      │ 0.05     │          │
+│  │ integration  │ 8       │ 100%     │ 0.00     │          │
+│  │ tooling      │ 3       │ 67%      │ 0.12     │          │
+│  └──────────────┴─────────┴──────────┴──────────┘          │
+│                                                              │
+│  By Agent                                                    │
+│  ┌──────────────┬─────────┬──────────┐                      │
+│  │ Agent        │ Count   │ Accuracy │                      │
+│  ├──────────────┼─────────┼──────────┤                      │
+│  │ emerson      │ 35      │ 91%      │                      │
+│  │ codereviewer │ 5       │ 100%     │                      │
+│  │ docsagent    │ 3       │ 100%     │                      │
+│  └──────────────┴─────────┴──────────┘                      │
+└──────────────────────────────────────────────────────────────┘
+```
+
+## Implementation Plan
+
+### Phase 1: Core Dashboard
+1. Create `dashboard/` directory structure
+2. Implement Flask app with Basic Auth
+3. Create CSTP client wrapper
+4. Build decision list view
+5. Build decision detail view
+
+### Phase 2: Review Workflow
+6. Build outcome review form
+7. Wire up to `cstp.reviewDecision`
+8. Add success/error feedback
+
+### Phase 3: Calibration
+9. Build calibration dashboard
+10. Add per-category breakdown
+11. Add per-agent breakdown (if data available)
+
+### Phase 4: Deployment
+12. Create Dockerfile
+13. Add to docker-compose.yml
+14. Document deployment
+
+## Testing
+
+- Manual testing via browser
+- Test auth (valid/invalid credentials)
+- Test decision CRUD flow
+- Test outcome update persists
+
+## Security Considerations
+
+- Basic Auth over HTTPS only in production
+- CSTP token stored as environment variable, not in code
+- No sensitive data in logs
+- Rate limiting (future enhancement)
+
+## Future Enhancements
+
+- OAuth/SSO integration
+- Calibration trend charts (time series)
+- Decision search (semantic via CSTP)
+- Export to CSV
+- Dark mode toggle
+- Mobile responsive design
+
+## Acceptance Criteria
+
+- [ ] Dashboard accessible at configured port
+- [ ] Basic Auth protects all routes
+- [ ] Can view paginated decision list
+- [ ] Can filter by category, stakes, outcome status
+- [ ] Can view decision details
+- [ ] Can submit outcome review
+- [ ] Calibration page shows overall + per-category stats
+- [ ] Runs as Docker container
+- [ ] No JavaScript build step required

--- a/website/specs/f019-list-guardrails.md
+++ b/website/specs/f019-list-guardrails.md
@@ -1,0 +1,56 @@
+# F019: List Guardrails Endpoint
+
+## Context
+Agents currently check guardrails blindly using `checkGuardrails` (or `check` in CLI). They do not know *which* rules are active or what the specific criteria are without reading the raw YAML files on the server (which they might not have access to).
+
+## Requirement
+Expose an API endpoint to list all active guardrails loaded by the CSTP server.
+
+## Specification
+
+### 1. JSON-RPC Method
+**Method:** `cstp.listGuardrails`
+
+**Params:**
+- `scope` (optional, string): Filter by project/scope. If provided, only returns guardrails that apply to this scope (or global ones).
+
+**Returns:**
+```json
+{
+  "guardrails": [
+    {
+      "id": "no-high-stakes-low-confidence",
+      "description": "Prevent high-stakes actions without high confidence",
+      "action": "block",
+      "scope": [],  # Empty = global
+      "conditions": [
+        {"field": "stakes", "operator": "eq", "value": "high"},
+        {"field": "confidence", "operator": "lt", "value": 0.5}
+      ],
+      "requirements": []
+    }
+  ],
+  "count": 1
+}
+```
+
+### 2. Python Service Layer
+Add `list_guardrails` function to `guardrails_service.py`:
+```python
+def list_guardrails(scope: str | None = None) -> list[dict[str, Any]]:
+    """List active guardrails, optionally filtered by scope."""
+```
+
+### 3. CLI Command
+Add `list-guardrails` command to `cstp.py`:
+```bash
+uv run scripts/cstp.py list-guardrails
+# Output:
+# ACTIVE GUARDRAILS (5):
+# - no-high-stakes-low-confidence (block): Prevent high-stakes actions...
+# - require-code-review (block): Production code requires review...
+```
+
+## Security
+- Read-only endpoint.
+- Available to all authenticated agents.

--- a/website/specs/f020-reasoning-traces.md
+++ b/website/specs/f020-reasoning-traces.md
@@ -1,0 +1,63 @@
+# F020: Structured Reasoning Traces
+
+## Context
+Current decision logging captures the `decision` (output) and `context` (input summary), plus high-level `reasons` (categorical). It completely misses the **process**—the step-by-step reasoning chain that led to the decision. 
+
+Recent research (GRPO, DAPO) shows that optimizing the reasoning *process* (step-level value) is critical for high-stakes agentic tasks. To support this, CSTP must capture the reasoning trace.
+
+## Requirement
+Update the `Decision` model and `recordDecision` endpoint to accept a structured reasoning trace.
+
+## Specification
+
+### 1. Schema Update
+Add `trace` field to `Decision` model:
+
+```python
+class ReasoningStep(BaseModel):
+    step: int
+    thought: str  # The reasoning content
+    output: str | None = None  # Optional intermediate result/action
+    confidence: float | None = None  # Step-level confidence (if available)
+    tags: list[str] = []  # e.g. ["planning", "critique", "selection"]
+
+class Decision(BaseModel):
+    # ... existing fields ...
+    trace: list[ReasoningStep] | None = None
+```
+
+### 2. API Update
+**Method:** `cstp.recordDecision`
+
+**Params:**
+- `trace` (optional, list): List of reasoning steps.
+
+**Example Payload:**
+```json
+{
+  "decision": "Use Postgres instead of SQLite",
+  "trace": [
+    {
+      "step": 1,
+      "thought": "Analyzing concurrency requirements...",
+      "output": "High concurrency needed",
+      "tags": ["analysis"]
+    },
+    {
+      "step": 2,
+      "thought": "Comparing SQLite vs Postgres limits...",
+      "output": "SQLite locks on write",
+      "tags": ["comparison"]
+    }
+  ]
+}
+```
+
+### 3. Downstream Usage
+*   **Offline Analysis:** DAPO-style attribution of failure to specific reasoning steps.
+*   **Pattern Detection:** "Steps tagged 'analysis' often missing in failed decisions."
+*   **Debugging:** Replay the agent's thought process.
+
+## Migration
+*   Backward compatible (optional field).
+*   Existing decisions have `trace=None`.

--- a/website/specs/f027-decision-quality.md
+++ b/website/specs/f027-decision-quality.md
@@ -1,0 +1,190 @@
+# F027: Decision Recording Quality for Better Retrieval
+
+**Status:** Draft
+**Author:** Emerson
+**Date:** 2026-02-09
+
+## Problem
+
+Decisions are recorded at an overly operational level, making semantic search return poor results. Typical query distances are 0.5+ (tangential), meaning the pre-decision query step rarely surfaces genuinely useful prior decisions.
+
+### Evidence
+
+```
+Query: "adjusting configuration defaults"
+Top result distance: 0.300 (barely related)
+
+Query: "infrastructure operational fix"  
+Top result distance: 0.234 (wrong decision entirely)
+```
+
+Decision text like *"Increased cron run trigger timeout from 60s to 120s"* is so specific that nothing else in the corpus matches. The embedding space is fragmented because every decision uses unique operational language instead of reusable conceptual patterns.
+
+### Root Cause
+
+1. **Decision text is an activity log, not a knowledge base.** We record *what we did* instead of *what we learned*.
+2. **Auto-extracted bridges parrot the decision text.** Structure and function fields just copy the decision summary and first reason - no real abstraction.
+3. **No cross-cutting metadata.** No tags, themes, or pattern labels to connect decisions across domains.
+4. **No guidance on recording quality.** The `record` command accepts anything - there's no nudge toward the right level of abstraction.
+
+## Solution
+
+Three layers: schema changes (tags + pattern fields), better auto-extraction, and agent-side recording guidance.
+
+### Phase 1: Tags & Pattern Fields (Code Change)
+
+Add two new fields to the decision schema:
+
+```yaml
+# New fields on RecordDecisionRequest
+tags: ["timeout", "defaults", "infrastructure"]  # searchable keywords
+pattern: "Override system defaults when they don't match actual workload"  # abstract pattern
+```
+
+**Schema changes:**
+- `RecordDecisionRequest`: add optional `tags: list[str]` and `pattern: str | None`
+- `decision_service.py`: write tags + pattern to YAML, include in ChromaDB metadata
+- Tags indexed as ChromaDB metadata (filterable): `metadata["tags"] = ",".join(tags)`
+- Pattern embedded alongside decision text for richer semantic matching
+
+**Embedding change:**
+Currently `build_embedding_text()` concatenates decision + context + reasons. Add pattern to this:
+```python
+def build_embedding_text(request):
+    parts = [request.decision]
+    if request.pattern:
+        parts.append(f"Pattern: {request.pattern}")
+    if request.context:
+        parts.append(request.context)
+    # ... reasons
+    return " | ".join(parts)
+```
+
+**Query changes:**
+- `queryDecisions`: support `filters.tags` (match any tag)
+- Tag-based search complements semantic search - find all decisions tagged "timeout" regardless of description wording
+
+**CLI changes (`cstp.py`):**
+```bash
+# Recording with tags and pattern
+cstp.py record \
+  -d "Increased cron trigger timeout from 60s to 120s" \
+  -f 0.90 -c tooling -s low \
+  --tag timeout --tag infrastructure --tag defaults \
+  --pattern "Override system defaults when they don't match actual workload" \
+  -r "empirical:First attempt failed at 60s, succeeded at 120s"
+
+# Querying by tag
+cstp.py query "timeout" --tag timeout
+
+# Pre-decision with tag filter
+cstp.py pre "fixing a timeout issue" --tag timeout
+```
+
+### Phase 2: Smarter Bridge Extraction (Code Change)
+
+Current auto-extraction just copies decision text → structure, first reason → function. Improve to actually abstract:
+
+**Option A: LLM-assisted extraction** (preferred if latency is acceptable)
+- On `recordDecision`, call a lightweight LLM (Gemini Flash) to generate:
+  - `structure`: "What general pattern does this decision represent?"
+  - `function`: "What general class of problem does this solve?"
+- Cache/async - don't block the record response
+
+**Option B: Rule-based extraction** (fallback)
+- Strip specifics (numbers, names, file paths) from decision text for structure
+- Use reason types to infer function category
+- Less accurate but zero latency
+
+**Bridge embedding:**
+- Embed structure and function separately in ChromaDB as additional documents
+- Bridge-side search (`--bridge-side structure/function`) already exists but only works well when bridges contain abstract language
+
+### Phase 3: Recording Quality Score (Code Change)
+
+Add a quality check to `recordDecision` response that scores the recording:
+
+```json
+{
+  "id": "abc123",
+  "quality": {
+    "score": 0.65,
+    "suggestions": [
+      "Decision text is very specific - consider adding a --pattern for the general principle",
+      "No tags provided - tags improve cross-domain retrieval",
+      "Only 1 reason type used - diverse reasons improve robustness (Minsky Ch 18)"
+    ]
+  }
+}
+```
+
+Quality signals:
+- Has pattern? (+0.2)
+- Has tags? (+0.15)
+- Has 2+ distinct reason types? (+0.15)
+- Has explicit bridge (not auto-extracted)? (+0.15)
+- Decision text length > 20 chars? (+0.1)
+- Context provided? (+0.1)
+- Has project context? (+0.1)
+- Deliberation inputs > 0? (+0.05)
+
+### Phase 4: Agent-Side Process Change (No Code)
+
+Update AGENTS.md recording guidance:
+
+```
+When recording decisions, think at TWO levels:
+1. OPERATIONAL: What specifically did you do? (the --decision flag)
+2. CONCEPTUAL: What pattern does this represent? (the --pattern flag)
+
+Bad:  "Increased cron trigger timeout from 60s to 120s"
+Good: "Increased cron trigger timeout from 60s to 120s"
+      --pattern "Override system defaults when they don't match actual workload characteristics"
+      --tag timeout --tag defaults --tag infrastructure
+
+The decision text is WHAT. The pattern is WHY IT MATTERS for future decisions.
+```
+
+## Implementation Plan
+
+| Phase | Effort | Impact | Dependencies |
+|-------|--------|--------|-------------|
+| P1: Tags + Pattern | ~2 hours | High | Schema + CLI + query changes |
+| P2: Better Bridges | ~3 hours | Medium | Gemini API key (already have) |
+| P3: Quality Score | ~1 hour | Medium | P1 (checks for tags/pattern) |
+| P4: Process Change | ~15 min | High | P1 (needs --tag/--pattern flags) |
+
+**Recommended order:** P1 → P4 → P3 → P2
+
+P1 + P4 together give the biggest bang: tags + patterns make the embedding space denser, and the process change ensures I actually use them. P3 provides ongoing feedback. P2 is a nice-to-have if manual bridges aren't enough.
+
+## Files Changed
+
+### P1
+- `a2a/cstp/decision_service.py` - add tags/pattern to schema
+- `a2a/cstp/dispatcher.py` - pass through new fields
+- `a2a/mcp_server.py` - pass through new fields
+- `a2a/cstp/query_service.py` - tag filtering
+- `scripts/cstp.py` - CLI flags
+- `guardrails/deliberation.yaml` - optional quality guardrail
+
+### P2
+- `a2a/cstp/bridge_hook.py` - smarter extraction
+- New: `a2a/cstp/llm_bridge.py` - LLM-assisted bridge generation
+
+### P3
+- `a2a/cstp/decision_service.py` - quality scorer
+- `a2a/cstp/dispatcher.py` - include in response
+
+## Success Metrics
+
+- Average query distance for top-3 results drops from ~0.5 to <0.3
+- % of decisions with tags: >80%
+- % of decisions with pattern: >60%
+- Pre-decision queries actually influence approach (qualitative)
+
+## Open Questions
+
+1. Should tags be free-form or from a controlled vocabulary?
+2. Should the quality score be a guardrail (warn if score < 0.5)?
+3. Is LLM-assisted bridge extraction worth the latency/cost?

--- a/website/specs/f029-task-router.md
+++ b/website/specs/f029-task-router.md
@@ -1,0 +1,85 @@
+# F029: Task Router - Centralized Orchestration Intelligence
+
+## Source
+MIT Media Lab / Google Research: "Towards a Science of Scaling Agent Systems" (Feb 4, 2026)
+
+## Key Research Findings
+- Adding more agents often **degrades** performance
+- Centralized orchestration improves parallel task performance by **81%**
+- Independent multi-agent systems amplify errors by **17.2x** vs **4.4x** for centralized
+- "Tool density" and "decomposability" predict optimal architecture with **87% accuracy**
+
+## Overview
+A task classification and routing service that analyzes incoming tasks and recommends the optimal agent architecture (single agent, centralized swarm, or sequential pipeline). Uses task decomposability and tool density metrics to route decisions.
+
+## API
+
+### New RPC Method: `cstp.classifyTask`
+
+```json
+{
+  "method": "cstp.classifyTask",
+  "params": {
+    "task": "Review PR #42 and update documentation",
+    "tools": ["github", "git", "file_read", "file_write"],
+    "constraints": {
+      "maxAgents": 3,
+      "timeoutSeconds": 300
+    }
+  }
+}
+```
+
+### Response
+
+```json
+{
+  "result": {
+    "architecture": "centralized_parallel",
+    "confidence": 0.87,
+    "reasoning": "Task is decomposable into 2 independent subtasks (code review, doc update) with shared tool dependencies (github, git). Centralized orchestration recommended to contain error amplification.",
+    "subtasks": [
+      {"id": 1, "description": "Code review", "tools": ["github", "git", "file_read"], "type": "parallel"},
+      {"id": 2, "description": "Documentation update", "tools": ["github", "file_write"], "type": "parallel"}
+    ],
+    "metrics": {
+      "toolDensity": 0.67,
+      "decomposability": 0.85,
+      "predictedErrorRate": "4.4x"
+    },
+    "alternatives": [
+      {"architecture": "single_agent", "confidence": 0.72, "tradeoff": "Simpler but 39% slower for parallel subtasks"},
+      {"architecture": "peer_mesh", "confidence": 0.31, "tradeoff": "17.2x error amplification risk"}
+    ]
+  }
+}
+```
+
+## Architecture Types
+
+| Type | When | Error Rate | Best For |
+|------|------|-----------|----------|
+| `single_agent` | Low decomposability, few tools | Baseline | Simple, sequential tasks |
+| `centralized_parallel` | High decomposability, shared tools | 4.4x | PR review + docs, research + writing |
+| `sequential_pipeline` | Ordered dependencies | 2-3x | Build → test → deploy |
+| `peer_mesh` | ⚠️ Rarely recommended | 17.2x | Only when tasks are fully independent |
+
+## Implementation Notes
+
+- Decomposability score: Analyze task description for independent subtask markers ("and", "then", "also")
+- Tool density: `shared_tools / total_tools` across subtasks
+- Store classification decisions in CSTP for calibration
+- Learn from outcomes: Which architectures actually succeeded?
+
+## Integration with OpenClaw
+- `sessions_spawn` could use this to decide single vs multi sub-agent
+- Heartbeat could classify queued tasks before execution
+- Dashboard: Show architecture recommendations with confidence
+
+## Acceptance Criteria
+- [ ] `cstp.classifyTask` RPC method implemented
+- [ ] MCP tool `classifyTask` exposed
+- [ ] Tool density and decomposability metrics calculated
+- [ ] Architecture recommendation with confidence score
+- [ ] Historical outcome tracking (which recommendations worked)
+- [ ] Dashboard view showing task classifications

--- a/website/specs/f030-circuit-breaker-guardrails.md
+++ b/website/specs/f030-circuit-breaker-guardrails.md
@@ -1,0 +1,121 @@
+# F030: Circuit Breaker Guardrails
+
+## Source
+- AutoGPT.net: "How AI Agents Navigate Financial Transactions Autonomously" (Feb 11, 2026)
+- ai16z/elizaOS: Trust-scored autonomous trading with kill switches
+- Existing CSTP guardrails (block/warn/allow)
+
+## Overview
+Evolve guardrails from static rules into dynamic circuit breakers that trip based on real-time failure patterns, automatically escalate, and require explicit reset. Inspired by distributed systems circuit breaker patterns (Hystrix, Resilience4j) applied to agent decision-making.
+
+## Current State
+Guardrails today are stateless: each check is independent. A guardrail doesn't know that the last 5 decisions in this category all failed. It can't detect cascading failures or escalate.
+
+## Circuit Breaker States
+
+```
+CLOSED (normal) → failures exceed threshold → OPEN (blocked)
+    ↑                                            |
+    └── manual reset or cooldown ← HALF_OPEN (probe) ←┘
+```
+
+| State | Behavior |
+|-------|----------|
+| `CLOSED` | Normal operation. Decisions flow through. Failures tracked. |
+| `OPEN` | All decisions in scope blocked. Agent notified. Human alert sent. |
+| `HALF_OPEN` | Single probe decision allowed. Success → CLOSED. Failure → OPEN. |
+
+## API
+
+### New RPC Method: `cstp.getCircuitState`
+
+```json
+{
+  "method": "cstp.getCircuitState",
+  "params": {
+    "scope": "category:tooling"
+  }
+}
+```
+
+### Response
+
+```json
+{
+  "result": {
+    "scope": "category:tooling",
+    "state": "closed",
+    "failureCount": 2,
+    "failureThreshold": 5,
+    "lastFailure": "2026-02-11T12:00:00Z",
+    "windowMs": 3600000,
+    "cooldownMs": 1800000
+  }
+}
+```
+
+### Enhanced `cstp.checkGuardrails` Response
+
+```json
+{
+  "result": {
+    "allowed": false,
+    "violations": [{
+      "guardrail": "category-tooling-breaker",
+      "type": "circuit_breaker",
+      "state": "open",
+      "message": "Circuit breaker OPEN: 5/5 recent tooling decisions failed. Cooldown: 22m remaining.",
+      "failureRate": 1.0,
+      "recentFailures": ["dec_abc", "dec_def", "dec_ghi"],
+      "action": "block",
+      "resetAt": "2026-02-11T13:30:00Z"
+    }]
+  }
+}
+```
+
+## Configuration
+
+```yaml
+circuit_breakers:
+  - scope: "category:tooling"
+    failure_threshold: 5
+    window_ms: 3600000        # 1 hour window
+    cooldown_ms: 1800000      # 30 min cooldown before half-open
+    notify: true               # Alert human when tripped
+    
+  - scope: "stakes:high"
+    failure_threshold: 3       # Lower threshold for high-stakes
+    window_ms: 86400000        # 24 hour window
+    cooldown_ms: 3600000       # 1 hour cooldown
+    notify: true
+    
+  - scope: "agent:code-reviewer"
+    failure_threshold: 4
+    window_ms: 7200000
+    cooldown_ms: 900000
+```
+
+## Scopes
+- `category:<name>` - per decision category
+- `stakes:<level>` - per stakes level
+- `agent:<id>` - per agent identity
+- `tag:<name>` - per decision tag
+- `global` - all decisions
+
+## Integration with Existing Guardrails
+- Circuit breakers are a new guardrail **type** alongside `block`/`warn`/`allow`
+- `cstp.checkGuardrails` automatically checks circuit breaker state
+- Failed decisions (via `cstp.reviewDecision` with `outcome: failure`) increment failure counters
+- Successful outcomes decrement or reset counters
+
+## Acceptance Criteria
+- [ ] Circuit breaker state machine (closed/open/half-open)
+- [ ] Configurable per scope (category, stakes, agent, tag)
+- [ ] Automatic tripping on failure threshold
+- [ ] Cooldown period with half-open probe
+- [ ] Integration with `cstp.checkGuardrails`
+- [ ] Notification on state change (open/closed)
+- [ ] Dashboard view showing breaker states
+- [ ] `cstp.resetCircuit` RPC for manual reset
+- [ ] MCP tool exposure

--- a/website/specs/f031-source-trust-scoring.md
+++ b/website/specs/f031-source-trust-scoring.md
@@ -1,0 +1,126 @@
+# F031: Source Trust Scoring
+
+## Source
+- ai16z/elizaOS: "Trust Scores" to filter social signals for autonomous trading
+- Minsky Ch 18: Parallel bundles - weight evidence by source reliability
+- CSTP calibration: We already track decision accuracy, extend to source tracking
+
+## Overview
+Assign and maintain trust scores for information sources referenced in decisions. When querying past decisions, weight results by the reliability of their sources. Enables agents to distinguish high-signal from low-signal information and make better-calibrated decisions.
+
+## Problem
+Today, all decisions are treated equally in retrieval regardless of where their information came from. A decision based on peer-reviewed research and one based on a random tweet have the same weight. We need source provenance.
+
+## API
+
+### Recording Source Attribution
+
+Enhanced `cstp.recordDecision`:
+
+```json
+{
+  "method": "cstp.recordDecision",
+  "params": {
+    "decision": "Adopted HSM architecture for long-context processing",
+    "confidence": 0.85,
+    "category": "architecture",
+    "stakes": "high",
+    "sources": [
+      {"id": "arxiv:2602.01234", "type": "paper", "name": "Hierarchical Shift Mixing", "url": "https://arxiv.org/abs/2602.01234"},
+      {"id": "mit-media-lab", "type": "institution", "name": "MIT Media Lab"},
+      {"id": "moltbook:user123", "type": "social", "name": "happy_milvus"}
+    ]
+  }
+}
+```
+
+### New RPC Method: `cstp.getSourceTrust`
+
+```json
+{
+  "method": "cstp.getSourceTrust",
+  "params": {
+    "sourceId": "moltbook:user123"
+  }
+}
+```
+
+### Response
+
+```json
+{
+  "result": {
+    "sourceId": "moltbook:user123",
+    "type": "social",
+    "name": "happy_milvus",
+    "trustScore": 0.72,
+    "decisionsReferenced": 8,
+    "successRate": 0.75,
+    "lastReferenced": "2026-02-10T15:00:00Z",
+    "breakdown": {
+      "accuracy": 0.75,
+      "recency": 0.80,
+      "consistency": 0.65
+    }
+  }
+}
+```
+
+### Enhanced Query Results
+
+`cstp.queryDecisions` response includes source trust:
+
+```json
+{
+  "result": {
+    "decisions": [{
+      "id": "dec_abc",
+      "decision": "...",
+      "sourceWeightedScore": 0.91,
+      "sources": [
+        {"id": "arxiv:2602.01234", "trustScore": 0.95},
+        {"id": "moltbook:user123", "trustScore": 0.72}
+      ]
+    }]
+  }
+}
+```
+
+## Trust Score Computation
+
+```
+trustScore = w1 * accuracy + w2 * recency + w3 * consistency
+
+accuracy   = successful_outcomes / total_outcomes (from decisions referencing this source)
+recency    = decay_factor(days_since_last_reference)
+consistency = 1 - stddev(outcome_scores)
+```
+
+Default weights: `w1=0.5, w2=0.2, w3=0.3`
+
+## Source Types
+
+| Type | Example | Initial Trust | Notes |
+|------|---------|--------------|-------|
+| `paper` | arXiv, journals | 0.80 | High baseline, peer-reviewed |
+| `institution` | MIT, Google Research | 0.75 | Track record weighted |
+| `documentation` | Official docs, RFCs | 0.85 | Authoritative |
+| `social` | Moltbook, Twitter | 0.50 | Starts neutral, earned |
+| `agent` | Minski, CodeReviewer | 0.70 | Track by agent ID |
+| `empirical` | Own experiments | 0.90 | Direct evidence |
+
+## Use Cases
+- **Moltbook engagement:** Weight posts by author trust score before engaging
+- **Research briefings:** Flag stories from low-trust sources
+- **Decision retrieval:** Surface high-trust decisions first
+- **Agent collaboration:** Track which sub-agents give reliable reviews
+
+## Acceptance Criteria
+- [ ] `sources` field on `cstp.recordDecision`
+- [ ] `cstp.getSourceTrust` RPC method
+- [ ] `cstp.listSources` RPC method (with filters)
+- [ ] Trust score computation from decision outcomes
+- [ ] Source-weighted query results in `cstp.queryDecisions`
+- [ ] MCP tools exposed
+- [ ] Dashboard: Source trust leaderboard
+- [ ] Automatic trust decay for stale sources

--- a/website/specs/f032-error-amplification-tracking.md
+++ b/website/specs/f032-error-amplification-tracking.md
@@ -1,0 +1,138 @@
+# F032: Error Amplification Tracking
+
+## Source
+MIT Media Lab / Google Research: "Towards a Science of Scaling Agent Systems" (Feb 4, 2026)
+- Independent multi-agent: **17.2x** error amplification
+- Centralized multi-agent: **4.4x** error amplification
+- Single agent: **1x** baseline
+
+## Overview
+Track error propagation chains across multi-agent decision sequences. When a sub-agent's decision leads to a downstream failure, trace the causal chain back to identify amplification patterns. Enables the system to detect when agent collaboration is making things worse, not better.
+
+## Problem
+Today we track individual decision outcomes but not causal chains. If CodeReviewer approves a PR, DocsAgent updates docs based on it, and the feature turns out broken - we mark each decision independently. We can't see that the review failure **amplified** into a docs failure.
+
+## API
+
+### Decision Lineage
+
+Enhanced `cstp.recordDecision`:
+
+```json
+{
+  "method": "cstp.recordDecision",
+  "params": {
+    "decision": "Updated docs based on PR #42 review",
+    "confidence": 0.85,
+    "parentDecisionId": "dec_abc",
+    "agentId": "docs-agent",
+    "context": "CodeReviewer approved PR #42 (dec_abc). Updating docs accordingly."
+  }
+}
+```
+
+### New RPC Method: `cstp.getAmplificationChain`
+
+```json
+{
+  "method": "cstp.getAmplificationChain",
+  "params": {
+    "decisionId": "dec_abc"
+  }
+}
+```
+
+### Response
+
+```json
+{
+  "result": {
+    "root": {
+      "id": "dec_abc",
+      "agent": "code-reviewer",
+      "decision": "Approved PR #42",
+      "outcome": "failure"
+    },
+    "chain": [
+      {
+        "id": "dec_def",
+        "agent": "docs-agent",
+        "decision": "Updated docs for PR #42",
+        "outcome": "failure",
+        "amplification": "inherited"
+      },
+      {
+        "id": "dec_ghi",
+        "agent": "main",
+        "decision": "Merged PR #42",
+        "outcome": "failure",
+        "amplification": "cascaded"
+      }
+    ],
+    "metrics": {
+      "chainLength": 3,
+      "amplificationFactor": 3.0,
+      "affectedAgents": ["code-reviewer", "docs-agent", "main"],
+      "architecture": "sequential_pipeline"
+    }
+  }
+}
+```
+
+### New RPC Method: `cstp.getAmplificationStats`
+
+```json
+{
+  "method": "cstp.getAmplificationStats",
+  "params": {
+    "windowDays": 30
+  }
+}
+```
+
+### Response
+
+```json
+{
+  "result": {
+    "averageAmplification": 2.3,
+    "maxChainLength": 5,
+    "totalChains": 12,
+    "byArchitecture": {
+      "single_agent": {"count": 45, "avgAmplification": 1.0},
+      "sequential_pipeline": {"count": 8, "avgAmplification": 2.8},
+      "centralized_parallel": {"count": 4, "avgAmplification": 1.6}
+    },
+    "topAmplifiers": [
+      {"agent": "code-reviewer", "rootFailures": 3, "totalDownstream": 7}
+    ],
+    "recommendation": "CodeReviewer decisions are the most common root of amplification chains. Consider adding a second reviewer for high-stakes PRs."
+  }
+}
+```
+
+## Data Model
+
+```yaml
+# Added to decision records
+parent_decision_id: "dec_abc"   # Decision this depends on
+agent_id: "docs-agent"          # Which agent made this
+chain_id: "chain_001"           # Group linked decisions
+```
+
+## Integration
+- When `cstp.reviewDecision` marks a decision as failed, scan for child decisions
+- Automatically propagate "inherited failure" markers down the chain
+- Circuit breakers (F030) can trip based on amplification factor, not just failure count
+- Task router (F029) can use historical amplification data to avoid bad architectures
+
+## Acceptance Criteria
+- [ ] `parentDecisionId` field on `cstp.recordDecision`
+- [ ] `agentId` field on `cstp.recordDecision`
+- [ ] Chain detection on failure review
+- [ ] `cstp.getAmplificationChain` RPC method
+- [ ] `cstp.getAmplificationStats` RPC method
+- [ ] Amplification factor calculation
+- [ ] Dashboard: Chain visualization (Mermaid)
+- [ ] MCP tools exposed
+- [ ] Integration with circuit breakers (F030)

--- a/website/specs/f033-censor-layer.md
+++ b/website/specs/f033-censor-layer.md
@@ -1,9 +1,10 @@
-# F027: Censor Layer - Proactive Failure Pattern Warnings
+# F033: Censor Layer - Proactive Failure Pattern Warnings
 
 > **Status:** Proposed
 > **Source:** Minsky Society of Mind Ch 27 (Censors and Jokes)
 > **Depends on:** Sufficient failure data (~10+ failed/partial decisions)
 > **Priority:** Low (blocked by data)
+> **Note:** Previously numbered F027; renumbered to avoid conflict with shipped F027 (Decision Quality)
 
 ## Concept
 

--- a/website/specs/f034-decomposed-confidence.md
+++ b/website/specs/f034-decomposed-confidence.md
@@ -1,9 +1,10 @@
-# F028: Decomposed Confidence - Per-Reason Confidence Weights
+# F034: Decomposed Confidence - Per-Reason Confidence Weights
 
 > **Status:** Proposed
 > **Source:** Minsky Society of Mind Ch 28 (The Mind and the World, section 28.3)
 > **Depends on:** Schema change across dataclass, YAML, CLI, MCP
 > **Priority:** Medium (addresses known calibration issue)
+> **Note:** Previously numbered F028; renumbered to avoid conflict with shipped F028 (Reasoning Capture)
 
 ## Problem
 

--- a/website/specs/f035-semantic-state-transfer.md
+++ b/website/specs/f035-semantic-state-transfer.md
@@ -1,0 +1,99 @@
+# F035: Semantic State Transfer
+
+> **Status:** Proposed
+> **Target:** v1.0.0 (Multi-Agent Cognition Network)
+> **Source:** Cisco Outshift Internet of Cognition, README roadmap
+
+## Overview
+Export and import decision context in a portable, self-contained format. Enables an agent to package its decision history, reasoning traces, and relevant guardrails into a transferable bundle that another agent - potentially on a different platform - can ingest and use.
+
+## Problem
+Today, decision intelligence is locked inside a single CSTP server instance. If Agent A works on a problem and Agent B needs to continue, B must either query A's server (requires network access) or start from scratch. There's no offline, portable way to transfer cognitive context.
+
+## Concept
+
+### Export: Decision Context Bundle
+```json
+{
+  "format": "cstp-bundle/v1",
+  "exported_at": "2026-02-11T20:00:00Z",
+  "agent": "emerson",
+  "scope": {
+    "project": "tfatykhov/cognition-agent-decisions",
+    "tags": ["architecture"],
+    "date_range": ["2026-02-01", "2026-02-11"]
+  },
+  "decisions": [
+    {
+      "id": "dec_abc",
+      "decision": "...",
+      "confidence": 0.85,
+      "reasons": [...],
+      "deliberation": {...},
+      "bridge": {"structure": "...", "function": "..."},
+      "outcome": "success",
+      "related": ["dec_def"]
+    }
+  ],
+  "guardrails": [...],
+  "patterns": {
+    "calibration": {...},
+    "anti_patterns": [...]
+  }
+}
+```
+
+### Import: Context Ingestion
+Receiving agent ingests the bundle into its own decision store, tagged with provenance:
+```json
+{
+  "source_agent": "emerson",
+  "imported_at": "2026-02-11T21:00:00Z",
+  "trust_score": 0.85
+}
+```
+
+## API
+
+### `cstp.exportBundle`
+```json
+{
+  "method": "cstp.exportBundle",
+  "params": {
+    "scope": {
+      "project": "owner/repo",
+      "tags": ["architecture"],
+      "dateRange": {"from": "2026-02-01", "to": "2026-02-11"}
+    },
+    "includeDeliberation": true,
+    "includeGuardrails": true,
+    "format": "json"
+  }
+}
+```
+
+### `cstp.importBundle`
+```json
+{
+  "method": "cstp.importBundle",
+  "params": {
+    "bundle": {...},
+    "trustScore": 0.85,
+    "conflictResolution": "keep_both"
+  }
+}
+```
+
+## Integration
+- Builds on F031 (Source Trust Scoring) for trust on imported decisions
+- Enables F035+ features (reasoning continuity, collective innovation)
+- Protocol-agnostic: works over SSTP, file transfer, or API
+
+## Acceptance Criteria
+- [ ] `cstp.exportBundle` RPC method
+- [ ] `cstp.importBundle` RPC method
+- [ ] MCP tools exposed
+- [ ] Provenance tracking on imported decisions
+- [ ] Selective export (by project, tags, date range)
+- [ ] Conflict resolution strategies (keep_both, prefer_local, prefer_remote)
+- [ ] Bundle validation and schema versioning

--- a/website/specs/f036-reasoning-continuity.md
+++ b/website/specs/f036-reasoning-continuity.md
@@ -1,0 +1,94 @@
+# F036: Reasoning Continuity
+
+> **Status:** Proposed
+> **Target:** v1.0.0 (Multi-Agent Cognition Network)
+> **Source:** README roadmap, Minsky Society of Mind (teaching-selves)
+> **Depends on:** F035 (Semantic State Transfer), F023 (Deliberation Traces)
+
+## Overview
+Enable one agent to "resume" another agent's decision thread. When Agent A starts reasoning about a problem but doesn't finish (session ends, context limits hit, or a specialist is needed), Agent B can pick up exactly where A left off - with full access to A's deliberation trace, query results, and partial conclusions.
+
+## Problem
+Today, when a sub-agent is spawned for a task (e.g., code review), it gets a task description but none of the parent agent's cognitive context. The reviewer doesn't know what decisions led to the code, what alternatives were considered, or what guardrails were checked. It starts cold.
+
+## Concept
+
+### Decision Thread
+A thread is a chain of linked decisions, deliberation traces, and thoughts:
+```
+Thread: "PR #94 Architecture"
+├── dec_001: "Plan: create feature specs" (emerson)
+│   ├── thought: "Checking MIT scaling research..."
+│   ├── thought: "4 features map well to findings"
+│   └── deliberation: [query results, guardrail checks]
+├── dec_002: "Code review PR #94" (code-reviewer)
+│   └── continues_thread: dec_001
+└── dec_003: "Update docs for PR #94" (docs-agent)
+    └── continues_thread: dec_001
+```
+
+### Resume Protocol
+```json
+{
+  "method": "cstp.resumeThread",
+  "params": {
+    "threadId": "thread_pr94",
+    "agentId": "code-reviewer",
+    "context": "Continuing architecture review started by emerson"
+  }
+}
+```
+
+### Response
+```json
+{
+  "result": {
+    "thread": {
+      "id": "thread_pr94",
+      "title": "PR #94 Architecture",
+      "startedBy": "emerson",
+      "decisions": [...],
+      "openQuestions": ["Should F030 integrate with F032?"],
+      "lastState": {
+        "conclusion": "4 specs created, pending review",
+        "confidence": 0.85,
+        "nextSteps": ["Code review", "Documentation"]
+      }
+    }
+  }
+}
+```
+
+## API
+
+### `cstp.createThread`
+Group related decisions into a named thread.
+
+### `cstp.resumeThread`
+Load full thread context for continuation by another agent.
+
+### `cstp.getThreadStatus`
+Check thread state: active, paused, completed, blocked.
+
+### Enhanced `cstp.recordDecision`
+```json
+{
+  "threadId": "thread_pr94",
+  "continuesDecision": "dec_001"
+}
+```
+
+## Integration
+- Uses F023 deliberation traces as the cognitive state to transfer
+- Uses F032 error amplification to track chain health
+- Uses F035 bundles as the serialization format
+- Enables handoffs between specialized agents (architect -> reviewer -> docs)
+
+## Acceptance Criteria
+- [ ] `cstp.createThread` RPC method
+- [ ] `cstp.resumeThread` RPC method
+- [ ] `cstp.getThreadStatus` RPC method
+- [ ] Thread linking on `cstp.recordDecision`
+- [ ] Full deliberation context loaded on resume
+- [ ] MCP tools exposed
+- [ ] Dashboard: Thread timeline visualization

--- a/website/specs/f037-collective-innovation.md
+++ b/website/specs/f037-collective-innovation.md
@@ -1,0 +1,106 @@
+# F037: Collective Innovation Protocol
+
+> **Status:** Proposed
+> **Target:** v1.0.0 (Multi-Agent Cognition Network)
+> **Source:** README roadmap, Cisco Outshift IoC
+> **Depends on:** F036 (Reasoning Continuity), F031 (Source Trust Scoring)
+
+## Overview
+Enable multiple agents to collaboratively reason about novel problems. Instead of one agent making a decision in isolation, a group of agents contribute perspectives, challenge assumptions, and converge on a solution - with the full deliberation captured as a structured multi-agent trace.
+
+## Problem
+Current CSTP is single-agent: one agent queries, checks guardrails, and records. Even with sub-agents, each decides independently. There's no protocol for structured multi-agent deliberation where agents explicitly build on, challenge, or refine each other's reasoning.
+
+## Concept
+
+### Deliberation Session
+```json
+{
+  "method": "cstp.openDeliberation",
+  "params": {
+    "topic": "Should we adopt HSM architecture for long-context processing?",
+    "category": "architecture",
+    "stakes": "high",
+    "participants": ["emerson", "minski", "code-reviewer"],
+    "protocol": "structured_debate"
+  }
+}
+```
+
+### Contribution Types
+| Type | Purpose | Example |
+|------|---------|---------|
+| `propose` | Initial proposal | "We should use HSM because..." |
+| `support` | Add supporting evidence | "MIT research confirms 81% improvement" |
+| `challenge` | Raise concerns | "HSM hasn't been tested at scale" |
+| `synthesize` | Combine perspectives | "HSM for parallel, attention for sequential" |
+| `vote` | Signal position | Confidence-weighted agreement/disagreement |
+
+### Deliberation Flow
+```
+1. OPEN: Emerson proposes topic
+2. PROPOSE: Emerson: "Adopt HSM for long-context" (confidence: 0.80)
+3. SUPPORT: Minski: "MIT data supports this" (confidence: 0.85)
+4. CHALLENGE: CodeReviewer: "No production benchmarks" (confidence: 0.70)
+5. SYNTHESIZE: Emerson: "HSM for parallel + attention fallback" (confidence: 0.82)
+6. VOTE: All agents signal confidence
+7. CLOSE: Decision recorded with full multi-agent trace
+```
+
+### Resolution
+```json
+{
+  "result": {
+    "decision": "Adopt HSM with attention fallback for sequential tasks",
+    "confidence": 0.82,
+    "consensusType": "convergent",
+    "participantVotes": {
+      "emerson": {"position": "support", "confidence": 0.85},
+      "minski": {"position": "support", "confidence": 0.80},
+      "code-reviewer": {"position": "conditional_support", "confidence": 0.70}
+    },
+    "dissent": ["No production benchmarks yet - revisit after pilot"]
+  }
+}
+```
+
+## Protocols
+
+### Structured Debate
+Round-robin: propose -> support/challenge -> synthesize -> vote. Best for high-stakes architectural decisions.
+
+### Advisory Panel
+One agent proposes, others advise. Proposer makes final call. Best for decisions with a clear owner.
+
+### Consensus
+All agents must agree above threshold. Best for shared-impact decisions.
+
+## API
+
+### `cstp.openDeliberation`
+Start a multi-agent deliberation session.
+
+### `cstp.contribute`
+Add a contribution (propose/support/challenge/synthesize/vote).
+
+### `cstp.closeDeliberation`
+Finalize and record the collective decision.
+
+### `cstp.getDeliberation`
+Retrieve full deliberation history.
+
+## Integration
+- F031 Source Trust weights each agent's contribution by their track record
+- F032 Error Amplification tracks whether collective decisions outperform solo ones
+- F036 Reasoning Continuity enables async deliberation across sessions
+- F030 Circuit Breakers can trigger mandatory deliberation for high-stakes decisions
+
+## Acceptance Criteria
+- [ ] `cstp.openDeliberation` RPC method
+- [ ] `cstp.contribute` RPC method (all 5 contribution types)
+- [ ] `cstp.closeDeliberation` with consensus calculation
+- [ ] `cstp.getDeliberation` RPC method
+- [ ] Multi-agent decision trace stored in CSTP
+- [ ] MCP tools exposed
+- [ ] Dashboard: Deliberation timeline view
+- [ ] At least 3 resolution protocols (debate, advisory, consensus)

--- a/website/specs/f038-cross-agent-federation.md
+++ b/website/specs/f038-cross-agent-federation.md
@@ -1,0 +1,153 @@
+# F038: Cross-Agent Federation
+
+> **Status:** Proposed
+> **Target:** v1.0.0 (Multi-Agent Cognition Network)
+> **Source:** README roadmap, docs/research/FEDERATION.md, Cisco Outshift IoC
+> **Depends on:** F035 (Semantic State Transfer), F031 (Source Trust Scoring)
+
+## Overview
+Enable multiple independent CSTP server instances to discover each other, share decisions and guardrails, and query across organizational boundaries. Each agent maintains its own decision store but can selectively federate with peers - sharing what's appropriate while keeping sensitive decisions private.
+
+## Problem
+Current architecture is hub-and-spoke: all agents connect to one CSTP server. This works for a single user's agents but breaks down for:
+- Multi-organization collaboration (each org runs their own CSTP)
+- Air-gapped environments (no shared network)
+- Specialized policy domains (security team has different guardrails than dev team)
+- Geographic distribution (latency to central server)
+
+## Architecture
+
+### Federation Topology
+```
+┌──────────────────┐     ┌──────────────────┐
+│  Org A CSTP      │     │  Org B CSTP      │
+│  ┌────┐ ┌────┐   │     │  ┌────┐ ┌────┐   │
+│  │AgA1│ │AgA2│   │◄───►│  │AgB1│ │AgB2│   │
+│  └────┘ └────┘   │     │  └────┘ └────┘   │
+│  Guardrails: orgA│     │  Guardrails: orgB│
+└──────────────────┘     └──────────────────┘
+         ▲                        ▲
+         │    ┌──────────────┐    │
+         └───►│ Federation   │◄───┘
+              │ Registry     │
+              └──────────────┘
+```
+
+### Trust Model
+```json
+{
+  "peer": {
+    "id": "cstp://orgb.example.com",
+    "name": "Org B CSTP",
+    "trustLevel": "verified",
+    "permissions": {
+      "queryDecisions": true,
+      "shareGuardrails": true,
+      "importDecisions": false,
+      "viewDeliberation": false
+    },
+    "publicKey": "...",
+    "verifiedAt": "2026-02-11T20:00:00Z"
+  }
+}
+```
+
+### Trust Levels
+| Level | Meaning | Permissions |
+|-------|---------|-------------|
+| `anonymous` | Unknown peer | Query only (public decisions) |
+| `verified` | Identity confirmed | Query + shared guardrails |
+| `trusted` | Established relationship | Full query + import + deliberation |
+| `internal` | Same organization | Everything |
+
+## API
+
+### `cstp.registerPeer`
+```json
+{
+  "method": "cstp.registerPeer",
+  "params": {
+    "url": "cstp://orgb.example.com",
+    "trustLevel": "verified",
+    "sharedToken": "..."
+  }
+}
+```
+
+### `cstp.federatedQuery`
+```json
+{
+  "method": "cstp.federatedQuery",
+  "params": {
+    "query": "database migration patterns",
+    "scope": "federation",
+    "peers": ["cstp://orgb.example.com"],
+    "minTrustLevel": "verified"
+  }
+}
+```
+
+### Response
+```json
+{
+  "result": {
+    "local": [{"id": "dec_abc", "source": "local", ...}],
+    "federated": [
+      {
+        "id": "dec_xyz",
+        "source": "cstp://orgb.example.com",
+        "trustLevel": "verified",
+        "trustScore": 0.78,
+        "decision": "Used event sourcing for migration",
+        "redacted": ["context", "deliberation"]
+      }
+    ]
+  }
+}
+```
+
+### `cstp.listPeers`
+List registered federation peers with health status.
+
+### `cstp.syncGuardrails`
+Import/export shared guardrail policies between peers.
+
+## Discovery
+
+### Static Registry
+```yaml
+federation:
+  peers:
+    - url: cstp://peer1.example.com
+      token: "..."
+      trust: verified
+```
+
+### Dynamic (Future)
+- DNS-SD for local network discovery
+- Central registry for internet-scale federation
+- Agent card exchange (A2A protocol)
+
+## Privacy Controls
+- **Decision visibility:** public / org / private per decision
+- **Redaction:** Strip context/deliberation from federated results
+- **Guardrail scoping:** org-level vs federated-level policies
+- **Audit trail:** All federated queries logged
+
+## Integration
+- F031 Source Trust: Federated results weighted by peer trust
+- F035 State Transfer: Bundle format for federation sync
+- F037 Collective Innovation: Cross-org deliberation sessions
+- F030 Circuit Breakers: Federation-wide circuit breakers for coordinated safety
+
+## Acceptance Criteria
+- [ ] `cstp.registerPeer` RPC method
+- [ ] `cstp.federatedQuery` RPC method
+- [ ] `cstp.listPeers` RPC method
+- [ ] `cstp.syncGuardrails` RPC method
+- [ ] Trust level enforcement on federated queries
+- [ ] Privacy controls (visibility, redaction)
+- [ ] Peer health monitoring
+- [ ] MCP tools exposed
+- [ ] Dashboard: Federation network view
+- [ ] Static registry configuration

--- a/website/specs/f039-protocol-stack.md
+++ b/website/specs/f039-protocol-stack.md
@@ -1,0 +1,140 @@
+# F039: Cognition Protocol Stack (SSTP/CSTP/LSTP)
+
+> **Status:** Proposed
+> **Target:** v1.0.0+ (Multi-Agent Cognition Network)
+> **Source:** Cisco Outshift Internet of Cognition, README roadmap
+
+## Overview
+Implement the three-layer protocol stack from Cisco Outshift's Internet of Cognition architecture. Each layer optimizes for different trade-offs between human auditability, bandwidth efficiency, and inference fidelity.
+
+## Protocol Layers
+
+### SSTP - Semantic State Transfer Protocol
+**Layer:** Semantic (human-auditable)
+**Current status:** Partially implemented as CSTP JSON-RPC
+
+The highest-level protocol. Decisions, guardrails, and reasoning are expressed in natural language with structured metadata. Fully auditable by humans.
+
+**Use cases:**
+- Cross-vendor strategic coordination
+- Policy governance and compliance
+- Human-in-the-loop decision review
+- Audit trails
+
+**Format:** JSON-RPC with natural language fields (what we have today)
+
+```json
+{
+  "decision": "Adopt HSM architecture for long-context processing",
+  "confidence": 0.85,
+  "reasons": [{"type": "analysis", "text": "MIT research shows 81% improvement"}],
+  "bridge": {
+    "structure": "Architecture pattern selection",
+    "function": "Optimize long-context inference performance"
+  }
+}
+```
+
+### CSTP - Compressed State Transfer Protocol
+**Layer:** Compressed (bandwidth-efficient)
+
+Decisions and context compressed into abstract feature representations. Reduces payload by 10-50x while preserving semantic meaning. Useful for edge deployments, high-frequency decision streams, and WAN communication.
+
+**Use cases:**
+- Edge agents with limited bandwidth
+- High-frequency trading/monitoring decisions
+- WAN federation between distant agents
+- Mobile/IoT agent decision sync
+
+**Format:** Compressed feature vectors + minimal metadata
+
+```json
+{
+  "id": "dec_abc",
+  "embedding": [0.12, -0.45, ...],
+  "confidence": 0.85,
+  "category_idx": 3,
+  "outcome_idx": 1,
+  "timestamp": 1707681600
+}
+```
+
+### LSTP - Latent State Transfer Protocol
+**Layer:** Latent (highest fidelity)
+
+Raw latent representations for maximum inference continuity. One agent's internal state can be directly loaded by another agent with compatible architecture. Closest to "transferring a mind state."
+
+**Use cases:**
+- Local cluster agents with shared model architecture
+- High-fidelity reasoning continuity (no information loss)
+- Agent cloning / forking
+- Research and experimentation
+
+**Format:** Serialized tensor state + model metadata
+
+```json
+{
+  "id": "state_abc",
+  "model": "gemini-3-pro",
+  "format": "safetensors",
+  "layers": ["reasoning_head", "decision_context"],
+  "compatible_models": ["gemini-3-pro", "gemini-3-flash"],
+  "data": "<base64 tensor data>"
+}
+```
+
+## Protocol Selection
+
+| Factor | SSTP | CSTP | LSTP |
+|--------|------|------|------|
+| Human auditability | Full | Partial | None |
+| Bandwidth | High | Low | Very High |
+| Fidelity | Good | Moderate | Perfect |
+| Cross-vendor | Yes | Yes | No (model-dependent) |
+| Latency | Medium | Low | High (transfer) / Low (resume) |
+
+### Auto-Selection Logic
+```json
+{
+  "method": "cstp.negotiateProtocol",
+  "params": {
+    "peer": "cstp://peer.example.com",
+    "constraints": {
+      "auditRequired": true,
+      "maxBandwidthKbps": 100,
+      "modelCompatible": false
+    }
+  }
+}
+```
+
+## Implementation Priority
+1. **SSTP** - Already partially implemented as current CSTP JSON-RPC. Formalize the spec.
+2. **CSTP (compressed)** - Add embedding-only query mode and compressed bundle format.
+3. **LSTP** - Research phase. Requires compatible model architectures.
+
+## API
+
+### `cstp.negotiateProtocol`
+Auto-negotiate the best protocol layer for a given peer connection.
+
+### `cstp.exportCompressed`
+Export decisions in CSTP compressed format.
+
+### `cstp.importCompressed`
+Import compressed decision bundles.
+
+## Integration
+- F035 State Transfer: Bundles can be serialized at any protocol layer
+- F038 Federation: Protocol negotiation between federated peers
+- F036 Reasoning Continuity: LSTP enables highest-fidelity thread resumption
+
+## Acceptance Criteria
+- [ ] SSTP formalized (current JSON-RPC spec documented as SSTP)
+- [ ] CSTP compressed format defined
+- [ ] `cstp.negotiateProtocol` RPC method
+- [ ] `cstp.exportCompressed` / `cstp.importCompressed`
+- [ ] Embedding-only query mode for CSTP layer
+- [ ] LSTP research document with feasibility analysis
+- [ ] Protocol selection matrix in documentation
+- [ ] MCP tools for protocol operations

--- a/website/specs/f040-task-decision-graph.md
+++ b/website/specs/f040-task-decision-graph.md
@@ -1,0 +1,62 @@
+# F040: Task-Decision Graph
+
+**Status:** Proposed
+**Priority:** Medium
+**Inspired by:** Beads (steveyegge/beads) - dependency-aware graph issue tracker for AI agents
+
+## Problem
+
+CSTP records decisions but has no concept of executable tasks. Agents decide "use approach X" but there's no structured way to track the work breakdown, execution status, or link outcomes back to the originating decision. This gap means:
+
+- Decisions float disconnected from their implementation
+- No way to ask "what work did this decision generate?"
+- Outcome reviews require manual correlation between decisions and completed work
+
+## Solution
+
+Add a task layer to CSTP where decisions can spawn trackable tasks with dependencies, forming a decision-task-outcome loop.
+
+### Core Concepts
+
+- **Decision → Tasks:** A decision can spawn one or more tasks
+- **Task Dependencies:** Tasks can block, relate to, or supersede other tasks
+- **Hierarchical IDs:** Tasks use dot-notation (dec-a3f8.1, dec-a3f8.1.1) for epic/task/subtask hierarchy
+- **Outcome Loop:** Task completion triggers decision outcome review
+
+### Data Model
+
+```python
+class Task:
+    id: str                    # Hash-based, e.g. "task-a3f8"
+    decision_id: str           # Parent decision
+    title: str
+    status: TaskStatus         # pending, in_progress, done, blocked
+    assignee: str | None       # Agent ID
+    dependencies: list[TaskLink]  # blocks, relates_to, supersedes
+    subtasks: list[str]        # Child task IDs
+    created_at: datetime
+    completed_at: datetime | None
+```
+
+### API
+
+```
+cstp.createTask      - Create task linked to a decision
+cstp.updateTask      - Update task status
+cstp.listTasks       - List tasks (by decision, status, assignee)
+cstp.getTaskGraph    - Get dependency graph for a decision
+```
+
+## Phases
+
+1. **P1:** Task CRUD + decision linking
+2. **P2:** Dependency graph with blocking detection
+3. **P3:** Hierarchical subtasks
+4. **P4:** Auto-trigger outcome review on task completion
+
+## Integration Points
+
+- F027 (Decision Quality): Tasks provide concrete evidence for outcome reviews
+- F028 (Reasoning Capture): Thoughts can reference specific tasks
+- F030 (Circuit Breakers): Task failure patterns can trip breakers
+- F038 (Federation): Tasks can be assigned to remote agents

--- a/website/specs/f041-memory-compaction.md
+++ b/website/specs/f041-memory-compaction.md
@@ -1,0 +1,69 @@
+# F041: Memory Compaction
+
+**Status:** Proposed
+**Priority:** High
+**Inspired by:** Beads (steveyegge/beads) - semantic "memory decay" that summarizes old closed tasks
+
+## Problem
+
+As decision count grows (currently 182+), loading full decision history into agent context becomes expensive and noisy. Agents waste context window on resolved decisions that could be summarized. There's no mechanism to distinguish between "active knowledge" and "historical record."
+
+## Solution
+
+Implement semantic compaction that progressively summarizes old, resolved decisions while preserving their calibration value and key learnings.
+
+### Compaction Levels
+
+| Level | Age | Content |
+|-------|-----|---------|
+| **Full** | < 7 days | Complete decision with all reasoning, traces, context |
+| **Summary** | 7-30 days | Decision text, outcome, key pattern, confidence vs actual |
+| **Digest** | 30-90 days | One-line summary grouped by category |
+| **Wisdom** | 90+ days | Statistical aggregates + extracted principles |
+
+### Compaction Process
+
+1. **Trigger:** Scheduled (daily) or on-demand via API
+2. **Summarize:** LLM-generated summary preserving decision essence
+3. **Preserve:** Raw data always kept in storage; compaction only affects query responses
+4. **Protect:** Decisions with `preserve: true` or unreviewed outcomes skip compaction
+
+### API
+
+```
+cstp.compact          - Run compaction cycle
+cstp.getCompacted     - Get decisions at appropriate compaction level
+cstp.setPreserve      - Mark decision as never-compact
+cstp.getWisdom        - Get category-level distilled principles
+```
+
+### Example Output
+
+**Wisdom level (90+ days, architecture category):**
+```json
+{
+  "category": "architecture",
+  "decisions": 45,
+  "success_rate": 0.93,
+  "key_principles": [
+    "Manual type resolution beats annotation magic (3 confirmations)",
+    "Search-first prevents duplicate work (8 confirmations)",
+    "Parallel independent reasons > single strong argument (5 confirmations)"
+  ],
+  "common_failure_mode": "Skipping pre-decision query (4 failures)"
+}
+```
+
+## Phases
+
+1. **P1:** Time-based compaction levels in query responses
+2. **P2:** LLM-generated summaries for summary/digest levels
+3. **P3:** Wisdom extraction - cross-decision principle mining
+4. **P4:** Configurable compaction policies per agent/category
+
+## Integration Points
+
+- F002 (Query): Compaction level affects query response size
+- F009 (Calibration): Compacted decisions retain calibration data
+- F024 (Bridge Definitions): Bridge summaries survive compaction
+- F034 (Decomposed Confidence): Confidence components inform compaction priority

--- a/website/specs/f042-decision-dependencies.md
+++ b/website/specs/f042-decision-dependencies.md
@@ -1,0 +1,79 @@
+# F042: Decision Dependency Graph
+
+**Status:** Proposed
+**Priority:** Medium
+**Inspired by:** Beads (steveyegge/beads) - graph links with relates_to, duplicates, supersedes, blocks
+
+## Problem
+
+CSTP's `related_to` field is flat - it lists similar decisions found during query but doesn't capture semantic relationships. There's no way to express:
+
+- "Decision B was blocked until Decision A resolved"
+- "Decision C supersedes Decision B (we changed our mind)"
+- "Decision D duplicates Decision E (same choice, different context)"
+
+This limits the decision history to a searchable list rather than a navigable knowledge graph.
+
+## Solution
+
+Add typed dependency links between decisions, enabling graph traversal and relationship-aware queries.
+
+### Link Types
+
+| Type | Meaning | Example |
+|------|---------|---------|
+| `blocks` | A must resolve before B can proceed | "Choose DB" blocks "Design schema" |
+| `supersedes` | B replaces A (A is now obsolete) | "Use HTMX" supersedes "Use React" |
+| `duplicates` | Same decision in different context | Two agents independently chose the same approach |
+| `relates_to` | Loosely connected (existing) | Topically similar decisions |
+| `contradicts` | B conflicts with A | Opposing approaches in different subsystems |
+| `refines` | B narrows/improves A | "Use PostgreSQL" refines "Use SQL database" |
+
+### Data Model
+
+```python
+class DecisionLink:
+    source_id: str
+    target_id: str
+    link_type: LinkType
+    created_at: datetime
+    created_by: str        # Agent that created the link
+    context: str | None    # Why this link exists
+```
+
+### API
+
+```
+cstp.linkDecisions    - Create typed link between decisions
+cstp.getGraph         - Get decision graph (optional: depth, link_types)
+cstp.findBlocked      - Decisions blocked by unresolved dependencies
+cstp.getChain         - Follow supersedes chain to current decision
+cstp.findContradictions - Detect conflicting active decisions
+```
+
+### Graph Queries
+
+```
+# "What's the current active decision for database choice?"
+cstp.getChain("dec-001")  # Follows supersedes links to latest
+
+# "Are there any contradictions in my architecture decisions?"
+cstp.findContradictions(category="architecture")
+
+# "What decisions are blocked right now?"
+cstp.findBlocked(status="pending")
+```
+
+## Phases
+
+1. **P1:** Link CRUD + basic graph storage
+2. **P2:** Supersedes chains + contradiction detection
+3. **P3:** Blocking/unblocking with notifications
+4. **P4:** Graph visualization in dashboard (F011)
+
+## Integration Points
+
+- F024 (Bridge Definitions): Links informed by bridge similarity
+- F027 (Decision Quality): Link density as quality signal
+- F030 (Circuit Breakers): Contradiction count as breaker trigger
+- F040 (Task Graph): Tasks inherit decision dependencies

--- a/website/specs/f043-distributed-merge.md
+++ b/website/specs/f043-distributed-merge.md
@@ -1,0 +1,76 @@
+# F043: Distributed Decision Merge
+
+**Status:** Proposed
+**Priority:** Low
+**Inspired by:** Beads (steveyegge/beads) - hash-based IDs + git-backed storage for zero-conflict multi-agent merge
+
+## Problem
+
+CSTP is centralized - all agents must be online and connected to the server to record decisions. This creates issues:
+
+- Agents can't record decisions during network outages
+- No mechanism for merging decision histories from independent CSTP instances
+- Short sequential IDs (8-char hex) can collide across instances
+- Multi-team setups require a single shared server
+
+## Solution
+
+Add offline-capable decision recording with content-addressable IDs and a merge protocol for synchronizing independent CSTP instances.
+
+### Content-Addressable IDs
+
+Replace short hex IDs with content-hash-based IDs:
+
+```python
+decision_id = sha256(
+    agent_id + timestamp + decision_text + category
+)[:12]  # "dec-a3f8b2c1d4e5"
+```
+
+Benefits:
+- Globally unique without coordination
+- Deterministic - same decision always gets same ID
+- Collision-resistant across instances
+
+### Offline Recording
+
+```
+# Agent records locally when server unavailable
+cstp.py record --offline -d "decision" -f 0.85 -c arch -s medium
+# Stores in local SQLite/JSONL
+
+# Sync when back online
+cstp.py sync --server http://192.168.1.141:9991
+# Merges local decisions into server, resolves conflicts
+```
+
+### Merge Protocol
+
+1. **Export:** `cstp.export` - dump decisions as JSONL with content-hash IDs
+2. **Import:** `cstp.import` - ingest external decisions, detect duplicates by hash
+3. **Conflict Resolution:**
+   - Same hash = duplicate, skip
+   - Different hash, same topic = potential `relates_to` link
+   - Contradicting decisions = flag for human review
+
+### Federation Sync (extends F038)
+
+```
+# Instance A exports to Instance B
+cstp.federate --push --target http://other-instance:9991
+cstp.federate --pull --source http://other-instance:9991
+```
+
+## Phases
+
+1. **P1:** Content-addressable ID generation (backward compatible)
+2. **P2:** Offline recording with local SQLite cache
+3. **P3:** Sync/merge protocol with conflict detection
+4. **P4:** Federation push/pull between CSTP instances
+
+## Integration Points
+
+- F038 (Cross-Agent Federation): Distributed merge is the transport layer for federation
+- F039 (Protocol Stack): Merge protocol as part of the CSTP protocol specification
+- F040 (Task Graph): Tasks sync alongside decisions
+- F042 (Dependencies): Links preserved across merge

--- a/website/specs/f044-agent-work-discovery.md
+++ b/website/specs/f044-agent-work-discovery.md
@@ -1,0 +1,108 @@
+# F044: Agent Work Discovery
+
+**Status:** Proposed
+**Priority:** High
+**Inspired by:** Beads (steveyegge/beads) - `bd ready` command that surfaces tasks with no open blockers
+
+## Problem
+
+CSTP is passive - agents record and query decisions but must know what to ask. There's no mechanism to surface:
+
+- Decisions needing outcome reviews
+- Categories with degrading calibration
+- Patterns with recurring failures
+- Unresolved contradictions
+- Stale decisions that need re-evaluation
+
+Agents miss valuable cognitive maintenance work because nothing prompts them.
+
+## Solution
+
+Add a `cstp.ready` endpoint that returns prioritized cognitive actions, turning CSTP from a passive record into an active work queue.
+
+### Ready Queue
+
+```bash
+cstp.py ready
+```
+
+```json
+{
+  "actions": [
+    {
+      "type": "review_outcome",
+      "priority": "high",
+      "decision_id": "dec-a3f8",
+      "reason": "Decision is 14 days old with no outcome review",
+      "suggestion": "Check if the approach worked"
+    },
+    {
+      "type": "calibration_drift",
+      "priority": "medium",
+      "category": "tooling",
+      "reason": "Brier score degraded 40% in last 7 days (0.02 -> 0.028)",
+      "suggestion": "Review recent tooling decisions for overconfidence"
+    },
+    {
+      "type": "contradiction",
+      "priority": "medium",
+      "decisions": ["dec-b1c2", "dec-d3e4"],
+      "reason": "Active decisions with conflicting approaches",
+      "suggestion": "Resolve: one should supersede the other"
+    },
+    {
+      "type": "stale_pattern",
+      "priority": "low",
+      "pattern": "Override system defaults when they don't match workload",
+      "reason": "Pattern referenced by 5 decisions, none reviewed in 30 days",
+      "suggestion": "Validate pattern still holds"
+    }
+  ]
+}
+```
+
+### Action Types
+
+| Type | Trigger | Priority Logic |
+|------|---------|---------------|
+| `review_outcome` | Decision age > review_period, no outcome | Higher stakes = higher priority |
+| `calibration_drift` | Category Brier score degraded >20% | Based on drift magnitude |
+| `contradiction` | Active decisions with conflicting patterns | Always medium+ |
+| `stale_pattern` | Pattern not validated in 30+ days | Based on pattern frequency |
+| `low_confidence_cluster` | 3+ recent decisions in same area with conf < 0.6 | Signals knowledge gap |
+| `success_streak` | 10+ successes in category | Prompt: raise default confidence? |
+
+### Agent Integration
+
+```markdown
+# In HEARTBEAT.md or agent instructions:
+During quiet periods, run `cstp.py ready` and address top items.
+```
+
+### Filtering
+
+```bash
+# Only high priority
+cstp.py ready --min-priority high
+
+# Specific types
+cstp.py ready --type review_outcome,calibration_drift
+
+# For specific agent
+cstp.py ready --agent code-reviewer
+```
+
+## Phases
+
+1. **P1:** Outcome review reminders (overdue decisions)
+2. **P2:** Calibration drift detection (extends existing checkDrift)
+3. **P3:** Contradiction and staleness detection
+4. **P4:** Configurable priority policies per agent
+
+## Integration Points
+
+- F009 (Calibration): Drift detection feeds ready queue
+- F030 (Circuit Breakers): Tripped breakers surface as high-priority actions
+- F040 (Task Graph): Blocked tasks appear in ready queue
+- F042 (Dependencies): Contradictions detected via dependency graph
+- F041 (Compaction): Compaction candidates surfaced as low-priority maintenance

--- a/website/specs/f045-graph-storage-layer.md
+++ b/website/specs/f045-graph-storage-layer.md
@@ -1,0 +1,222 @@
+# F045: Decision Graph Storage Layer
+
+**Status:** Proposed
+**Priority:** High
+**Research basis:** Context Graphs (Masood 2026), Graph-Constrained Reasoning (ICML 2025), MemoBrain (Qian et al. 2026), KnowFlow (Neural Networks 2026), Dual Memory Knowledge Graphs (ScienceDirect 2026)
+
+## Problem
+
+CSTP stores decisions as independent documents with flat `related_to` links discovered via semantic similarity. This misses structural relationships that only a graph can express:
+
+- **No traversal:** Can't follow chains of decisions to find root causes or downstream impacts
+- **No centrality:** Can't determine which decisions are structurally important (many dependents) vs peripheral
+- **No contradiction detection:** Conflicting active decisions aren't surfaced unless semantically similar
+- **No constrained reasoning:** Agents can make decisions that violate the existing dependency structure
+- **Compaction is time-based, not salience-based:** Old but structurally critical decisions get summarized equally
+
+CSTP is already 80% of a decision knowledge graph - it has nodes (decisions), edges (related_to), attributes (confidence, outcome, bridge-definitions), and semantic search. Adding a proper graph layer unlocks the remaining 20%.
+
+## Solution
+
+Add a graph storage layer alongside ChromaDB that represents decisions as nodes and their relationships as typed, directed edges. Queries can use graph traversal, semantic search, or both.
+
+### Architecture
+
+```
+┌─────────────────────────────────────┐
+│           CSTP API Layer            │
+├──────────────┬──────────────────────┤
+│  ChromaDB    │   Graph Store        │
+│  (vectors)   │   (structure)        │
+│              │                      │
+│  Semantic    │   Traversal          │
+│  similarity  │   Centrality         │
+│  Bridge      │   Path finding       │
+│  search      │   Contradiction      │
+│              │   detection          │
+└──────────────┴──────────────────────┘
+        │               │
+        └───── Dual Retrieval ────────┘
+              (F024 upgrade)
+```
+
+### Graph Model
+
+**Nodes:** Each decision becomes a graph node with properties:
+```python
+class DecisionNode:
+    id: str                    # Decision ID
+    category: str
+    stakes: str
+    confidence: float
+    outcome: str | None
+    date: str
+    tags: list[str]
+    pattern: str | None        # Abstract pattern (F027)
+    structure_desc: str | None # Bridge structure (F024)
+    function_desc: str | None  # Bridge function (F024)
+    salience: float            # Computed: graph centrality score
+```
+
+**Edges:** Typed, directed relationships between decisions:
+```python
+class DecisionEdge:
+    source_id: str
+    target_id: str
+    edge_type: EdgeType        # See below
+    weight: float              # Strength of relationship
+    created_at: datetime
+    created_by: str            # Agent or auto-detected
+    context: str | None
+```
+
+**Edge Types:**
+| Type | Direction | Meaning |
+|------|-----------|---------|
+| `depends_on` | A → B | A required B to exist first |
+| `supersedes` | A → B | A replaces B (B is obsolete) |
+| `contradicts` | A ↔ B | A and B conflict (bidirectional) |
+| `refines` | A → B | A narrows or improves on B |
+| `relates_to` | A ↔ B | Topically connected (existing, auto-populated) |
+| `caused_by` | A → B | A was a consequence of B's outcome |
+| `blocks` | A → B | B cannot proceed until A resolves |
+
+### Storage Backend
+
+**Phase 1: NetworkX (in-process)**
+- Zero infrastructure - pure Python, in-memory graph
+- Persist as JSONL alongside ChromaDB
+- Sufficient for hundreds to low thousands of decisions
+- Built-in centrality algorithms (PageRank, betweenness)
+
+**Phase 2: Neo4j (optional, at scale)**
+- For deployments with 10K+ decisions or multi-agent federation
+- Cypher queries for complex traversal
+- Native graph visualization
+- Docker-composable with existing CSTP stack
+
+### API
+
+```
+# Graph CRUD
+cstp.linkDecisions     - Create typed edge between decisions
+cstp.unlinkDecisions   - Remove edge
+cstp.getGraph          - Get subgraph (node + N hops, optional edge type filter)
+
+# Graph Queries
+cstp.findPath          - Shortest path between two decisions
+cstp.getAncestors      - All decisions this one depends on
+cstp.getDescendants    - All decisions that depend on this one
+cstp.findContradictions - Active decisions with contradiction edges
+cstp.getBlockedChain   - Decisions blocked by unresolved dependencies
+
+# Salience
+cstp.computeSalience   - Recalculate centrality scores for all nodes
+cstp.getHighSalience   - Top N structurally important decisions
+```
+
+### Dual Retrieval (upgrades F024 Bridge Search)
+
+Current F024 bridge search uses two semantic paths (structure vs function). Graph layer adds a third:
+
+1. **Semantic (vector):** "What decisions are about similar topics?" (ChromaDB)
+2. **Structural (graph):** "What decisions are connected to this one?" (Graph traversal)
+3. **Hybrid:** Combine both - semantically similar AND structurally connected = highest relevance
+
+```python
+def dual_query(query: str, decision_id: str | None = None, hops: int = 2):
+    # Semantic results from ChromaDB
+    semantic = chromadb.query(query, top_k=10)
+    
+    # Graph results if we have a starting node
+    if decision_id:
+        graph_neighbors = graph.get_subgraph(decision_id, hops=hops)
+        # Boost decisions that appear in BOTH result sets
+        return merge_and_rank(semantic, graph_neighbors)
+    
+    return semantic
+```
+
+### Salience-Based Compaction (upgrades F041)
+
+Instead of time-based decay, use graph centrality to determine compaction priority:
+
+| Salience | Compaction | Reason |
+|----------|-----------|--------|
+| High (top 20%) | Never compact | Many dependents, structurally critical |
+| Medium | Summary after 30 days | Some connections, moderate importance |
+| Low (leaf nodes, reviewed) | Digest after 14 days | Peripheral, outcome captured |
+| Superseded | Fold into successor immediately | Obsolete by definition |
+
+### Graph-Aware Guardrails (upgrades F030)
+
+New guardrail type: `graph-constraint`
+
+```python
+# Block decisions that contradict active high-salience decisions
+{
+    "name": "no-contradict-high-salience",
+    "type": "graph-constraint",
+    "rule": "New decision must not contradict any active decision with salience > 0.7",
+    "action": "block",
+    "message": "This contradicts {conflicting_decision}. Supersede it first."
+}
+```
+
+### Auto-Edge Detection
+
+When recording a new decision, automatically detect potential edges:
+1. Run semantic query for similar decisions
+2. Compare patterns and tags for potential `refines` or `contradicts`
+3. Check if any active decisions in the same category have opposing outcomes → suggest `contradicts`
+4. If decision references another decision's outcome → suggest `caused_by`
+
+## Phases
+
+### P1: Foundation (NetworkX + basic edges)
+- NetworkX graph initialized from existing `related_to` data
+- `linkDecisions` and `getGraph` API endpoints
+- JSONL persistence alongside ChromaDB
+- Edge types: `relates_to`, `supersedes`, `depends_on`
+
+### P2: Salience + Dual Retrieval
+- PageRank-based salience scoring
+- `computeSalience`, `getHighSalience` endpoints
+- Dual retrieval: semantic + graph merged results
+- Salience field added to query response
+
+### P3: Graph-Aware Guardrails
+- `contradicts` and `blocks` edge types
+- `findContradictions`, `getBlockedChain` endpoints
+- Graph-constraint guardrail type
+- Auto-edge detection on `recordDecision`
+
+### P4: Advanced Queries + Visualization
+- Path finding, ancestor/descendant traversal
+- Graph export for dashboard visualization (D3.js/Cypher)
+- Integration with F044 (Work Discovery) - graph-informed ready queue
+- Optional Neo4j backend for scale
+
+## Integration Points
+
+- **F002 (Query):** Dual retrieval merges semantic + graph results
+- **F024 (Bridge Definitions):** Graph adds structural retrieval path
+- **F027 (Decision Quality):** Edge count and diversity as quality signals
+- **F030 (Circuit Breakers):** Graph-constraint guardrails
+- **F040 (Task Graph):** Tasks as a subgraph connected to decision nodes
+- **F041 (Compaction):** Salience-based instead of time-based decay
+- **F042 (Dependencies):** F045 subsumes F042 - this IS the dependency graph
+- **F043 (Distributed Merge):** Graph edges included in merge protocol
+- **F044 (Work Discovery):** Contradictions, blocked chains, low-salience clusters in ready queue
+
+## Research References
+
+1. **Context Graphs** (Masood, 2026) - Governed queryable memory layer connecting entities, decisions, evidence. Explanation packets: answer + evidence paths + provenance.
+2. **Graph-Constrained Reasoning** (Luo et al., ICML 2025) - Constrains LLM reasoning to valid knowledge graph paths. KG-Trie structure.
+3. **MemoBrain** (Qian et al., 2026) - Dependency-aware memory over reasoning steps. Prunes invalid steps, folds sub-trajectories, preserves reasoning backbone.
+4. **KnowFlow** (Neural Networks, 2026) - Knowledge-streamlined agent design. Structured knowledge pipeline consulted before acting.
+5. **Dual Memory Knowledge Graph** (ScienceDirect, 2026) - Integrates semantic memory (meaning) with observability memory (what happened). Reduces hallucination.
+
+## Note on F042
+
+F045 subsumes F042 (Decision Dependency Graph). F042 described typed links between decisions; F045 provides the full storage layer, algorithms, and integration. F042 should be marked as "merged into F045" in the index.

--- a/website/specs/f046-pre-action-hook.md
+++ b/website/specs/f046-pre-action-hook.md
@@ -1,0 +1,173 @@
+# F046: Pre-Action Hook API
+
+**Status:** Shipped (v0.11.0)
+**Priority:** High
+**Category:** Agentic Loop Integration
+
+## Problem
+
+Integrating CSTP into an agent's decision loop currently requires 3 separate API calls before acting:
+1. `queryDecisions` - find relevant past decisions
+2. `checkGuardrails` - validate the action is allowed
+3. `recordDecision` - commit intent before executing
+
+This 3-call overhead discourages adoption. Agents skip steps under time pressure. Our own experience confirms this - the single biggest process failure is skipping the pre-decision query (documented in 4+ violations).
+
+## Solution
+
+A single `cstp.preAction` endpoint that combines query + guardrails + optional record in one round-trip. Designed to be called at the decision point in any agentic loop.
+
+### API
+
+```json
+{
+  "method": "cstp.preAction",
+  "params": {
+    "agent_id": "claude-code",
+    "action": {
+      "description": "Refactor auth module to use JWT instead of sessions",
+      "category": "architecture",
+      "stakes": "high",
+      "confidence": 0.80
+    },
+    "options": {
+      "query_limit": 5,
+      "auto_record": true,
+      "include_patterns": true
+    }
+  }
+}
+```
+
+### Response
+
+```json
+{
+  "result": {
+    "allowed": true,
+    "decision_id": "dec-a3f8b2c1",
+
+    "relevant_decisions": [
+      {
+        "id": "dec-7e2f",
+        "decision": "Chose JWT for API auth in microservice layer",
+        "outcome": "success",
+        "date": "2026-01-15",
+        "pattern": "Stateless auth scales better than session-based",
+        "confidence": 0.90,
+        "similarity": 0.87
+      }
+    ],
+
+    "guardrail_results": [
+      {
+        "name": "no-high-stakes-low-confidence",
+        "status": "pass",
+        "message": null
+      },
+      {
+        "name": "no-production-without-review",
+        "status": "warn",
+        "message": "High-stakes change - ensure code review before merge"
+      }
+    ],
+
+    "calibration_context": {
+      "category_accuracy": 0.91,
+      "category_brier": 0.03,
+      "confidence_tendency": "slightly_underconfident",
+      "suggestion": "Your architecture decisions succeed 91% of the time - confidence of 0.80 may be low"
+    },
+
+    "patterns_summary": [
+      "Stateless auth scales better than session-based (3 confirmations)",
+      "Migration decisions need rollback plan (2 confirmations)"
+    ]
+  }
+}
+```
+
+### Behavior
+
+1. **Query:** Semantic search for similar past decisions (hybrid mode)
+2. **Guardrails:** Run all active guardrails against the proposed action
+3. **Calibration:** Fetch agent's calibration profile for this category
+4. **Patterns:** Extract relevant confirmed patterns from matching decisions
+5. **Record (optional):** If `auto_record: true` and guardrails pass, record the decision immediately and return `decision_id`
+6. **Block:** If any guardrail blocks, return `allowed: false` with reasons. Decision is NOT recorded.
+
+### Blocked Response
+
+```json
+{
+  "result": {
+    "allowed": false,
+    "decision_id": null,
+    "block_reasons": [
+      {
+        "guardrail": "no-high-stakes-low-confidence",
+        "message": "Stakes=high but confidence=0.35. Increase confidence or lower stakes.",
+        "suggestion": "Research more before proceeding, or break into smaller decisions"
+      }
+    ],
+    "relevant_decisions": [...],
+    "calibration_context": {...}
+  }
+}
+```
+
+### MCP Tool Definition
+
+```json
+{
+  "name": "pre_action",
+  "description": "Check if an action is safe and informed before executing. Returns relevant past decisions, guardrail results, calibration context, and optionally records the decision. Call this BEFORE making any significant choice.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "description": { "type": "string", "description": "What you plan to do" },
+      "category": { "type": "string", "enum": ["architecture", "process", "integration", "tooling", "security"] },
+      "stakes": { "type": "string", "enum": ["low", "medium", "high", "critical"] },
+      "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+      "reasons": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "type": { "type": "string" },
+            "text": { "type": "string" }
+          }
+        }
+      },
+      "tags": { "type": "array", "items": { "type": "string" } },
+      "pattern": { "type": "string", "description": "Abstract pattern this decision represents" },
+      "auto_record": { "type": "boolean", "default": true }
+    },
+    "required": ["description", "category", "stakes", "confidence"]
+  }
+}
+```
+
+## Design Principles
+
+- **One call, full context.** Reduce friction to zero - if the agent only makes one CSTP call, this is the one.
+- **Opinionated defaults.** `auto_record: true`, `query_limit: 5`, `include_patterns: true`. Works out of the box.
+- **Fail open or fail closed.** Configurable per deployment. Default: warn on guardrail violations but allow (fail open). Production: block on violations (fail closed).
+- **Idempotent query, non-idempotent record.** If `auto_record: false`, the call is pure query (safe to retry). If `auto_record: true`, it creates a decision (call once).
+
+## Phases
+
+1. **P1:** Core endpoint combining query + guardrails + record
+2. **P2:** Calibration context injection + pattern extraction
+3. **P3:** MCP tool exposure + Claude Desktop/Code integration
+4. **P4:** Configurable fail-open/fail-closed modes
+
+## Integration Points
+
+- F002 (Query): Reuses hybrid query internally
+- F003 (Guardrails): Reuses guardrail evaluation
+- F007 (Record): Reuses decision recording
+- F009 (Calibration): Category-specific calibration context
+- F027 (Quality): Auto-enforces tags + pattern requirement
+- F045 (Graph): Future - include graph-neighbor decisions in results
+- F047 (Session Context): preAction is the per-decision call; F047 is the per-session call

--- a/website/specs/f047-session-context.md
+++ b/website/specs/f047-session-context.md
@@ -1,0 +1,191 @@
+# F047: Session Context Endpoint
+
+**Status:** Shipped (v0.11.0)
+**Priority:** High
+**Category:** Agentic Loop Integration
+
+## Problem
+
+Agents starting a new session have no cognitive context. They don't know:
+- What decisions were made previously in this domain
+- What their calibration profile looks like (am I overconfident? in which areas?)
+- What guardrails are active
+- What cognitive maintenance is overdue (unreviewed decisions, calibration drift)
+
+Loading this context requires multiple API calls and manual system prompt construction. Most frameworks don't bother - agents start cold every time.
+
+## Solution
+
+A single `cstp.getSessionContext` endpoint that returns everything an agent needs to be cognitively aware at session start. Designed for injection into system prompts or agent initialization.
+
+### API
+
+```json
+{
+  "method": "cstp.getSessionContext",
+  "params": {
+    "agent_id": "claude-code",
+    "task_description": "Build authentication service for user API",
+    "include": ["decisions", "guardrails", "calibration", "ready", "patterns", "contradictions"],
+    "decisions_limit": 10,
+    "ready_limit": 5,
+    "format": "markdown"
+  }
+}
+```
+
+### Response (format: "json")
+
+```json
+{
+  "result": {
+    "agent_profile": {
+      "agent_id": "claude-code",
+      "total_decisions": 47,
+      "reviewed": 32,
+      "overall_accuracy": 0.94,
+      "brier_score": 0.028,
+      "tendency": "slightly_underconfident",
+      "strongest_category": "tooling",
+      "weakest_category": "security",
+      "active_since": "2026-01-15"
+    },
+
+    "relevant_decisions": [
+      {
+        "id": "dec-7e2f",
+        "decision": "Chose JWT for API auth",
+        "outcome": "success",
+        "date": "2026-01-15",
+        "pattern": "Stateless auth scales better",
+        "tags": ["auth", "jwt", "architecture"]
+      }
+    ],
+
+    "active_guardrails": [
+      {
+        "name": "no-high-stakes-low-confidence",
+        "description": "Block if stakes=high and confidence < 0.5",
+        "action": "block"
+      },
+      {
+        "name": "no-production-without-review",
+        "description": "Require code review for production changes",
+        "action": "warn"
+      }
+    ],
+
+    "calibration_by_category": {
+      "architecture": { "accuracy": 0.93, "brier": 0.03, "decisions": 18, "tendency": "well_calibrated" },
+      "security": { "accuracy": 0.80, "brier": 0.08, "decisions": 5, "tendency": "overconfident" }
+    },
+
+    "ready_queue": [
+      {
+        "type": "review_outcome",
+        "priority": "high",
+        "decision_id": "dec-b1c2",
+        "reason": "Architecture decision from 12 days ago, no outcome recorded"
+      }
+    ],
+
+    "confirmed_patterns": [
+      { "pattern": "Stateless auth scales better than session-based", "confirmations": 3, "category": "architecture" },
+      { "pattern": "Always validate input at API boundary", "confirmations": 5, "category": "security" }
+    ],
+
+    "active_contradictions": []
+  }
+}
+```
+
+### Response (format: "markdown")
+
+When `format: "markdown"`, returns a pre-formatted block ready for system prompt injection:
+
+```json
+{
+  "result": {
+    "markdown": "## CSTP Decision Context\n\n### Your Profile\n- 47 decisions logged, 94% accuracy, Brier 0.028\n- ⚠️ Tendency: slightly underconfident (raise confidence in architecture)\n- ⚠️ Weak area: security (80% accuracy, 5 decisions)\n\n### Relevant Past Decisions\n| Decision | Outcome | Date | Pattern |\n|----------|---------|------|---------|\n| Chose JWT for API auth | ✅ success | 2026-01-15 | Stateless auth scales better |\n...\n\n### Active Guardrails\n- 🚫 no-high-stakes-low-confidence: Block if stakes=high, confidence < 0.5\n- ⚠️ no-production-without-review: Warn on production changes without review\n\n### Pending Tasks\n- ❗ Review outcome for dec-b1c2 (architecture, 12 days overdue)\n\n### Confirmed Patterns\n- Stateless auth scales better (3x confirmed)\n- Always validate input at API boundary (5x confirmed)\n\n### Decision Protocol\nUse `pre_action` tool before any significant decision.\nInclude: confidence, category, stakes, 2+ reasons, tags, pattern."
+  }
+}
+```
+
+### Use Cases
+
+**1. Claude Code CLI - system prompt injection:**
+```markdown
+# In CLAUDE.md (auto-generated or templated)
+{{cstp_session_context}}
+```
+
+A build script or pre-hook calls `getSessionContext` and injects the markdown into CLAUDE.md before the session starts.
+
+**2. OpenClaw - agent initialization:**
+```python
+# In agent startup
+context = await cstp.get_session_context(
+    agent_id="emerson",
+    task_description=current_task,
+    format="markdown"
+)
+system_prompt += context["markdown"]
+```
+
+**3. LangChain / CrewAI / AutoGen:**
+```python
+# As a tool or system message
+context = cstp_client.get_session_context(agent_id="agent-1", task="...")
+agent = Agent(system_message=base_prompt + context.markdown)
+```
+
+**4. Periodic refresh (long sessions):**
+Call `getSessionContext` every N turns to refresh decisions and ready queue as the session evolves.
+
+### MCP Tool Definition
+
+```json
+{
+  "name": "get_session_context",
+  "description": "Get full cognitive context for this session: relevant past decisions, calibration profile, active guardrails, pending tasks, and confirmed patterns. Call at session start or when switching tasks.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "task_description": { "type": "string", "description": "What you're working on this session" },
+      "include": {
+        "type": "array",
+        "items": { "type": "string", "enum": ["decisions", "guardrails", "calibration", "ready", "patterns", "contradictions"] },
+        "default": ["decisions", "guardrails", "calibration", "ready", "patterns"]
+      },
+      "decisions_limit": { "type": "integer", "default": 10 },
+      "ready_limit": { "type": "integer", "default": 5 },
+      "format": { "type": "string", "enum": ["json", "markdown"], "default": "markdown" }
+    },
+    "required": ["task_description"]
+  }
+}
+```
+
+## Design Principles
+
+- **Session-level, not decision-level.** F046 (preAction) is called per decision. F047 is called once at session start (or on task switch).
+- **Markdown-first.** Most agent frameworks inject context as text. The markdown format is ready to paste into any system prompt.
+- **Progressive disclosure.** The `include` array lets lightweight agents request only what they need. Full context for complex agents, just guardrails for simple ones.
+- **Framework-agnostic.** JSON-RPC + MCP. Works with Claude Code, OpenClaw, LangChain, CrewAI, raw curl.
+
+## Phases
+
+1. **P1:** Core endpoint - decisions + guardrails + calibration
+2. **P2:** Ready queue + patterns + contradictions
+3. **P3:** Markdown formatting + MCP tool
+4. **P4:** Auto-refresh middleware for long sessions
+
+## Integration Points
+
+- F002 (Query): Task-scoped decision retrieval
+- F003 (Guardrails): Active guardrail listing
+- F009 (Calibration): Per-agent, per-category calibration
+- F027 (Quality): Confirmed patterns from quality-scored decisions
+- F044 (Work Discovery): Ready queue integration
+- F045 (Graph): Graph-neighbor decisions in context
+- F046 (Pre-Action): Session context is the complement - F047 loads context, F046 gates individual decisions

--- a/website/specs/f048-multi-vectordb.md
+++ b/website/specs/f048-multi-vectordb.md
@@ -1,0 +1,513 @@
+# F048: Multi-Vector-DB Support
+
+**Status:** P1 Shipped (v0.12.0)
+**Priority:** High
+**Category:** Infrastructure
+
+## Problem
+
+CSTP is hardcoded to ChromaDB via direct HTTP API calls in `query_service.py` and `decision_service.py`. This creates:
+
+- **Vendor lock-in:** Users must run ChromaDB even if they already have another vector DB
+- **No testing without Docker:** No in-memory backend for unit tests
+- **Manual hybrid search:** CSTP implements hybrid retrieval (F017) in Python by combining semantic + keyword results, when some backends (Weaviate, Qdrant) support this natively
+- **Embedding coupling:** Embedding generation (currently Gemini) is interleaved with storage logic
+
+## Solution
+
+Extract vector operations behind a `VectorStore` abstract interface with pluggable backends, and similarly abstract embedding generation behind an `EmbeddingProvider` interface.
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────┐
+│              CSTP Services                   │
+│  query_service.py  decision_service.py       │
+├─────────────────────────────────────────────┤
+│           VectorStore Interface              │
+│  upsert() query() delete() count() reset()  │
+├──────┬──────┬──────┬──────┬──────┬──────────┤
+│Chroma│Weavi-│pgvec-│Qdrant│Pine- │ Memory   │
+│  DB  │ ate  │ tor  │      │ cone │ (test)   │
+└──────┴──────┴──────┴──────┴──────┴──────────┘
+
+┌─────────────────────────────────────────────┐
+│         EmbeddingProvider Interface          │
+│  embed(texts) -> list[list[float]]          │
+├──────┬──────┬──────┬────────────────────────┤
+│Gemini│OpenAI│Ollama│sentence-transformers   │
+└──────┴──────┴──────┴────────────────────────┘
+```
+
+### VectorStore Interface
+
+```python
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+@dataclass(slots=True)
+class VectorResult:
+    """Single result from vector similarity search."""
+    id: str
+    document: str
+    metadata: dict[str, Any]
+    distance: float
+
+class VectorStore(ABC):
+    """Abstract vector store interface for decision storage and retrieval."""
+
+    @abstractmethod
+    async def initialize(self) -> None:
+        """Initialize connection, create collection if needed."""
+        ...
+
+    @abstractmethod
+    async def upsert(
+        self,
+        id: str,
+        document: str,
+        embedding: list[float],
+        metadata: dict[str, Any],
+    ) -> bool:
+        """Insert or update a document with its embedding and metadata."""
+        ...
+
+    @abstractmethod
+    async def query(
+        self,
+        embedding: list[float],
+        n_results: int = 10,
+        where: dict[str, Any] | None = None,
+    ) -> list[VectorResult]:
+        """Find similar documents by embedding vector.
+        
+        Args:
+            embedding: Query vector.
+            n_results: Maximum results.
+            where: Metadata filters (backend translates to native syntax).
+        """
+        ...
+
+    @abstractmethod
+    async def hybrid_query(
+        self,
+        text: str,
+        embedding: list[float],
+        n_results: int = 10,
+        where: dict[str, Any] | None = None,
+        semantic_weight: float = 0.7,
+    ) -> list[VectorResult]:
+        """Hybrid search combining semantic + keyword.
+        
+        Backends with native hybrid (Weaviate, Qdrant) use it directly.
+        Others fall back to manual merge.
+        """
+        ...
+
+    @abstractmethod
+    async def delete(self, ids: list[str]) -> bool:
+        """Delete documents by ID."""
+        ...
+
+    @abstractmethod
+    async def count(self) -> int:
+        """Return total document count."""
+        ...
+
+    @abstractmethod
+    async def reset(self) -> bool:
+        """Delete and recreate the collection."""
+        ...
+
+    @abstractmethod
+    async def close(self) -> None:
+        """Clean up connections."""
+        ...
+```
+
+### EmbeddingProvider Interface
+
+```python
+class EmbeddingProvider(ABC):
+    """Abstract embedding generation interface."""
+
+    @abstractmethod
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        """Generate embeddings for one or more texts.
+        
+        Args:
+            texts: Input texts to embed.
+            
+        Returns:
+            List of embedding vectors (one per input text).
+        """
+        ...
+
+    @property
+    @abstractmethod
+    def dimensions(self) -> int:
+        """Return the embedding dimensionality."""
+        ...
+
+    @property
+    @abstractmethod
+    def model_name(self) -> str:
+        """Return the model identifier."""
+        ...
+```
+
+### Backend Implementations
+
+#### ChromaDB (P0 - extract existing)
+
+Move current `query_service.py` and `decision_service.py` HTTP calls into `vectordb/chromadb.py`. Zero behavior change, pure refactor.
+
+```python
+class ChromaDBStore(VectorStore):
+    """ChromaDB via HTTP API (v2)."""
+    
+    def __init__(self, url: str, collection: str, tenant: str, database: str):
+        self.url = url
+        self.collection = collection
+        # ... existing HTTP logic moved here
+
+    async def hybrid_query(self, text, embedding, n_results, where, semantic_weight):
+        # Manual merge (current F017 implementation)
+        semantic = await self.query(embedding, n_results * 2, where)
+        keyword = await self._keyword_search(text, n_results * 2, where)
+        return self._merge_results(semantic, keyword, semantic_weight)
+```
+
+#### Weaviate (P1)
+
+Native hybrid search, built-in vectorization, multi-tenancy.
+
+```python
+class WeaviateStore(VectorStore):
+    """Weaviate via REST/GraphQL API."""
+
+    def __init__(self, url: str, collection: str, api_key: str | None = None):
+        self.url = url
+        self.collection = collection
+        self.api_key = api_key
+
+    async def query(self, embedding, n_results, where):
+        # nearVector query
+        payload = {
+            "nearVector": {"vector": embedding},
+            "limit": n_results,
+        }
+        if where:
+            payload["where"] = self._translate_where(where)
+        # ... GraphQL or REST v2 API call
+
+    async def hybrid_query(self, text, embedding, n_results, where, semantic_weight):
+        # Native hybrid - single API call
+        payload = {
+            "hybrid": {
+                "query": text,
+                "vector": embedding,
+                "alpha": semantic_weight,  # 0=BM25, 1=vector
+            },
+            "limit": n_results,
+        }
+        if where:
+            payload["where"] = self._translate_where(where)
+        # ... single request, Weaviate handles fusion internally
+```
+
+**Weaviate advantages for CSTP:**
+- `hybrid_query` is a single API call (vs ChromaDB's manual 2-query merge)
+- `alpha` parameter maps directly to CSTP's `hybrid_weight` config
+- Multi-tenancy maps to per-agent isolation (F038 federation)
+- Built-in `text2vec-*` modules can replace external embedding providers
+- Batch import API for efficient reindexing
+- Cross-reference properties could support F045 (graph edges)
+
+**Filter translation:**
+```python
+def _translate_where(self, cstp_where: dict) -> dict:
+    """Translate CSTP where clause to Weaviate filter format."""
+    # CSTP: {"category": "architecture", "stakes": {"$in": ["high", "medium"]}}
+    # Weaviate: {"operator": "And", "operands": [
+    #   {"path": ["category"], "operator": "Equal", "valueText": "architecture"},
+    #   {"path": ["stakes"], "operator": "ContainsAny", "valueTextArray": ["high", "medium"]}
+    # ]}
+```
+
+#### pgvector (P1)
+
+PostgreSQL with pgvector extension. Zero extra infrastructure for Postgres users.
+
+```python
+class PgVectorStore(VectorStore):
+    """PostgreSQL + pgvector extension."""
+
+    def __init__(self, dsn: str, table: str = "decisions"):
+        self.dsn = dsn
+        self.table = table
+
+    async def query(self, embedding, n_results, where):
+        # SQL with cosine distance
+        sql = f"""
+            SELECT id, document, metadata, 
+                   1 - (embedding <=> $1::vector) as similarity
+            FROM {self.table}
+            WHERE {self._build_where(where)}
+            ORDER BY embedding <=> $1::vector
+            LIMIT $2
+        """
+
+    async def hybrid_query(self, text, embedding, n_results, where, semantic_weight):
+        # pg_trgm for keyword + pgvector for semantic
+        sql = f"""
+            WITH semantic AS (
+                SELECT id, document, metadata,
+                       1 - (embedding <=> $1::vector) as score
+                FROM {self.table} WHERE {self._build_where(where)}
+                ORDER BY embedding <=> $1::vector LIMIT $3
+            ),
+            keyword AS (
+                SELECT id, document, metadata,
+                       ts_rank(to_tsvector(document), plainto_tsquery($2)) as score
+                FROM {self.table} WHERE {self._build_where(where)}
+                ORDER BY score DESC LIMIT $3
+            )
+            SELECT id, document, metadata,
+                   ({semantic_weight} * COALESCE(s.score, 0) + 
+                    {1 - semantic_weight} * COALESCE(k.score, 0)) as combined
+            FROM semantic s FULL OUTER JOIN keyword k USING (id)
+            ORDER BY combined DESC LIMIT $3
+        """
+```
+
+#### Qdrant (P2)
+
+```python
+class QdrantStore(VectorStore):
+    """Qdrant via REST API."""
+
+    async def hybrid_query(self, text, embedding, n_results, where, semantic_weight):
+        # Qdrant has native hybrid via "fusion" in query API
+        payload = {
+            "prefetch": [
+                {"query": embedding, "using": "dense", "limit": n_results * 2},
+                {"query": text, "using": "sparse", "limit": n_results * 2},
+            ],
+            "query": {"fusion": "rrf"},  # Reciprocal Rank Fusion
+            "limit": n_results,
+        }
+```
+
+#### In-Memory (P1 - testing)
+
+```python
+class MemoryStore(VectorStore):
+    """In-memory vector store for testing. No external dependencies."""
+
+    def __init__(self):
+        self._docs: dict[str, dict] = {}
+
+    async def query(self, embedding, n_results, where):
+        # Brute-force cosine similarity
+        results = []
+        for id, doc in self._docs.items():
+            if self._matches_where(doc["metadata"], where):
+                dist = self._cosine_distance(embedding, doc["embedding"])
+                results.append(VectorResult(id, doc["document"], doc["metadata"], dist))
+        results.sort(key=lambda r: r.distance)
+        return results[:n_results]
+```
+
+### Embedding Providers
+
+```
+a2a/cstp/embeddings/
+├── __init__.py             # ABC + factory
+├── gemini.py               # Current (768 dims, free tier)
+├── openai.py               # text-embedding-3-small/large
+├── ollama.py               # Local models (nomic-embed-text, etc.)
+├── sentence_transformers.py # Local HuggingFace models
+└── weaviate_builtin.py     # Weaviate's text2vec modules (no separate call needed)
+```
+
+### Configuration
+
+```env
+# Vector store
+VECTOR_BACKEND=chromadb                    # chromadb | weaviate | pgvector | qdrant | pinecone | memory
+VECTOR_URL=http://chromadb:8000            # Backend URL
+VECTOR_COLLECTION=decisions                # Collection/table name
+VECTOR_API_KEY=                            # For cloud backends (Pinecone, Weaviate Cloud)
+
+# Embeddings
+EMBEDDING_PROVIDER=gemini                  # gemini | openai | ollama | sentence_transformers | weaviate
+EMBEDDING_MODEL=text-embedding-004         # Provider-specific model name
+EMBEDDING_DIMENSIONS=768                   # Output dimensions
+EMBEDDING_URL=                             # For Ollama/custom endpoints
+
+# Weaviate-specific
+WEAVIATE_TEXT2VEC_MODULE=text2vec-openai   # Built-in vectorizer (optional)
+WEAVIATE_MULTI_TENANCY=false              # Enable per-agent tenants
+```
+
+### Factory
+
+```python
+def create_vector_store() -> VectorStore:
+    backend = os.getenv("VECTOR_BACKEND", "chromadb")
+    url = os.getenv("VECTOR_URL", "http://chromadb:8000")
+    collection = os.getenv("VECTOR_COLLECTION", "decisions")
+    api_key = os.getenv("VECTOR_API_KEY")
+
+    match backend:
+        case "chromadb":
+            return ChromaDBStore(url=url, collection=collection)
+        case "weaviate":
+            return WeaviateStore(url=url, collection=collection, api_key=api_key)
+        case "pgvector":
+            return PgVectorStore(dsn=url, table=collection)
+        case "qdrant":
+            return QdrantStore(url=url, collection=collection, api_key=api_key)
+        case "pinecone":
+            return PineconeStore(api_key=api_key, index=collection)
+        case "memory":
+            return MemoryStore()
+        case _:
+            raise ValueError(f"Unknown vector backend: {backend}")
+
+def create_embedding_provider() -> EmbeddingProvider:
+    provider = os.getenv("EMBEDDING_PROVIDER", "gemini")
+    model = os.getenv("EMBEDDING_MODEL", "text-embedding-004")
+
+    match provider:
+        case "gemini":
+            return GeminiEmbeddings(model=model)
+        case "openai":
+            return OpenAIEmbeddings(model=model)
+        case "ollama":
+            url = os.getenv("EMBEDDING_URL", "http://localhost:11434")
+            return OllamaEmbeddings(url=url, model=model)
+        case "weaviate":
+            return WeaviateBuiltinEmbeddings()  # No-op, Weaviate handles it
+        case _:
+            raise ValueError(f"Unknown embedding provider: {provider}")
+```
+
+### Docker Compose Examples
+
+**ChromaDB (current, default):**
+```yaml
+services:
+  cstp:
+    environment:
+      VECTOR_BACKEND: chromadb
+      VECTOR_URL: http://chromadb:8000
+      EMBEDDING_PROVIDER: gemini
+  chromadb:
+    image: chromadb/chroma:latest
+```
+
+**Weaviate (hybrid search, built-in embeddings):**
+```yaml
+services:
+  cstp:
+    environment:
+      VECTOR_BACKEND: weaviate
+      VECTOR_URL: http://weaviate:8080
+      EMBEDDING_PROVIDER: weaviate
+      WEAVIATE_TEXT2VEC_MODULE: text2vec-openai
+  weaviate:
+    image: semitechnologies/weaviate:latest
+    environment:
+      ENABLE_MODULES: text2vec-openai
+      DEFAULT_VECTORIZER_MODULE: text2vec-openai
+```
+
+**pgvector (no extra services):**
+```yaml
+services:
+  cstp:
+    environment:
+      VECTOR_BACKEND: pgvector
+      VECTOR_URL: postgresql://user:pass@postgres:5432/cstp
+      EMBEDDING_PROVIDER: ollama
+      EMBEDDING_URL: http://ollama:11434
+  postgres:
+    image: pgvector/pgvector:pg16
+```
+
+**Fully local (no cloud APIs):**
+```yaml
+services:
+  cstp:
+    environment:
+      VECTOR_BACKEND: qdrant
+      VECTOR_URL: http://qdrant:6333
+      EMBEDDING_PROVIDER: ollama
+      EMBEDDING_MODEL: nomic-embed-text
+  qdrant:
+    image: qdrant/qdrant:latest
+  ollama:
+    image: ollama/ollama:latest
+```
+
+## Phases
+
+### P1: Abstraction + ChromaDB extraction ✅ Shipped
+- [x] Define `VectorStore` and `EmbeddingProvider` ABCs
+- [x] Extract ChromaDB logic from `query_service.py` and `decision_service.py` into `vectordb/chromadb.py`
+- [x] Extract Gemini embedding logic into `embeddings/gemini.py`
+- [x] Add `MemoryStore` for testing
+- [x] Factory with env-based backend selection
+- [x] Refactor `reindex_service.py` to use VectorStore interface
+- [x] Update all tests to use MemoryStore + factory injection (446 tests pass)
+- **Zero behavior change** - existing ChromaDB deployments work unchanged
+
+**Implementation notes (P1):**
+- `hybrid_query()` was kept off the ABC — hybrid search stays orchestrated in the dispatcher (semantic via VectorStore + BM25 via `bm25_index.py`), matching existing behavior
+- `EmbeddingProvider.embed()` takes a single string (not batch) — `embed_batch()` provided as sequential default
+- `VectorStore.close()` is a non-abstract default no-op — backends override only if they hold resources
+- MemoryStore implements full ChromaDB-style where-clause matching: `$gte`, `$lte`, `$gt`, `$lt`, `$ne`, `$in`, `$nin`, `$contains`, `$or`, `$and`
+
+### P2: Weaviate + pgvector
+- Implement `WeaviateStore` with native hybrid search
+- Implement `PgVectorStore` with pgvector extension
+- Add `OllamaEmbeddings` for fully local stack
+- Docker compose examples for each
+- Integration tests per backend
+
+### P3: Qdrant + Pinecone + OpenAI embeddings
+- Implement remaining backends
+- `OpenAIEmbeddings` provider
+- Cloud deployment guides
+
+### P4: Backend-specific optimizations
+- Weaviate multi-tenancy for agent isolation (F038)
+- Weaviate cross-references for decision graph edges (F045)
+- pgvector partitioning for large decision sets
+- Batch import APIs for efficient reindexing
+
+## Migration Guide
+
+For existing ChromaDB users: **nothing changes.** Set `VECTOR_BACKEND=chromadb` (or leave unset, it's the default).
+
+For new deployments: choose based on your stack:
+
+| Already running | Recommended backend | Why |
+|----------------|-------------------|-----|
+| Nothing | ChromaDB | Simplest, lightweight |
+| PostgreSQL | pgvector | No extra infra |
+| Kubernetes | Weaviate or Qdrant | Production-grade, scalable |
+| Cloud-only | Pinecone or Weaviate Cloud | Managed, zero-ops |
+| Air-gapped / local | Qdrant + Ollama | Fully offline |
+
+## Integration Points
+
+- F002 (Query): `query_service.py` uses `VectorStore.query()` / `hybrid_query()`
+- F007 (Record): `decision_service.py` uses `VectorStore.upsert()`
+- F017 (Hybrid Retrieval): Backends with native hybrid skip manual merge
+- F038 (Federation): Weaviate multi-tenancy for per-agent isolation
+- F045 (Graph): Weaviate cross-references for graph edges alongside vectors
+- F046 (Pre-Action): Uses query internally, benefits from faster backends
+- F047 (Session Context): Bulk query benefits from backend optimizations

--- a/website/specs/index.md
+++ b/website/specs/index.md
@@ -1,21 +1,94 @@
 # Feature Specs
 
-Design documents for Cognition Engines features - past, present, and future.
+Design documents for Cognition Engines features — past, present, and future.
+
+## Shipped (v0.8.0)
+
+| Spec | Feature |
+|------|---------|
+| [F001](/specs/f001-cstp-server) | CSTP Server Infrastructure |
+| [F002](/specs/f002-query-decisions) | Query Decisions |
+| [F003](/specs/f003-check-guardrails) | Check Guardrails |
+| [F004](/specs/f004-announce-intent) | Announce Intent |
+| [F005](/specs/f005-cstp-client) | CSTP Client |
+| [F006](/specs/f006-docker-deployment) | Docker Deployment |
+| [F007](/specs/f007-record-decision) | Record Decision |
+| [F008](/specs/f008-review-decision) | Review Decision |
+| [F009](/specs/f009-get-calibration) | Get Calibration |
+| [F010](/specs/f010-project-context) | Project Context |
+| [F011](/specs/f011-web-dashboard) | Web Dashboard |
+
+## Shipped (v0.9.0)
+
+| Spec | Feature |
+|------|---------|
+| [F019](/specs/f019-list-guardrails) | List Guardrails |
+
+::: info
+F014–F017 (Hybrid Retrieval, Temporal Decay, Reason Diversity, Bridge Search) were shipped in v0.9.0 but their specs were implementation plans only. See the [changelog](/changelog) for details.
+:::
 
 ## Shipped (v0.10.0)
 
-| Spec | Feature | Status |
-|------|---------|--------|
-| [F022](/specs/f022-mcp-server) | MCP Server | Shipped |
-| [F023](/specs/f023-deliberation-traces) | Deliberation Traces | Shipped |
-| [F024](/specs/f024-bridge-definitions) | Bridge-Definitions | Shipped |
+| Spec | Feature |
+|------|---------|
+| [F022](/specs/f022-mcp-server) | MCP Server |
+| [F023](/specs/f023-deliberation-traces) | Deliberation Traces |
+| [F024](/specs/f024-bridge-definitions) | Bridge-Definitions |
+| [F027](/specs/f027-decision-quality) | Decision Recording Quality |
 
-## Proposed
+## Shipped (v0.11.0)
 
-| Spec | Feature | Status |
-|------|---------|--------|
-| [F027](/specs/f027-censor-layer) | Censor Layer | Proposed (needs failure data) |
-| [F028](/specs/f028-decomposed-confidence) | Decomposed Confidence | Proposed |
+| Spec | Feature |
+|------|---------|
+| [F046](/specs/f046-pre-action-hook) | Pre-Action Hook API |
+| [F047](/specs/f047-session-context) | Session Context Endpoint |
+
+## Roadmap
+
+### Research & Observability
+
+| Spec | Feature |
+|------|---------|
+| [F020](/specs/f020-reasoning-traces) | Structured Reasoning Traces |
+| [F029](/specs/f029-task-router) | Task Router |
+| [F030](/specs/f030-circuit-breaker-guardrails) | Circuit Breaker Guardrails |
+| [F031](/specs/f031-source-trust-scoring) | Source Trust Scoring |
+| [F032](/specs/f032-error-amplification-tracking) | Error Amplification Tracking |
+
+### Minsky-Inspired
+
+| Spec | Feature |
+|------|---------|
+| [F033](/specs/f033-censor-layer) | Censor Layer |
+| [F034](/specs/f034-decomposed-confidence) | Decomposed Confidence |
+
+### Federation
+
+| Spec | Feature |
+|------|---------|
+| [F035](/specs/f035-semantic-state-transfer) | Semantic State Transfer |
+| [F036](/specs/f036-reasoning-continuity) | Reasoning Continuity |
+| [F037](/specs/f037-collective-innovation) | Collective Innovation |
+| [F038](/specs/f038-cross-agent-federation) | Cross-Agent Federation |
+| [F039](/specs/f039-protocol-stack) | Cognition Protocol Stack |
+
+### Beads-Inspired (Decision Graphs)
+
+| Spec | Feature |
+|------|---------|
+| [F040](/specs/f040-task-decision-graph) | Task-Decision Graph |
+| [F041](/specs/f041-memory-compaction) | Memory Compaction |
+| [F042](/specs/f042-decision-dependencies) | Decision Dependencies |
+| [F043](/specs/f043-distributed-merge) | Distributed Merge |
+| [F044](/specs/f044-agent-work-discovery) | Agent Work Discovery |
+| [F045](/specs/f045-graph-storage-layer) | Graph Storage Layer |
+
+### Infrastructure
+
+| Spec | Feature |
+|------|---------|
+| [F048](/specs/f048-multi-vectordb) | Multi-Vector-DB Support |
 
 ## Theoretical Sources
 
@@ -23,5 +96,6 @@ Design documents for Cognition Engines features - past, present, and future.
 |---------|---------|-----------|
 | Minsky Ch 12 | Bridge-Definitions | F024 |
 | Minsky Ch 18 | Parallel Bundles | Reason types, confidence |
-| Minsky Ch 27 | Censors vs Suppressors | F027 |
-| Minsky Ch 28 | Mental Currencies | F028 |
+| Minsky Ch 27 | Censors vs Suppressors | F033 |
+| Minsky Ch 28 | Mental Currencies | F034 |
+| Beads (Wirth) | Linked Structures | F040–F045 |


### PR DESCRIPTION
Add all 35 feature specs (F001–F048) to the website specs section.

- Organized by version: v0.8.0, v0.9.0, v0.10.0, v0.11.0, Roadmap
- Collapsible sidebar groups
- Updated index page with full feature listing
- Corrected F027/F033/F034 mappings

⚡ Emerson