### PR TITLE
feat: F049 Live Deliberation Viewer spec

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -113,11 +113,15 @@ Link decisions to executable tasks with dependencies.
 - [ ] Implement Minsky Ch 27 censor for blocking bad decision patterns
 - Spec: `docs/features/F033-censor-layer.md`
 
-### Dashboard: Live Deliberation Viewer
-- [ ] Show open thought sessions from `cstp.debugTracker` in dashboard UI
-- [ ] Real-time updates (polling or SSE)
-- [ ] Per-session breakdown: agent key, input count, thought text, age
-- [ ] Visual indicator for thought accumulation and consumption
+### F049: Live Deliberation Viewer
+- [ ] Add `debug_tracker()` to `cstp_client.py`
+- [ ] Create `/deliberation` route + template
+- [ ] HTMX auto-refresh (5s polling)
+- [ ] Parse composite keys (agent name, decision link)
+- [ ] Color-code by age (active/stale/orphaned)
+- [ ] Type badges for thought sources
+- [ ] P2: Consumption history tracking
+- Spec: `docs/features/F049-live-deliberation-viewer.md`
 
 ### Other improvements
 - [ ] Add date-range filtering to `cstp.queryDecisions` (`dateFrom`/`dateTo` params)

--- a/docs/features/F049-live-deliberation-viewer.md
+++ b/docs/features/F049-live-deliberation-viewer.md
@@ -1,0 +1,189 @@
+# F049: Live Deliberation Viewer
+
+**Status:** Proposed
+**Priority:** P1
+**Depends on:** F028 (Reasoning Capture), F045 (Graph Storage), debugTracker endpoint
+
+## Problem
+
+Agents accumulate deliberation traces (thoughts, queries, guardrail checks) in the tracker before recording decisions. Today, the only way to inspect this is via `cstp.debugTracker` JSON-RPC - a raw JSON dump with no visual structure. When multiple agents share an MCP connection, it's hard to understand:
+
+- Which agents are actively deliberating
+- How many thoughts have accumulated per decision
+- Whether thoughts are being consumed correctly on `recordDecision`
+- The real-time flow from thought → decision → review
+
+Operators need a live view to monitor agent cognition, debug isolation issues, and verify the deliberation pipeline works end-to-end.
+
+## Solution
+
+Add a **Live Deliberation** page to the dashboard that shows real-time tracker state with auto-refresh, organized by agent and decision.
+
+## UI Design
+
+### Page Layout
+
+```
+┌─────────────────────────────────────────────────────┐
+│  🧠 Live Deliberation                    ⟳ Auto 5s  │
+├─────────────────────────────────────────────────────┤
+│                                                     │
+│  Active Sessions: 3          Total Thoughts: 12     │
+│                                                     │
+│  ┌─────────────────────────────────────────────┐    │
+│  │ 🟢 agent:planner:decision:abc123            │    │
+│  │    4 thoughts · 45s ago                     │    │
+│  │  ┌─────────────────────────────────────┐    │    │
+│  │  │ r-0292d47a · reasoning · 45s ago    │    │    │
+│  │  │ "Considering approach A vs B..."    │    │    │
+│  │  ├─────────────────────────────────────┤    │    │
+│  │  │ r-81e0aacd · reasoning · 38s ago    │    │    │
+│  │  │ "Approach B better for isolation"   │    │    │
+│  │  ├─────────────────────────────────────┤    │    │
+│  │  │ r-f3a1b2c4 · query · 30s ago       │    │    │
+│  │  │ "Found 3 similar decisions..."      │    │    │
+│  │  ├─────────────────────────────────────┤    │    │
+│  │  │ r-d5e6f7a8 · guardrail · 25s ago   │    │    │
+│  │  │ "Guardrail check passed"            │    │    │
+│  │  └─────────────────────────────────────┘    │    │
+│  └─────────────────────────────────────────────┘    │
+│                                                     │
+│  ┌─────────────────────────────────────────────┐    │
+│  │ 🟢 agent:architect:decision:def456          │    │
+│  │    2 thoughts · 12s ago                     │    │
+│  │  ...                                        │    │
+│  └─────────────────────────────────────────────┘    │
+│                                                     │
+│  ┌─────────────────────────────────────────────┐    │
+│  │ 🟡 mcp-session (no agent_id)               │    │
+│  │    6 thoughts · 2m ago                      │    │
+│  │  ...                                        │    │
+│  └─────────────────────────────────────────────┘    │
+│                                                     │
+│  ── Recently Consumed ──────────────────────────    │
+│  ✅ agent:dev:decision:ghi789 → decision 01cab3    │
+│     3 thoughts consumed · 5m ago                    │
+│                                                     │
+└─────────────────────────────────────────────────────┘
+```
+
+### Key Visual Elements
+
+1. **Session cards** - one per tracker key, color-coded:
+   - 🟢 Active (thoughts < 60s old)
+   - 🟡 Stale (thoughts > 60s old)
+   - 🔴 Very stale (> 5min, likely orphaned)
+
+2. **Thought timeline** - chronological list within each card:
+   - Type badge (reasoning, query, guardrail)
+   - Truncated text with expand-on-click
+   - Relative timestamp
+
+3. **Composite key breakdown** - parse and display:
+   - Agent name (from `agent:{name}`)
+   - Decision ID (from `decision:{id}`, linked to decision detail page)
+   - Warning icon for bare `mcp-session` keys (no isolation)
+
+4. **Recently consumed section** - show tracker keys that were cleared by `recordDecision` in the last 10 minutes, with link to the resulting decision
+
+5. **Auto-refresh** - HTMX polling every 5s (configurable), with visual pulse on new thoughts
+
+## API Requirements
+
+### Existing: `cstp.debugTracker`
+
+Already returns the needed data:
+
+```json
+{
+  "sessions": ["agent:planner:decision:abc123", ...],
+  "sessionCount": 3,
+  "detail": {
+    "agent:planner:decision:abc123": {
+      "key": "agent:planner:decision:abc123",
+      "inputCount": 4,
+      "inputs": [
+        {
+          "id": "r-0292d47a",
+          "type": "reasoning",
+          "text": "Considering approach A vs B...",
+          "source": "cstp:recordThought",
+          "ageSeconds": 45
+        }
+      ]
+    }
+  }
+}
+```
+
+### New: Consumption History (optional, P2)
+
+Track last N consumed tracker sessions for the "Recently Consumed" section:
+
+```json
+{
+  "method": "cstp.debugTracker",
+  "params": {
+    "include_consumed": true,
+    "consumed_limit": 10
+  }
+}
+```
+
+Returns additional `consumed` array with `{ key, thoughtCount, consumedAt, decisionId }`.
+
+## Implementation
+
+### Dashboard Changes
+
+1. **Route:** `GET /deliberation` → `deliberation()` view
+2. **Template:** `templates/deliberation.html`
+3. **Partial:** `templates/deliberation_partial.html` (HTMX swap target)
+4. **Nav:** Add sidebar link with 🔮 icon
+5. **Client:** `cstp_client.py` add `debug_tracker()` method
+6. **Auto-refresh:** `hx-get="/deliberation/partial" hx-trigger="every 5s" hx-swap="innerHTML"`
+
+### CSS
+
+- Reuse existing card styles from overview/decisions pages
+- Add type badges (reasoning=blue, query=green, guardrail=yellow)
+- Pulse animation for new thoughts (CSS `@keyframes`)
+- Collapsible thought text (Alpine.js `x-show`)
+
+### Tech Stack
+
+Same as existing dashboard:
+- Flask + Jinja2
+- HTMX for partial updates
+- Alpine.js for interactive elements
+- Chart.js (optional, for thought rate sparkline)
+
+## Checklist
+
+- [ ] Add `debug_tracker()` to `cstp_client.py`
+- [ ] Create `deliberation.html` template
+- [ ] Create `deliberation_partial.html` for HTMX refresh
+- [ ] Add `/deliberation` route to `app.py`
+- [ ] Add sidebar nav link
+- [ ] Parse composite keys for display (agent name, decision link)
+- [ ] Color-code by age (active/stale/orphaned)
+- [ ] Type badges for thought sources
+- [ ] Auto-refresh with HTMX polling
+- [ ] Expand/collapse thought text
+- [ ] Add to dashboard tests
+- [ ] P2: Consumption history tracking in server
+- [ ] P2: "Recently Consumed" section
+- [ ] P2: Thought rate sparkline chart
+
+## Testing
+
+- Mock `debugTracker` response in dashboard tests
+- Test composite key parsing (`agent:x:decision:y` → agent="x", decision="y")
+- Test empty state (no active sessions)
+- Test stale detection (age thresholds)
+
+## Security
+
+- Dashboard auth required (existing `auth.py`)
+- Thought text may contain sensitive reasoning - same access level as decision detail
+- No new CSTP auth changes needed (reuses dashboard token)

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -30,7 +30,10 @@ All feature specs live in `docs/features/`. One file per feature, consistent nam
 | F028 | Reasoning Capture | v0.10.0 | *(shipped as part of F023/F027)* |
 | F046 | Pre-Action Hook API | v0.11.0 | `F046-pre-action-hook.md` |
 | F047 | Session Context Endpoint | v0.11.0 | `F047-session-context.md` |
