### PR TITLE
fix: VitePress SVG rendering — remove blank lines in HTML blocks

### DIFF
--- a/website/nous.md
+++ b/website/nous.md
@@ -600,13 +600,10 @@ description: "AI that remembers, learns, and gets smarter. Built on the FORGE co
     transform: translateY(0);
   }
 </style>
-
 <div class="nous-page">
-
 <div class="nous-bg-grid"></div>
 <div class="nous-bg-glow-1"></div>
 <div class="nous-bg-glow-2"></div>
-
 <!-- ===== HERO ===== -->
 <div class="nous-section nous-hero">
   <div class="nous-hero-content">
@@ -638,7 +635,6 @@ description: "AI that remembers, learns, and gets smarter. Built on the FORGE co
         </div>
       </div>
     </div>
-
     <!-- Hero Architecture Diagram -->
     <div class="nous-hero-diagram">
       <svg viewBox="0 0 500 480" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -727,7 +723,6 @@ description: "AI that remembers, learns, and gets smarter. Built on the FORGE co
     </div>
   </div>
 </div>
-
 <!-- ===== PROBLEM / SOLUTION ===== -->
 <div class="nous-section">
   <div class="nous-section-header nous-fade-up">
@@ -762,7 +757,6 @@ description: "AI that remembers, learns, and gets smarter. Built on the FORGE co
     </div>
   </div>
 </div>
-
 <!-- ===== ARCHITECTURE: BRAIN / HEART ===== -->
 <div class="nous-section" id="architecture">
   <div class="nous-section-header nous-fade-up">
@@ -803,7 +797,6 @@ description: "AI that remembers, learns, and gets smarter. Built on the FORGE co
     </div>
   </div>
 </div>
-
 <!-- ===== COGNITIVE LOOP ===== -->
 <div class="nous-section">
   <div class="nous-section-header nous-fade-up">
@@ -885,7 +878,6 @@ description: "AI that remembers, learns, and gets smarter. Built on the FORGE co
     </svg>
   </div>
 </div>
-
 <!-- ===== MEMORY TYPES ===== -->
 <div class="nous-section" id="memory">
   <div class="nous-section-header nous-fade-up">
@@ -926,7 +918,6 @@ description: "AI that remembers, learns, and gets smarter. Built on the FORGE co
     </div>
   </div>
 </div>
-
 <!-- ===== KEY FEATURES ===== -->
 <div class="nous-section" id="features">
   <div class="nous-section-header nous-fade-up">
@@ -991,7 +982,6 @@ description: "AI that remembers, learns, and gets smarter. Built on the FORGE co
     </div>
   </div>
 </div>
-
 <!-- ===== COMPETITIVE MOAT ===== -->
 <div class="nous-section" id="moat">
   <div class="nous-section-header nous-fade-up">
@@ -1044,7 +1034,6 @@ description: "AI that remembers, learns, and gets smarter. Built on the FORGE co
     </div>
   </div>
 </div>
-
 <!-- ===== METRICS ===== -->
 <div class="nous-section" id="metrics">
   <div class="nous-section-header nous-fade-up">
@@ -1077,7 +1066,6 @@ description: "AI that remembers, learns, and gets smarter. Built on the FORGE co
       <div class="nous-metric-label">Features Shipped</div>
     </div>
   </div>
-
   <!-- Research Foundation -->
   <div style="margin-top: 4rem;">
     <div class="nous-section-header nous-fade-up">
@@ -1128,7 +1116,6 @@ description: "AI that remembers, learns, and gets smarter. Built on the FORGE co
       </div>
     </div>
   </div>
-
   <!-- Brand Hierarchy -->
   <div class="nous-brand-bar nous-fade-up">
     <div class="nous-brand-item">
@@ -1147,7 +1134,6 @@ description: "AI that remembers, learns, and gets smarter. Built on the FORGE co
     </div>
   </div>
 </div>
-
 <!-- ===== FOOTER ===== -->
 <div class="nous-footer">
   <p style="margin-bottom: 0.5rem;">
@@ -1157,9 +1143,7 @@ description: "AI that remembers, learns, and gets smarter. Built on the FORGE co
   <p>Built by a single engineer. Powered by cognitive science. Ready to scale.</p>
   <p style="margin-top: 1rem; font-size: 0.75rem; color: #4a4a60;">© 2026 Cognition Engines. All rights reserved.</p>
 </div>
-
 </div>
-
 <script setup>
 import { onMounted } from 'vue'
 


### PR DESCRIPTION
## Problem
SVG diagrams on cognition-engines.ai/nous.html were rendering as raw text instead of actual diagrams.

## Root Cause
VitePress/CommonMark HTML block type 6 (custom tags like `<div>`) **ends at blank lines**. There were 16 blank lines scattered within the HTML content section.

After each blank line, VitePress switched back to markdown mode. The subsequent 4+ space indented HTML/SVG content was then parsed as **indented code blocks** (markdown treats 4+ spaces as code), causing SVG markup to render as literal text.

## Fix
Removed all 16 blank lines from within the HTML content section (between `</style>` and `<script setup>`). This ensures VitePress treats the entire page as one continuous HTML block, preserving proper SVG rendering.

## Verification
- All SVG diagrams should now render as actual graphics
- All CSS animations should work
- Layout and text content unchanged