### PR TITLE
docs: add dedicated Contact page with top nav link

### DIFF
--- a/website/.vitepress/config.mjs
+++ b/website/.vitepress/config.mjs
@@ -22,6 +22,7 @@ export default withMermaid(defineConfig({
       { text: 'Guide', link: '/guide/what-is-cognition-engines' },
       { text: 'Reference', link: '/reference/product-overview' },
       { text: 'Specs', link: '/specs/' },
+      { text: 'Contact', link: '/contact' },
       {
         text: 'v0.12.0',
         items: [

--- a/website/contact.md
+++ b/website/contact.md
@@ -1,0 +1,16 @@
+# Contact
+
+## Owner
+
+**Timur Fatykhov**
+- 📧 [timur.fatykhov@cognition-engines.ai](mailto:timur.fatykhov@cognition-engines.ai)
+
+## Project
+
+- **GitHub:** [tfatykhov/cognition-agent-decisions](https://github.com/tfatykhov/cognition-agent-decisions)
+- **Website:** [cognition-engines.ai](https://cognition-engines.ai)
+- **Issues:** [GitHub Issues](https://github.com/tfatykhov/cognition-agent-decisions/issues)
+
+## Contributing
+
+We welcome contributions! Please open an issue or pull request on GitHub.


### PR DESCRIPTION
- New `/contact` page with owner email, GitHub links, contributing note
- Added Contact link in top nav after Specs, before version selector

Docs-only.