### PR TITLE
fix: pass agent_id through pre_action, get_session_context, ready MCP handlers

### DIFF
--- a/a2a/mcp_schemas.py
+++ b/a2a/mcp_schemas.py
@@ -500,6 +500,13 @@ class PreActionInput(BaseModel):
         default=None,
         description="Abstract pattern this action represents",
     )
+    agent_id: str | None = Field(
+        default=None,
+        description=(
+            "Agent identifier for multi-agent attribution. "
+            "Use when multiple agents share an MCP connection."
+        ),
+    )
 
 
 # ============================================================================
@@ -539,6 +546,13 @@ class GetSessionContextInput(BaseModel):
         default="markdown",
         description="Response format: 'json' for structured data, 'markdown' for system prompt injection",
     )
+    agent_id: str | None = Field(
+        default=None,
+        description=(
+            "Agent identifier for multi-agent attribution. "
+            "Use when multiple agents share an MCP connection."
+        ),
+    )
 
 
 # ============================================================================
@@ -571,6 +585,13 @@ class ReadyInput(BaseModel):
         description=(
             "Filter to specific category: architecture, process, "
             "integration, tooling, security"
+        ),
+    )
+    agent_id: str | None = Field(
+        default=None,
+        description=(
+            "Agent identifier for multi-agent attribution. "
+            "Use when multiple agents share an MCP connection."
         ),
     )
 

--- a/a2a/mcp_server.py
+++ b/a2a/mcp_server.py
@@ -961,7 +961,7 @@ async def _handle_pre_action_mcp(arguments: dict[str, Any]) -> list[TextContent]
         params["pattern"] = args.pattern
 
     request = PreActionRequest.from_params(params)