+| F041 | Memory Compaction | v0.12.0 | `F041-memory-compaction.md` |
 | F044 | Agent Work Discovery | v0.12.0 | `F044-agent-work-discovery.md` |
+| F045 | Decision Graph Storage Layer | v0.12.0 | `F045-graph-storage-layer.md` |
+| F048 | Multi-Vector-DB Support | v0.12.0 | `F048-multi-vectordb.md` |
 
 ## Roadmap
 
@@ -49,14 +52,15 @@ All feature specs live in `docs/features/`. One file per feature, consistent nam
 | F038 | Cross-Agent Federation | Cisco IoC, README | `F038-cross-agent-federation.md` |
 | F039 | Cognition Protocol Stack | Cisco IoC (SSTP/CSTP/LSTP) | `F039-protocol-stack.md` |
 | F040 | Task-Decision Graph | Beads (steveyegge/beads) | `F040-task-decision-graph.md` |
-| F041 | Memory Compaction | Beads (steveyegge/beads) | `F041-memory-compaction.md` |
+| ~~F041~~ | ~~Memory Compaction~~ | ~~Beads~~ | *Shipped in v0.12.0* |
 | F042 | ~~Decision Dependency Graph~~ | ~~Beads~~ (merged into F045) | `F042-decision-dependencies.md` |
 | F043 | Distributed Decision Merge | Beads (steveyegge/beads) | `F043-distributed-merge.md` |
 | ~~F044~~ | ~~Agent Work Discovery~~ | ~~Beads~~ | *Shipped in v0.12.0* |
