### PR TITLE
docs: update README, website, TODO for F044/F045 (v0.12.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Later            → review_outcome       (log success/failure)
 |------|---------|
 | `pre_action` **(PRIMARY)** | All-in-one: queries similar decisions, evaluates guardrails, fetches calibration, extracts patterns, optionally records. One call replaces 3. |
 | `get_session_context` **(PRIMARY)** | Full cognitive context at session start: agent profile, relevant decisions, guardrails, calibration by category, ready queue, confirmed patterns. JSON or markdown output. |
+| `ready` **(PRIMARY)** | Prioritized cognitive maintenance queue: overdue reviews, calibration drift, stale decisions. Filter by priority, type, category. |
 
 ### Granular MCP Tools
 
@@ -93,6 +94,13 @@ Later            → review_outcome       (log success/failure)
 | `get_reason_stats` | Which reasoning types predict success |
 | `update_decision` | Update decision text/context after work |
 | `record_thought` | Capture reasoning steps during work |
+
+### Graph Tools
+
+| Tool | Purpose |
+|------|---------|
+| `link_decisions` | Create typed edges between decisions (`relates_to`, `supersedes`, `depends_on`) |
+| `get_graph` | Query subgraph around a decision with configurable depth and edge type filters |
 
 ## JSON-RPC API
 
@@ -119,7 +127,7 @@ curl -X POST http://localhost:8100/cstp \
   }'
 ```
 
-**Available methods:** `cstp.queryDecisions`, `cstp.checkGuardrails`, `cstp.recordDecision`, `cstp.reviewDecision`, `cstp.getCalibration`, `cstp.getDecision`, `cstp.getReasonStats`, `cstp.updateDecision`, `cstp.recordThought`, `cstp.preAction`, `cstp.getSessionContext`, `cstp.checkDrift`, `cstp.reindex`, `cstp.listGuardrails`, `cstp.attributeOutcomes`
+**Available methods:** `cstp.queryDecisions`, `cstp.checkGuardrails`, `cstp.recordDecision`, `cstp.reviewDecision`, `cstp.getCalibration`, `cstp.getDecision`, `cstp.getReasonStats`, `cstp.updateDecision`, `cstp.recordThought`, `cstp.preAction`, `cstp.getSessionContext`, `cstp.ready`, `cstp.linkDecisions`, `cstp.getGraph`, `cstp.checkDrift`, `cstp.reindex`, `cstp.listGuardrails`, `cstp.attributeOutcomes`
 
 ## Architecture
 
@@ -181,7 +189,8 @@ See [docs/features/INDEX.md](docs/features/INDEX.md) for the complete feature ca
 | v0.9.0 | Hybrid Retrieval, Drift Alerts, Calibration (F014-F017) | ✅ Shipped |
 | v0.10.0 | MCP Server, Deliberation Traces, Bridge Definitions, Quality (F019-F028) | ✅ Shipped |
 | v0.11.0 | Pre-Action Hook, Session Context, Dashboard, Website, Pluggable Storage (F027-F028, F046-F048) | ✅ Shipped |
-| v0.12.0 | Agent Work Discovery, Graph Storage (F044, F045) | 🚧 In Progress |
+| v0.12.0 | Agent Work Discovery, Graph Storage, Pluggable Storage (F044, F045, F048) | ✅ Shipped |
+| v0.13.0 | Memory Compaction, Circuit Breakers (F041, F030) | 🚧 In Progress |
 
 ### Upcoming
 

--- a/TODO.md
+++ b/TODO.md
@@ -45,13 +45,18 @@ Semantic decay for old resolved decisions.
 - [ ] `preserve: true` flag to skip compaction
 - Spec: `docs/features/F041-memory-compaction.md`
 
-### F045: Decision Graph Storage Layer (P1 — NetworkX foundation) ✅
+### F045: Decision Graph Storage Layer ✅
 - [x] Add `networkx` dependency
 - [x] Initialize graph from existing `related_to` data on startup
 - [x] Implement `cstp.linkDecisions` (create typed edges)
 - [x] Implement `cstp.getGraph` (subgraph query with depth + edge type filter)
-- [x] JSONL persistence for graph edges
+- [x] JSONL persistence for graph edges (`GRAPH_DATA_PATH` env var)
 - [x] Edge types: `relates_to`, `supersedes`, `depends_on`
+- [x] Thread safety (asyncio.Lock)
+- [x] GraphStore ABC + factory pattern
+- [ ] Add `cstp.getNeighbors` (lightweight neighbor query)
+- [ ] Auto-linking in `recordDecision` flow
+- [ ] MCP tool registration for graph endpoints
 - Spec: `docs/features/F045-graph-storage-layer.md`
 
 ### F030: Circuit Breaker Guardrails

--- a/website/.vitepress/config.mjs
+++ b/website/.vitepress/config.mjs
@@ -23,7 +23,7 @@ export default withMermaid(defineConfig({
       { text: 'Reference', link: '/reference/product-overview' },
       { text: 'Specs', link: '/specs/' },
       {
-        text: 'v0.11.0',
+        text: 'v0.12.0',
         items: [
           { text: 'Changelog', link: '/changelog' },
           { text: 'GitHub', link: 'https://github.com/tfatykhov/cognition-agent-decisions' }

--- a/website/guide/mcp-integration.md
+++ b/website/guide/mcp-integration.md
@@ -1,8 +1,8 @@
 # MCP Integration
 
-> **Feature:** F022, F046, F047 | **Status:** Shipped in v0.10.0+
+> **Feature:** F022, F044, F045, F046, F047 | **Status:** Shipped in v0.12.0
 
-Cognition Engines exposes 11 tools via the [Model Context Protocol](https://modelcontextprotocol.io/) for integration with Claude Code, Claude Desktop, OpenClaw, and any MCP-compliant agent.
+Cognition Engines exposes 14+ tools via the [Model Context Protocol](https://modelcontextprotocol.io/) for integration with Claude Code, Claude Desktop, OpenClaw, and any MCP-compliant agent.
 
 ## Endpoint
 
@@ -18,6 +18,14 @@ Streamable HTTP - handles both POST (tool calls) and GET (SSE events).
 |------|-------------|
 | `pre_action` **(PRIMARY)** | All-in-one pre-action check: queries similar past decisions, evaluates guardrails, fetches calibration context, extracts patterns, and optionally records the decision. One call replaces `query_decisions` + `check_action` + `log_decision`. |
 | `get_session_context` **(PRIMARY)** | Full cognitive context for session start: agent profile (accuracy, Brier, tendency), relevant decisions, guardrails, calibration by category, overdue reviews, and confirmed patterns. Available in JSON or markdown for system prompt injection. |
+| `ready` **(PRIMARY)** | Prioritized cognitive maintenance queue: overdue reviews, calibration drift, stale decisions. Filter by priority, type, category. |
+
+## Graph Tools (F045)
+
+| Tool | Description |
+|------|-------------|
+| `link_decisions` | Create typed edges between decisions (`relates_to`, `supersedes`, `depends_on`) with optional weight |
+| `get_graph` | Query subgraph around a decision with configurable depth and edge type filters. Returns nodes with metadata and weighted edges. |
 
 ## Granular Tools (Fine-Grained Control)
 
@@ -36,15 +44,19 @@ Streamable HTTP - handles both POST (tool calls) and GET (SSE events).
 ## Recommended Workflow
 
 ```