-    response = await pre_action(request, agent_id="mcp-client")
+    response = await pre_action(request, agent_id=args.agent_id or "mcp-client")
 
     return [
         TextContent(
@@ -993,7 +993,7 @@ async def _handle_get_session_context_mcp(
         params["include"] = args.include
 
     request = SessionContextRequest.from_params(params)
-    response = await get_session_context(request, agent_id="mcp-client")
+    response = await get_session_context(request, agent_id=args.agent_id or "mcp-client")
 
     return [
         TextContent(
@@ -1020,7 +1020,7 @@ async def _handle_ready_mcp(arguments: dict[str, Any]) -> list[TextContent]:
         params["category"] = args.category
 
     request = ReadyRequest.from_params(params)
-    response = await get_ready_actions(request)
+    response = await get_ready_actions(request, agent_id=args.agent_id or "mcp-client")
 
     return [
         TextContent(

--- a/tests/test_issue_144_mcp_agent_id.py
+++ b/tests/test_issue_144_mcp_agent_id.py
@@ -1,0 +1,172 @@
+"""Tests for issue #144: agent_id passthrough in MCP handlers.
+
+Verifies that _handle_pre_action_mcp, _handle_get_session_context_mcp,
+and _handle_ready_mcp correctly forward the agent_id argument to their
+respective service functions (defaulting to "mcp-client" when omitted).
+"""
+
+import importlib.util
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+# Skip entire module if mcp is not installed (CI environment)
+if not importlib.util.find_spec("mcp"):
+    mock_mcp = MagicMock()
+    sys.modules["mcp"] = mock_mcp
+    sys.modules["mcp.server"] = mock_mcp.server
+    sys.modules["mcp.server.stdio"] = mock_mcp.server.stdio
+    sys.modules["mcp.server.streamable_http_manager"] = mock_mcp.server.streamable_http_manager
+    sys.modules["mcp.types"] = mock_mcp.types
+    mock_mcp.types.TextContent = type(
+        "TextContent",
+        (),
+        {"__init__": lambda self, **kwargs: self.__dict__.update(kwargs)},
+    )
+
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# pre_action handler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pre_action_passes_agent_id() -> None:
+    """pre_action handler forwards explicit agent_id to service."""
+    mock_response = MagicMock()
+    mock_response.to_dict.return_value = {"allowed": True, "decisionId": "abc12345"}
+
+    with patch(
+        "a2a.cstp.preaction_service.pre_action",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ) as mock_fn:
+        from a2a.mcp_server import _handle_pre_action_mcp
+
+        await _handle_pre_action_mcp({
+            "action": {"description": "test action"},
+            "agent_id": "my-agent",
+        })
+
+        mock_fn.assert_called_once()
+        _, kwargs = mock_fn.call_args
+        assert kwargs["agent_id"] == "my-agent"
+
+
+@pytest.mark.asyncio
+async def test_pre_action_defaults_to_mcp_client() -> None:
+    """pre_action handler defaults agent_id to 'mcp-client' when omitted."""
+    mock_response = MagicMock()
+    mock_response.to_dict.return_value = {"allowed": True, "decisionId": "abc12345"}
+
+    with patch(
+        "a2a.cstp.preaction_service.pre_action",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ) as mock_fn:
+        from a2a.mcp_server import _handle_pre_action_mcp
+
+        await _handle_pre_action_mcp({
+            "action": {"description": "test action"},
+        })
+
+        mock_fn.assert_called_once()
+        _, kwargs = mock_fn.call_args
+        assert kwargs["agent_id"] == "mcp-client"
+
+
+# ---------------------------------------------------------------------------
+# get_session_context handler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_session_context_passes_agent_id() -> None:
+    """get_session_context handler forwards explicit agent_id to service."""
+    mock_response = MagicMock()
+    mock_response.to_dict.return_value = {"markdown": "# Context"}
+
+    with patch(
+        "a2a.cstp.session_context_service.get_session_context",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ) as mock_fn:
+        from a2a.mcp_server import _handle_get_session_context_mcp
+
+        await _handle_get_session_context_mcp({
+            "agent_id": "planner-agent",
+        })
+
+        mock_fn.assert_called_once()
+        _, kwargs = mock_fn.call_args
+        assert kwargs["agent_id"] == "planner-agent"
+
+
+@pytest.mark.asyncio
+async def test_get_session_context_defaults_to_mcp_client() -> None:
+    """get_session_context handler defaults agent_id to 'mcp-client' when omitted."""
+    mock_response = MagicMock()
+    mock_response.to_dict.return_value = {"markdown": "# Context"}
+
+    with patch(
+        "a2a.cstp.session_context_service.get_session_context",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ) as mock_fn:
+        from a2a.mcp_server import _handle_get_session_context_mcp
+
+        await _handle_get_session_context_mcp({})
+
+        mock_fn.assert_called_once()
+        _, kwargs = mock_fn.call_args
+        assert kwargs["agent_id"] == "mcp-client"
+
+
+# ---------------------------------------------------------------------------
+# ready handler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ready_passes_agent_id() -> None:
+    """ready handler forwards explicit agent_id to service."""
+    mock_response = MagicMock()
+    mock_response.to_dict.return_value = {"actions": [], "total": 0}
+
+    with patch(
+        "a2a.cstp.ready_service.get_ready_actions",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ) as mock_fn:
+        from a2a.mcp_server import _handle_ready_mcp
+
+        await _handle_ready_mcp({
+            "agent_id": "dev-agent",
+        })
+
+        mock_fn.assert_called_once()
+        _, kwargs = mock_fn.call_args
+        assert kwargs["agent_id"] == "dev-agent"
+
+
+@pytest.mark.asyncio
+async def test_ready_defaults_to_mcp_client() -> None:
+    """ready handler defaults agent_id to 'mcp-client' when omitted."""
+    mock_response = MagicMock()
+    mock_response.to_dict.return_value = {"actions": [], "total": 0}
+
+    with patch(
+        "a2a.cstp.ready_service.get_ready_actions",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ) as mock_fn:
+        from a2a.mcp_server import _handle_ready_mcp
+
+        await _handle_ready_mcp({})
+
+        mock_fn.assert_called_once()
+        _, kwargs = mock_fn.call_args
+        assert kwargs["agent_id"] == "mcp-client"


### PR DESCRIPTION
## Summary
- Added `agent_id: str | None` field to `PreActionInput`, `GetSessionContextInput`, and `ReadyInput` Pydantic schemas in `mcp_schemas.py`
- Updated `_handle_pre_action_mcp`, `_handle_get_session_context_mcp`, and `_handle_ready_mcp` handlers to use `args.agent_id or "mcp-client"` instead of hardcoded `"mcp-client"`
- Added 6 tests verifying agent_id passthrough and default fallback for all 3 handlers

Closes #144

## Test plan
- [x] 6 new tests in `test_issue_144_mcp_agent_id.py` — all pass
- [x] Full suite: 865 passed, 3 skipped, 0 failures
- [x] Ruff lint: clean
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)