-| F045 | Decision Graph Storage Layer | GNN/KG Research (ICML 2025, MemoBrain, Context Graphs) | `F045-graph-storage-layer.md` |
+| ~~F045~~ | ~~Decision Graph Storage Layer~~ | ~~GNN/KG Research~~ | *Shipped in v0.12.0* |
 | ~~F046~~ | ~~Pre-Action Hook API~~ | ~~Agentic Loop Integration~~ | *Shipped in v0.11.0* |
 | ~~F047~~ | ~~Session Context Endpoint~~ | ~~Agentic Loop Integration~~ | *Shipped in v0.11.0* |
-| F048 | Multi-Vector-DB Support | Infrastructure | `F048-multi-vectordb.md` |
+| ~~F048~~ | ~~Multi-Vector-DB Support~~ | ~~Infrastructure~~ | *Shipped in v0.12.0* |
+| F049 | Live Deliberation Viewer | Dashboard + debugTracker | `F049-live-deliberation-viewer.md` |
 
 ## Retired IDs
 


### PR DESCRIPTION
## F049: Live Deliberation Viewer

New dashboard page showing real-time deliberation tracker state.

### What it does
- Shows all active tracker sessions from `cstp.debugTracker`
- Session cards organized by composite key (agent + decision)
- Thought timeline with type badges (reasoning/query/guardrail)
- Color-coded by age: 🟢 active, 🟡 stale, 🔴 orphaned
- HTMX auto-refresh every 5s
- Composite key parsing: links decision IDs to detail pages
- P2: Recently consumed section (tracker → decision mapping)

### Files
- `docs/features/F049-live-deliberation-viewer.md` — full spec with UI mockup
- `docs/features/INDEX.md` — F041/F045/F048 moved to shipped, F049 added to roadmap
- `TODO.md` — F049 checklist added

Docs-only PR.