-Session start → get_session_context (load cognitive context)
+Session start    → get_session_context  (load cognitive context)
        ↓
-Decision point → pre_action (query + guardrails + record in one call)
+Maintenance      → ready                (check for overdue reviews, drift)
        ↓
-During work → record_thought (capture reasoning)
+Decision point   → pre_action           (query + guardrails + record)
        ↓
-After work → update_decision (finalize decision text and context)
+During work      → record_thought       (capture reasoning)
        ↓
-Later → review_outcome (record success/failure for calibration)
+After work       → update_decision      (finalize decision text)
+       ↓
+Link related     → link_decisions       (explicit relationships)
+       ↓
+Later            → review_outcome       (record success/failure)
 ```
 
 ## Claude Code CLI

--- a/website/specs/index.md
+++ b/website/specs/index.md
@@ -44,6 +44,14 @@ F014–F017 (Hybrid Retrieval, Temporal Decay, Reason Diversity, Bridge Search) 
 | [F046](/specs/f046-pre-action-hook) | Pre-Action Hook API |
 | [F047](/specs/f047-session-context) | Session Context Endpoint |
 
+## Shipped (v0.12.0)
+
+| Spec | Feature |
+|------|---------|
+| [F044](/specs/f044-agent-work-discovery) | Agent Work Discovery (`cstp.ready`) |
+| [F045](/specs/f045-graph-storage-layer) | Decision Graph Storage Layer |
+| [F048](/specs/f048-multi-vectordb) | Multi-Vector-DB Support (P1: ABCs + MemoryStore) |
+
 ## Roadmap
 
 ### Research & Observability
@@ -81,14 +89,9 @@ F014–F017 (Hybrid Retrieval, Temporal Decay, Reason Diversity, Bridge Search) 
 | [F041](/specs/f041-memory-compaction) | Memory Compaction |
 | [F042](/specs/f042-decision-dependencies) | Decision Dependencies |
 | [F043](/specs/f043-distributed-merge) | Distributed Merge |
-| [F044](/specs/f044-agent-work-discovery) | Agent Work Discovery |
-| [F045](/specs/f045-graph-storage-layer) | Graph Storage Layer |
-
 ### Infrastructure
 
-| Spec | Feature |
-|------|---------|
-| [F048](/specs/f048-multi-vectordb) | Multi-Vector-DB Support |
+*F048 Multi-Vector-DB shipped in v0.12.0. Weaviate and pgvector backends planned as P2.*
 
 ## Theoretical Sources
 


### PR DESCRIPTION
Update docs for shipped F044 Agent Work Discovery + F045 Graph Storage:
- README: add ready + graph tools to MCP tables, update roadmap
- Website: MCP integration page, specs index, version badge
- TODO: mark done, add F045 follow-up items