### PR TITLE
fix: log_decision MCP tool - multi-agent deliberation isolation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -106,6 +106,12 @@ Link decisions to executable tasks with dependencies.
 - [ ] Implement Minsky Ch 27 censor for blocking bad decision patterns
 - Spec: `docs/features/F033-censor-layer.md`
 
+### Dashboard: Live Deliberation Viewer
+- [ ] Show open thought sessions from `cstp.debugTracker` in dashboard UI
+- [ ] Real-time updates (polling or SSE)
+- [ ] Per-session breakdown: agent key, input count, thought text, age
+- [ ] Visual indicator for thought accumulation and consumption
+
 ### Other improvements
 - [ ] Add date-range filtering to `cstp.queryDecisions` (`dateFrom`/`dateTo` params)
 

--- a/a2a/mcp_schemas.py
+++ b/a2a/mcp_schemas.py
@@ -235,6 +235,16 @@ class LogDecisionInput(BaseModel):
         ge=1,
         description="Pull request number",
     )
+    agent_id: str | None = Field(
+        default=None,
+        description="Agent identifier for multi-agent deliberation isolation. "
+        "Use when multiple agents share an MCP connection.",
+    )
+    decision_id: str | None = Field(
+        default=None,
+        description="Decision ID from pre_action to scope deliberation consumption. "
+        "Ensures only thoughts tracked for THIS decision are attached.",
+    )
     deliberation: DeliberationSchema | None = Field(
         default=None,
         description="Chain-of-thought trace: inputs gathered, reasoning steps, and timing",


### PR DESCRIPTION
## Summary

Adds `agent_id` and `decision_id` params to `log_decision` MCP tool, matching `record_thought` (PR #137).

## Problem

`log_decision` used hardcoded `get_mcp_tracker_key()` (returns `mcp-session`), bypassing the composite tracker key resolution. When multiple agents share an MCP connection and track thoughts with `agent_id`/`decision_id`, `log_decision` would consume from the wrong tracker key.

## Changes

- **`mcp_schemas.py`**: Added `agent_id` and `decision_id` optional fields to `LogDecisionInput`
- **`mcp_server.py`**: Uses `build_tracker_key(agent_id, decision_id, "mcp-session")` for tracker consumption + related decision extraction + deliberation auto-attach
- Passes `agent_id` to `RecordDecisionRequest` (was hardcoded `mcp-client`)

Fixes P1 from PR #131 review. Closes #129.