### PR TITLE
fix: add safe_auto_link() to pre_action auto_record path

### DIFF
--- a/a2a/cstp/preaction_service.py
+++ b/a2a/cstp/preaction_service.py
@@ -227,6 +227,25 @@ async def pre_action(
             record_result = await record_decision(record_req)
             if record_result.success:
                 decision_id = record_result.id
+
+                # F045 follow-up: Auto-link decision in graph (issue #157)
+                from .graph_service import safe_auto_link
+
+                related_dicts = (
+                    [r.to_dict() for r in record_req.related_to]
+                    if record_req.related_to
+                    else []
+                )
+                await safe_auto_link(
+                    response_id=decision_id,
+                    category=record_req.category,
+                    stakes=record_req.stakes,
+                    confidence=record_req.confidence,
+                    tags=list(record_req.tags),
+                    pattern=record_req.pattern,
+                    related_to=related_dicts,
+                    summary=str(record_req.decision)[:120],
+                )
         except Exception as e:
             logger.warning("Auto-record failed in pre_action: %s", e)
 


### PR DESCRIPTION
## Summary
- **Fixes #157** — `pre_action(auto_record=true)` now calls `safe_auto_link()` after successful `record_decision()`, matching the existing pattern in `dispatcher.py` and `mcp_server.py`
- Adds test `test_auto_record_calls_safe_auto_link` verifying the call with correct parameters

## Test plan
- [x] New test asserts `safe_auto_link` is called with correct `response_id`, `category`, `stakes`, `confidence`, `tags`, `pattern`, and `summary`
- [x] All 903 existing tests pass
- [x] Lint clean (`ruff check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)