### PR TITLE
fix: upgrade low-quality-recording guardrail to block

### DIFF
--- a/guardrails/quality.yaml
+++ b/guardrails/quality.yaml
@@ -6,5 +6,5 @@
   condition:
     phase: record
     quality_score: "< 0.5"
-  action: warn
+  action: block
   message: "Low quality recording (score {quality_score}). Add --tag, --pattern, and diverse reasons for better retrieval."


### PR DESCRIPTION
One-line change: `action: warn` → `action: block` in `guardrails/quality.yaml`.

Decisions with quality score < 0.5 (missing tags, pattern, or reasons) will now be blocked instead of just warned. Forces agents to use the full pre_action flow.