### PR TITLE
fix: add agent_id to MCP record_thought for multi-agent isolation (#136)

### DIFF
--- a/a2a/mcp_schemas.py
+++ b/a2a/mcp_schemas.py
@@ -402,11 +402,21 @@ class RecordThoughtInput(BaseModel):
         min_length=1,
         description="Reasoning/chain-of-thought text to record",
     )
+    agent_id: str | None = Field(
+        default=None,
+        description=(
+            "Agent identifier for multi-agent isolation. "
+            "Thoughts from different agent_ids are tracked separately. "
+            "Required when multiple agents share an MCP connection."
+        ),
+    )
     decision_id: str | None = Field(
         default=None,
         description=(
-            "Decision ID to append thought to (post-decision mode). "
-            "Omit for pre-decision mode (auto-attached on next recordDecision)."
+            "Decision ID to scope thought to. In post-decision mode "
+            "(decision already recorded), appends to existing deliberation. "
+            "In pre-decision mode, scopes the tracker bucket so only "
+            "recordDecision with matching decision_id consumes these thoughts."
         ),
     )
 


### PR DESCRIPTION
Closes #136

## Changes
- `mcp_schemas.py`: Added `agent_id` field to `RecordThoughtInput`
- `mcp_server.py`: Use `build_tracker_key(agent_id, decision_id, transport_key="mcp-session")` instead of hardcoded `"mcp-session"`
- Smart `decision_id` handling: if decision exists → append (post-decision), if not → tracker scoping (pre-decision)
- Return `tracker_key` in pre-decision response for debugging

## MCP Flow (after fix)
```
1. pre_action(auto_record=true)
   → decisionId: "abc123"

2. record_thought(text="...", agent_id="architect", decision_id="abc123")
   → tracker_key: "agent:architect:decision:abc123"

3. record_thought(text="...", agent_id="dev", decision_id="abc123")
   → tracker_key: "agent:dev:decision:abc123"

4. log_decision(agent_id="architect")
   → consumes ONLY architect thoughts
```

Backward compatible: no params = same `mcp-session` key as before.