### PR TITLE
feat: add cstp.debugTracker endpoint (#126)

### DIFF
--- a/a2a/cstp/deliberation_tracker.py
+++ b/a2a/cstp/deliberation_tracker.py
@@ -181,8 +181,8 @@ class DeliberationTracker:
             Dict with sessions list, session_count, and detail mapping.
         """
         with self._lock:
-            cutoff = time.time() - self._ttl
             now = time.time()
+            cutoff = now - self._ttl
 
             if key is not None:
                 session = self._sessions.get(key)

--- a/a2a/cstp/dispatcher.py
+++ b/a2a/cstp/dispatcher.py
@@ -833,19 +833,23 @@ async def _handle_debug_tracker(params: dict[str, Any], agent_id: str) -> dict[s
     """Handle cstp.debugTracker method (F126).
 
     Read-only peek at deliberation tracker state for debugging.
+    Any authenticated agent can inspect all sessions (admin-level debug tool).
 
     Args:
         params: JSON-RPC params with optional 'key' field.
-        agent_id: Authenticated agent ID.
+        agent_id: Authenticated agent ID (not scoped — intentional for debugging).
 
     Returns:
         Tracker debug info with sessions, counts, and input details.
     """
     from .deliberation_tracker import debug_tracker
-    from .models import DebugTrackerRequest
+    from .models import DebugTrackerRequest, DebugTrackerResponse
 
+    params = params or {}
     request = DebugTrackerRequest.from_params(params)
-    return debug_tracker(key=request.key)
+    raw = debug_tracker(key=request.key)
+    response = DebugTrackerResponse.from_raw(raw)
+    return response.to_dict()
 
 
 async def _handle_update_decision(params: dict[str, Any], agent_id: str) -> dict[str, Any]:

--- a/tests/test_f126_debug_tracker.py
+++ b/tests/test_f126_debug_tracker.py
@@ -13,7 +13,7 @@ from a2a.cstp.deliberation_tracker import (
     track_reasoning,
 )
 from a2a.cstp.dispatcher import CstpDispatcher, register_methods
-from a2a.cstp.models import DebugTrackerRequest, DebugTrackerResponse
+from a2a.cstp.models import DebugTrackerRequest, DebugTrackerResponse, TrackerSessionDetail
 from a2a.models.jsonrpc import JsonRpcRequest
 
 
@@ -61,15 +61,17 @@ class TestDebugTrackerModels:
         assert req.key == "agent-1"
 
     def test_response_to_dict(self) -> None:
+        session_detail = TrackerSessionDetail(key="s1", input_count=1, inputs=[])
         resp = DebugTrackerResponse(
             sessions=["s1", "s2"],
             session_count=2,
-            detail={"s1": {"inputCount": 1, "inputs": []}},
+            detail={"s1": session_detail},
         )
         data = resp.to_dict()
         assert data["sessions"] == ["s1", "s2"]
         assert data["sessionCount"] == 2
         assert "s1" in data["detail"]
+        assert data["detail"]["s1"]["inputCount"] == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `cstp.debugTracker` endpoint for read-only inspection of the in-memory deliberation tracker state
- Enables debugging the pre_action deliberation pipeline (issue #120) by peeking at tracked thoughts per session without consuming them
- Supports filtering by session key or returning all sessions, with age_seconds computed per input

## Changes
- **`a2a/cstp/deliberation_tracker.py`** — `debug_sessions()` method + `debug_tracker()` convenience function
- **`a2a/cstp/models.py`** — `DebugTrackerRequest`, `TrackerInputDetail`, `TrackerSessionDetail`, `DebugTrackerResponse` dataclasses
- **`a2a/cstp/dispatcher.py`** — `_handle_debug_tracker` handler + `cstp.debugTracker` registration
- **`tests/test_f126_debug_tracker.py`** — 19 tests (models, core tracker, convenience functions, dispatcher integration)

## Test plan
- [x] 19 new tests all pass
- [x] Full suite: 722 passed, 3 skipped, 0 failures
- [x] Lint clean (`ruff check`)
- [ ] Manual verification: call `recordThought` → `debugTracker` → `preAction` → `debugTracker` to trace deliberation pipeline

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)