### PR TITLE
feat(F055): Decision Provenance & Control Evidence

### DIFF
--- a/a2a/cstp/dispatcher.py
+++ b/a2a/cstp/dispatcher.py
@@ -62,6 +62,13 @@ from .models import (
     SessionContextRequest,
 )
 from .preaction_service import pre_action
+from .provenance_service import (
+    export_evidence_bundle,
+    ingest_evidence,
+    link_evidence,
+    map_controls,
+    verify_evidence_chain,
+)
 from .query_service import query_decisions, load_all_decisions
 from .reindex_service import reindex_decisions
 from .session_context_service import get_session_context
@@ -1094,6 +1101,38 @@ async def _handle_reset_circuit(
     return response.to_dict()
 
 
+# ── F055: Decision Provenance handlers ───────────────────────────────────────
+
+
+async def _handle_ingest_evidence(params: dict[str, Any], agent_id: str) -> dict[str, Any]:
+    """Handle cstp.ingestEvidence method (F055)."""
+    return await ingest_evidence(params, agent_id)
+
+
+async def _handle_link_evidence(params: dict[str, Any], agent_id: str) -> dict[str, Any]:
+    """Handle cstp.linkEvidence method (F055)."""
+    return await link_evidence(params, agent_id)
+
+
+async def _handle_map_controls(params: dict[str, Any], agent_id: str) -> dict[str, Any]:
+    """Handle cstp.mapControls method (F055)."""
+    return await map_controls(params, agent_id)
+
+
+async def _handle_export_evidence_bundle(
+    params: dict[str, Any], agent_id: str
+) -> dict[str, Any]:
+    """Handle cstp.exportEvidenceBundle method (F055)."""
+    return await export_evidence_bundle(params, agent_id)
+
+
+async def _handle_verify_evidence_chain(
+    params: dict[str, Any], agent_id: str
+) -> dict[str, Any]:
+    """Handle cstp.verifyEvidenceChain method (F055)."""
+    return await verify_evidence_chain(params, agent_id)
+
+
 def register_methods(dispatcher: CstpDispatcher) -> None:
     """Register all CSTP method handlers.
 
@@ -1148,6 +1187,13 @@ def register_methods(dispatcher: CstpDispatcher) -> None:
 
     # F126: Debug Tracker
     dispatcher.register("cstp.debugTracker", _handle_debug_tracker)
+
+    # F055: Decision Provenance & Control Evidence
+    dispatcher.register("cstp.ingestEvidence", _handle_ingest_evidence)
+    dispatcher.register("cstp.linkEvidence", _handle_link_evidence)
+    dispatcher.register("cstp.mapControls", _handle_map_controls)
+    dispatcher.register("cstp.exportEvidenceBundle", _handle_export_evidence_bundle)
+    dispatcher.register("cstp.verifyEvidenceChain", _handle_verify_evidence_chain)
 
 
 async def _handle_debug_tracker(params: dict[str, Any], agent_id: str) -> dict[str, Any]:

--- a/a2a/cstp/provenance/__init__.py
+++ b/a2a/cstp/provenance/__init__.py
@@ -1,0 +1,1 @@
+"""F055 Decision Provenance subpackage — mapping engine and control rules."""

--- a/a2a/cstp/provenance/mapping.py
+++ b/a2a/cstp/provenance/mapping.py
@@ -1,0 +1,195 @@
+"""
+Framework mapping rule engine for F055 Decision Provenance.
+
+Loads declarative YAML rule files and applies them to event streams.
+Coverage is computed and reported SEPARATELY per evidence class — never blended.
+
+  observed_coverage_pct — % of observed events with at least one framework mapping
+  attested_coverage_pct — % of attested events with at least one framework mapping
+
+A control satisfied only by attested evidence is flagged attested_only=True and
+must be rendered distinctly in any bundle output (including PDF).
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+MAPPINGS_DIR = Path(__file__).parent / "mappings"
+INSUFFICIENT_EVIDENCE_TAG = "INSUFFICIENT_EVIDENCE"
+
+
+@dataclass
+class EvidenceClassStats:
+    """Coverage stats for a single evidence class."""
+
+    total_events: int = 0
+    mapped_events: int = 0
+    unmapped_events: int = 0
+    coverage_pct: float = 0.0
+
+
+@dataclass
+class MappingResult:
+    """Result of applying framework rules to an event stream.
+
+    Coverage is reported separately per class. There is no blended coverage_pct
+    anywhere in this structure — that is intentional and load-bearing.
+    """
+
+    observed: EvidenceClassStats = field(default_factory=EvidenceClassStats)
+    attested: EvidenceClassStats = field(default_factory=EvidenceClassStats)
+    mappings: list[dict] = field(default_factory=list)
+    insufficient_evidence: list[dict] = field(default_factory=list)
+    unmapped: list[dict] = field(default_factory=list)
+    attested_only_controls: set[str] = field(default_factory=set)
+
+    @property
+    def total_insufficient_evidence(self) -> int:
+        return len(self.insufficient_evidence)
+
+
+def load_rules(mappings_dir: Path = MAPPINGS_DIR) -> list[dict]:
+    """Load all YAML rule files from mappings_dir. Returns combined list of rules."""
+    all_rules = []
+    for yaml_file in sorted(mappings_dir.glob("*.yaml")):
+        with open(yaml_file) as f:
+            data = yaml.safe_load(f)
+        framework = data.get("framework", yaml_file.stem)
+        for rule in data.get("rules", []):
+            rule = dict(rule)
+            rule["_framework"] = framework
+            rule["_file"] = yaml_file.name
+            all_rules.append(rule)
+    return all_rules
+
+
+def _check_condition(payload: dict, condition: dict) -> bool:
+    """Evaluate a single condition against an event payload."""
+    field_name = condition.get("field")
+    value = payload.get(field_name)
+
+    if "equals" in condition:
+        return value == condition["equals"]
+    if "gt" in condition:
+        return value is not None and value > condition["gt"]
+    if "lt" in condition:
+        return value is not None and value < condition["lt"]
+    if "truthy" in condition:
+        return bool(value) == condition["truthy"]
+    if "in" in condition:
+        return value in condition["in"]
+    return value is not None
+
+
+def _rule_matches(event: dict, rule: dict) -> bool:
+    """Return True if a rule's match block applies to this event."""
+    match = rule.get("match", {})
+    if match.get("event_type") != event.get("event_type"):
+        return False
+    for condition in match.get("conditions", []):
+        if not _check_condition(event.get("payload", {}), condition):
+            return False
+    return True
+
+
+def apply_rules(events: list[dict], rules: list[dict]) -> MappingResult:
+    """Apply all rules to all events, computing per-class coverage.
+
+    An event is 'mapped' if at least one rule matched it (including INSUFFICIENT_EVIDENCE).
+    An event is 'unmapped' if no rule matched it at all.
+
+    Coverage is computed separately for 'observed' and 'attested' events.
+    There is NO single blended coverage_pct.
+    """
+    result = MappingResult()
+
+    # Track which seqs were mapped, keyed by evidence_class
+    mapped_seqs_by_class: dict[str, set] = {"observed": set(), "attested": set()}
+
+    for event in events:
+        seq = event.get("seq")
+        event_type = event.get("event_type")
+        ev_class = event.get("evidence_class", "observed")
+
+        for rule in rules:
+            if not _rule_matches(event, rule):
+                continue
+
+            mapped_seqs_by_class.setdefault(ev_class, set()).add(seq)
+
+            entry: dict = {
+                "seq": seq,
+                "event_type": event_type,
+                "pr_number": event.get("payload", {}).get("pr_number"),
+                "rule_id": rule.get("id"),
+                "framework": rule.get("_framework"),
+                "stage": rule.get("stage"),
+                "function_id": rule.get("function_id"),
+                "control_name": rule.get("control_name"),
+                "ts": event.get("ts"),
+                "evidence_class": ev_class,
+            }
+            if rule.get("stretch"):
+                entry["stretch"] = True
+            if rule.get("confidence"):
+                entry["confidence"] = rule.get("confidence")
+
+            if rule.get("insufficient_evidence"):
+                entry["type"] = INSUFFICIENT_EVIDENCE_TAG
+                entry["reason"] = rule.get("reason", "").strip()
+                result.insufficient_evidence.append(entry)
+            else:
+                entry["type"] = "mapping"
+                entry["description"] = rule.get("description", "").strip()
+                result.mappings.append(entry)
+
+    # Identify unmapped events
+    for event in events:
+        seq = event.get("seq")
+        ev_class = event.get("evidence_class", "observed")
+        if seq not in mapped_seqs_by_class.get(ev_class, set()):
+            result.unmapped.append({
+                "seq": seq,
+                "event_type": event.get("event_type"),
+                "pr_number": event.get("payload", {}).get("pr_number"),
+                "ts": event.get("ts"),
+                "evidence_class": ev_class,
+            })
+
+    # Compute per-class coverage
+    obs_total = sum(1 for e in events if e.get("evidence_class", "observed") == "observed")
+    att_total = sum(1 for e in events if e.get("evidence_class") == "attested")
+
+    result.observed.total_events = obs_total
+    result.observed.mapped_events = len(mapped_seqs_by_class.get("observed", set()))
+    result.observed.unmapped_events = obs_total - result.observed.mapped_events
+    if obs_total > 0:
+        result.observed.coverage_pct = round(
+            result.observed.mapped_events / obs_total * 100, 1
+        )
+
+    result.attested.total_events = att_total
+    result.attested.mapped_events = len(mapped_seqs_by_class.get("attested", set()))
+    result.attested.unmapped_events = att_total - result.attested.mapped_events
+    if att_total > 0:
+        result.attested.coverage_pct = round(
+            result.attested.mapped_events / att_total * 100, 1
+        )
+
+    # Identify attested-only controls: controls with attested mappings but NO observed mappings
+    observed_control_ids: set[str] = {
+        m["function_id"] for m in result.mappings if m.get("evidence_class") == "observed"
+    }
+    attested_control_ids: set[str] = {
+        m["function_id"] for m in result.mappings if m.get("evidence_class") == "attested"
+    }
+    result.attested_only_controls = attested_control_ids - observed_control_ids
+
+    # Tag attested-only mappings in the list
+    for m in result.mappings:
+        if m.get("function_id") in result.attested_only_controls:
+            m["attested_only"] = True
+
+    return result

--- a/a2a/cstp/provenance/mappings/cstp-attested.yaml
+++ b/a2a/cstp/provenance/mappings/cstp-attested.yaml
@@ -1,0 +1,57 @@
+version: "1.0"
+framework: "CSTP Attested"
+evidence_class: "attested"
+description: >
+  Framework mappings for first-party CSTP decision records (attested evidence).
+  These rules apply to cstp_decision_linked events created by cstp.linkEvidence.
+  Attested evidence is self-reported by the agent and discounted heavily by auditors
+  compared to observed third-party evidence.
+  Controls satisfied ONLY by these rules are flagged attested_only=true in bundles.
+
+rules:
+  # Agent decision documentation — attested evidence of decision intent
+  - id: "CSTP-SR117-MV1-decision-record"
+    stage: "Model Development"
+    function_id: "MV-1"
+    control_name: "Agent Decision Documentation (Self-Attested)"
+    description: >
+      A recorded CSTP decision provides self-attested documentation of the agent's
+      reasoning, confidence score, stakes assessment, and rationale at decision time.
+      Weaker than observed PR evidence — an agent can write anything into this record.
+      Useful as a corroborating signal, not as primary evidence.
+    match:
+      event_type: "cstp_decision_linked"
+
+  # Reviewed CSTP decision — attested post-hoc review evidence
+  - id: "CSTP-SR117-MV3-reviewed-decision"
+    stage: "Model Validation"
+    function_id: "MV-3"
+    control_name: "Agent Decision Review (Self-Attested)"
+    description: >
+      A CSTP decision with a recorded outcome and review provides self-attested
+      evidence of post-decision quality assessment. The review is performed by the
+      agent or its operator, not an independent third party — treat as weak MV-3
+      evidence pending independent validation.
+    match:
+      event_type: "cstp_decision_linked"
+      conditions:
+        - field: "has_outcome"
+          truthy: true
+
+  # High-stakes CSTP decisions — governance evidence
+  - id: "CSTP-NIST-GOVERN-1.1-high-stakes-decision"
+    stage: "GOVERN"
+    function_id: "GOVERN-1.1"
+    control_name: "High-Stakes AI Decision Governance (Self-Attested)"
+    description: >
+      GOVERN-1.1 requires policies for AI risk management.
+      A recorded high-stakes CSTP decision demonstrates that the agent applied
+      governance criteria (confidence, stakes, reasons) before acting.
+      Self-attested; an examiner will ask for corroborating observed evidence.
+    match:
+      event_type: "cstp_decision_linked"
+      conditions:
+        - field: "stakes"
+          in:
+            - "high"
+            - "critical"

--- a/a2a/cstp/provenance/mappings/nist-ai-rmf.yaml
+++ b/a2a/cstp/provenance/mappings/nist-ai-rmf.yaml
@@ -1,0 +1,121 @@
+version: "1.0"
+framework: "NIST AI RMF"
+evidence_class: "observed"
+description: >
+  NIST Artificial Intelligence Risk Management Framework (AI RMF 1.0, January 2023).
+  Maps GitHub PR events to GOVERN, MAP, MEASURE, and MANAGE function subcategories.
+  All rules in this file produce observed-class evidence (third-party GitHub events).
+  Reference: https://airc.nist.gov/RMF
+
+rules:
+  # GOVERN: Policies and accountability for AI risk management
+  - id: "NIST-GOVERN-1.1-agent-disclosure"
+    stage: "GOVERN"
+    function_id: "GOVERN-1.1"
+    control_name: "AI Risk Policies — Agent Contribution Disclosure"
+    description: >
+      GOVERN-1.1 requires organizational policies for AI risk management.
+      Agent-authored PRs with Co-Authored-By trailers provide a machine-readable
+      disclosure of AI involvement, enabling policy enforcement at the commit level.
+    match:
+      event_type: "pr_opened"
+      conditions:
+        - field: "is_agent_authored"
+          equals: true
+
+  # MAP: Context and risk identification
+  # stretch: true — PROOF.md rates this "weak; would not survive an audit question".
+  # MAP-1.1 envisions a systematic risk-context assessment, not a code-change description.
+  # Retained for traceability but surfaced as partial/contested in output bundles.
+  - id: "NIST-MAP-1.1-change-context"
+    stage: "MAP"
+    function_id: "MAP-1.1"
+    control_name: "AI Risk Context Identification"
+    confidence: low
+    stretch: true
+    description: >
+      MAP-1.1 requires identifying the context in which AI systems operate.
+      Each PR opening captures the risk context: what changed, how much,
+      whether AI was involved, and what issue or requirement it addresses.
+      NOTE: This is a stretch mapping — a PR description is not a formal risk-context
+      assessment. Treat as partial evidence only.
+    match:
+      event_type: "pr_opened"
+
+  # MEASURE: Analysis and evaluation of AI risk
+  - id: "NIST-MEASURE-2.5-human-review"
+    stage: "MEASURE"
+    function_id: "MEASURE-2.5"
+    control_name: "AI Risk Evaluation via Human Review"
+    description: >
+      MEASURE-2.5 requires evaluating AI risks through independent assessment.
+      A human reviewer's approval constitutes a documented risk evaluation:
+      a qualified person attested that the AI output is acceptable for deployment.
+    match:
+      event_type: "pr_review_approved"
+
+  # MEASURE: Review comments as risk evaluation evidence
+  - id: "NIST-MEASURE-2.6-review-challenge"
+    stage: "MEASURE"
+    function_id: "MEASURE-2.6"
+    control_name: "Risk Identification via Review Challenge"
+    description: >
+      MEASURE-2.6 covers evaluation of AI risk factors. Review comments and
+      change requests document identified risks and required remediations,
+      constituting evidence of ongoing risk assessment.
+    match:
+      event_type: "pr_review_comment"
+
+  # MANAGE: Risk response — approved deployment (agent-authored only)
+  # is_agent_authored condition required: MANAGE-1.1 is "AI Risk Response".
+  # Claiming AI risk management credit for purely human-authored merges is a category error.
+  - id: "NIST-MANAGE-1.1-approved-deployment"
+    stage: "MANAGE"
+    function_id: "MANAGE-1.1"
+    control_name: "AI Risk Response — Approved Change Deployment"
+    description: >
+      MANAGE-1.1 requires responding to identified AI risks with appropriate actions.
+      Merging a reviewed and approved agent-authored change demonstrates that the risk
+      evaluation was completed and the organization accepted the residual risk for deployment.
+    match:
+      event_type: "pr_merged"
+      conditions:
+        - field: "approval_count"
+          gt: 0
+        - field: "is_agent_authored"
+          equals: true
+
+  # MANAGE: INSUFFICIENT EVIDENCE — agent change deployed without human oversight
+  - id: "NIST-MANAGE-2.2-ie-no-human-oversight"
+    stage: "MANAGE"
+    function_id: "MANAGE-2.2"
+    control_name: "Human Oversight of AI Decisions"
+    insufficient_evidence: true
+    reason: >
+      INSUFFICIENT EVIDENCE: Agent-authored change was deployed without human oversight.
+      NIST AI RMF MANAGE-2.2 requires human oversight mechanisms for AI system outputs.
+      Merging agent-authored code without any human approval removes the human-in-the-loop
+      control. No evidence of risk evaluation or acceptance before deployment.
+    match:
+      event_type: "pr_merged"
+      conditions:
+        - field: "is_agent_authored"
+          equals: true
+        - field: "approval_count"
+          equals: 0
+
+  # GOVERN: Commit-level agent attribution as governance record
+  - id: "NIST-GOVERN-6.1-commit-attribution"
+    stage: "GOVERN"
+    function_id: "GOVERN-6.1"
+    control_name: "AI System Accountability Records"
+    description: >
+      GOVERN-6.1 requires accountability mechanisms for AI systems.
+      Each agent-authored commit with a Co-Authored-By trailer creates
+      an immutable, commit-level record of AI contribution — a governance artifact
+      that survives repository history even if PR metadata is lost.
+    match:
+      event_type: "pr_commit"
+      conditions:
+        - field: "is_agent_authored"
+          equals: true

--- a/a2a/cstp/provenance/mappings/sr11-7.yaml
+++ b/a2a/cstp/provenance/mappings/sr11-7.yaml
@@ -1,0 +1,132 @@
+version: "1.0"
+framework: "SR 11-7"
+evidence_class: "observed"
+description: >
+  Federal Reserve SR 11-7 Supervisory Guidance on Model Risk Management.
+  Maps GitHub PR events to SR 11-7 model development/validation/governance stages.
+  All rules in this file produce observed-class evidence (third-party GitHub events).
+  Reference: https://www.federalreserve.gov/supervisionreg/srletters/sr1107a1.pdf
+
+rules:
+  # Model Development stage: agent-authored code change documented
+  - id: "SR11-7-MV1-agent-pr-opened"
+    stage: "Model Development"
+    function_id: "MV-1"
+    control_name: "Agent-Authored Change Documentation"
+    description: >
+      SR 11-7 MV-1 requires documentation of model development activities.
+      An agent-authored PR opening provides a record of what the agent produced,
+      including diff stats, linked issues, and authorship attribution.
+    match:
+      event_type: "pr_opened"
+      conditions:
+        - field: "is_agent_authored"
+          equals: true
+
+  # Model Development stage: human-authored code change (reduced scrutiny but tracked)
+  - id: "SR11-7-MV1-human-pr-opened"
+    stage: "Model Development"
+    function_id: "MV-1"
+    control_name: "Human-Authored Change Documentation"
+    description: >
+      Human-authored changes are also documented as part of the change record
+      for completeness of the development audit trail.
+    match:
+      event_type: "pr_opened"
+      conditions:
+        - field: "is_agent_authored"
+          equals: false
+
+  # Model Validation stage: independent human reviewer approved the change
+  - id: "SR11-7-MV3-human-approval"
+    stage: "Model Validation"
+    function_id: "MV-3"
+    control_name: "Independent Human Review and Approval"
+    description: >
+      SR 11-7 MV-3 requires independent review of model outputs and decisions.
+      A human reviewer's approval provides evidence of independent oversight
+      of the agent-generated or human-generated code change.
+    match:
+      event_type: "pr_review_approved"
+
+  # Model Validation stage: review feedback (CHANGES_REQUESTED or COMMENTED)
+  - id: "SR11-7-MV3-review-feedback"
+    stage: "Model Validation"
+    function_id: "MV-3"
+    control_name: "Review Feedback and Challenge"
+    description: >
+      SR 11-7 MV-3 values critical challenge of model outputs.
+      Review comments and change requests demonstrate active oversight
+      rather than rubber-stamp approval.
+    match:
+      event_type: "pr_review_comment"
+
+  # Change Management stage: approved agent-authored change was merged
+  - id: "SR11-7-CM1-approved-agent-merge"
+    stage: "Change Management"
+    function_id: "CM-1"
+    control_name: "Approved Agent Change Deployment"
+    description: >
+      SR 11-7 CM-1 requires documented approval before deploying model changes.
+      Merging an agent-authored PR with prior human approval satisfies this control.
+    match:
+      event_type: "pr_merged"
+      conditions:
+        - field: "is_agent_authored"
+          equals: true
+        - field: "approval_count"
+          gt: 0
+
+  # Change Management stage: human-authored change merged (informational)
+  - id: "SR11-7-CM1-human-merge"
+    stage: "Change Management"
+    function_id: "CM-1"
+    control_name: "Human Change Deployment"
+    description: >
+      Human-authored change merged after review. Tracked for completeness
+      of change management evidence.
+    match:
+      event_type: "pr_merged"
+      conditions:
+        - field: "is_agent_authored"
+          equals: false
+        - field: "approval_count"
+          gt: 0
+
+  # INSUFFICIENT EVIDENCE: agent-authored PR merged without any human approval
+  - id: "SR11-7-MV3-ie-no-approval-on-merge"
+    stage: "Model Validation"
+    function_id: "MV-3"
+    control_name: "Independent Human Review and Approval"
+    insufficient_evidence: true
+    reason: >
+      INSUFFICIENT EVIDENCE: Agent-authored PR was merged without any human approval.
+      SR 11-7 MV-3 requires independent review of agent/model outputs before deployment.
+      Self-merge of agent-authored code without a second reviewer violates the independence
+      requirement and creates an unverifiable change in the audit trail.
+    match:
+      event_type: "pr_merged"
+      conditions:
+        - field: "is_agent_authored"
+          equals: true
+        - field: "approval_count"
+          equals: 0
+
+  # INSUFFICIENT EVIDENCE: human PR merged without any review
+  - id: "SR11-7-CM1-ie-no-approval-human"
+    stage: "Change Management"
+    function_id: "CM-1"
+    control_name: "Approved Change Deployment"
+    insufficient_evidence: true
+    reason: >
+      INSUFFICIENT EVIDENCE: Human-authored PR merged without any recorded approval.
+      While SR 11-7 primarily targets model/agent changes, change management controls
+      require documented approval for production changes. Solo-merge without review
+      creates a gap in the change evidence trail.
+    match:
+      event_type: "pr_merged"
+      conditions:
+        - field: "is_agent_authored"
+          equals: false
+        - field: "approval_count"
+          equals: 0

--- a/a2a/cstp/provenance_service.py
+++ b/a2a/cstp/provenance_service.py
@@ -1,0 +1,641 @@
+"""F055 Decision Provenance & Control Evidence service.
+
+Provides five CSTP methods that turn GitHub PR history and CSTP decision records
+into an auditor-facing evidence bundle mapped to SR 11-7 and NIST AI RMF controls.
+
+Two evidence classes are maintained and NEVER blended:
+  observed  — third-party GitHub events, hash-chained for tamper-evidence
+  attested  — first-party CSTP decision records linked via cstp.linkEvidence
+
+See website/specs/f055-decision-provenance.md for the full design spec.
+"""
+
+import json
+import logging
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from .provenance.mapping import (
+    MAPPINGS_DIR,
+    MappingResult,
+    apply_rules,
+    load_rules,
+)
+from .storage.provenance import (
+    EVIDENCE_CLASS_ATTESTED,
+    EVIDENCE_CLASS_OBSERVED,
+    append_event,
+    get_events,
+    get_head_hash,
+    get_last_bundle_head_hash,
+    init_db,
+    store_bundle_head_hash,
+    verify_chain,
+)
+
+logger = logging.getLogger("cstp.provenance")
+
+DEFAULT_PROVENANCE_DB = os.environ.get(
+    "PROVENANCE_DB",
+    str(Path.home() / ".cstp" / "provenance.db"),
+)
+
+
+def _get_db_path(params: dict[str, Any]) -> str:
+    return params.get("db_path") or DEFAULT_PROVENANCE_DB
+
+
+def _ensure_db(db_path: str) -> None:
+    Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+    init_db(db_path)
+
+
+# ── cstp.ingestEvidence ───────────────────────────────────────────────────────
+
+
+async def ingest_evidence(params: dict[str, Any], agent_id: str) -> dict[str, Any]:
+    """Ingest observed events into the hash chain.
+
+    Params:
+        events   — list of event dicts, each with: event_type, ts, source, payload
+        source   — default source label if not specified per-event (default: "external")
+        db_path  — optional override for the provenance DB path
+
+    All ingested events receive evidence_class='observed'. The caller cannot override
+    this — observed events must come from external systems only.
+
+    Returns:
+        ingested      — count of events appended
+        head_hash     — hash of the new chain head after ingestion
+        first_seq     — sequence number of the first appended event
+    """
+    db_path = _get_db_path(params)
+    _ensure_db(db_path)
+
+    raw_events = params.get("events")
+    if not raw_events or not isinstance(raw_events, list):
+        raise ValueError("'events' must be a non-empty list")
+
+    default_source = params.get("source", "external")
+    ingested = 0
+    first_seq: int | None = None
+
+    for ev in raw_events:
+        if not isinstance(ev, dict):
+            raise ValueError("Each event must be a dict")
+        event_type = ev.get("event_type")
+        if not event_type:
+            raise ValueError("Each event must have 'event_type'")
+
+        payload = ev.get("payload", {})
+        ts = ev.get("ts")
+        source = ev.get("source") or default_source
+
+        seq, _ = append_event(
+            source=source,
+            event_type=event_type,
+            evidence_class=EVIDENCE_CLASS_OBSERVED,
+            payload=payload,
+            ts=ts,
+            db_path=db_path,
+        )
+        if first_seq is None:
+            first_seq = seq
+        ingested += 1
+
+    head_hash = get_head_hash(db_path)
+    return {
+        "ingested": ingested,
+        "head_hash": head_hash,
+        "first_seq": first_seq,
+    }
+
+
+# ── cstp.linkEvidence ─────────────────────────────────────────────────────────
+
+
+async def link_evidence(params: dict[str, Any], agent_id: str) -> dict[str, Any]:
+    """Correlate an existing CSTP decision to observed events.
+
+    This creates an attested evidence event (evidence_class='attested') in the
+    provenance store that references the CSTP decision. The attested event is
+    separate from the observed hash chain — its integrity derives from the CSTP
+    decision store, not a hash chain.
+
+    Params:
+        decision_id  — CSTP decision ID to correlate
+        event_seqs   — list of observed event sequence numbers being linked
+        stakes       — stakes level from the CSTP decision (optional, for mapping)
+        has_outcome  — whether the decision has a recorded outcome (optional)
+        db_path      — optional override for the provenance DB path
+
+    Returns:
+        linked        — count of event seqs linked
+        decision_id   — echoed decision ID
+        attested_seq  — sequence number of the synthetic attested event created
+    """
+    db_path = _get_db_path(params)
+    _ensure_db(db_path)
+
+    decision_id = params.get("decision_id")
+    if not decision_id:
+        raise ValueError("'decision_id' is required")
+
+    event_seqs = params.get("event_seqs", [])
+    if not isinstance(event_seqs, list):
+        raise ValueError("'event_seqs' must be a list")
+
+    stakes = params.get("stakes")
+    has_outcome = params.get("has_outcome", False)
+
+    payload: dict[str, Any] = {
+        "decision_id": decision_id,
+        "event_seqs": event_seqs,
+        "has_outcome": bool(has_outcome),
+    }
+    if stakes:
+        payload["stakes"] = stakes
+
+    # The attested synthetic event goes into the events table with evidence_class='attested'.
+    # It does NOT extend the observed hash chain — it has its own chain entry using its
+    # evidence_class in the preimage, making the class itself tamper-evident.
+    ts = datetime.now(UTC).isoformat()
+    seq, _ = append_event(
+        source=f"cstp:{agent_id}",
+        event_type="cstp_decision_linked",
+        evidence_class=EVIDENCE_CLASS_ATTESTED,
+        payload=payload,
+        ts=ts,
+        db_path=db_path,
+    )
+
+    return {
+        "linked": len(event_seqs),
+        "decision_id": decision_id,
+        "attested_seq": seq,
+    }
+
+
+# ── cstp.mapControls ──────────────────────────────────────────────────────────
+
+
+def _mapping_result_to_dict(mr: MappingResult) -> dict[str, Any]:
+    """Serialise MappingResult to a JSON-safe dict."""
+    return {
+        "coverage": {
+            "observed": {
+                "total_events": mr.observed.total_events,
+                "mapped_events": mr.observed.mapped_events,
+                "unmapped_events": mr.observed.unmapped_events,
+                "coverage_pct": mr.observed.coverage_pct,
+            },
+            "attested": {
+                "total_events": mr.attested.total_events,
+                "mapped_events": mr.attested.mapped_events,
+                "unmapped_events": mr.attested.unmapped_events,
+                "coverage_pct": mr.attested.coverage_pct,
+            },
+        },
+        "mappings": mr.mappings,
+        "insufficient_evidence": mr.insufficient_evidence,
+        "insufficient_evidence_count": mr.total_insufficient_evidence,
+        "unmapped": mr.unmapped,
+        "attested_only_controls": sorted(mr.attested_only_controls),
+    }
+
+
+async def map_controls(params: dict[str, Any], agent_id: str) -> dict[str, Any]:
+    """Run the YAML rules engine and return per-class control mappings.
+
+    Coverage is reported separately for observed and attested evidence.
+    There is no single blended coverage_pct.
+    Controls satisfied only by attested evidence are flagged attested_only=True.
+
+    Params:
+        db_path       — optional override for the provenance DB path
+        mappings_dir  — optional override for the YAML rules directory
+
+    Returns:
+        coverage.observed   — {total_events, mapped_events, unmapped_events, coverage_pct}
+        coverage.attested   — same structure for attested class
+        mappings            — list of mapping entries, each with evidence_class
+        insufficient_evidence  — list of gap entries
+        attested_only_controls — control IDs satisfied ONLY by attested evidence
+    """
+    db_path = _get_db_path(params)
+    _ensure_db(db_path)
+
+    mappings_dir_override = params.get("mappings_dir")
+    mappings_dir = Path(mappings_dir_override) if mappings_dir_override else MAPPINGS_DIR
+
+    events = get_events(db_path)
+    rules = load_rules(mappings_dir)
+    mr = apply_rules(events, rules)
+
+    return _mapping_result_to_dict(mr)
+
+
+# ── cstp.exportEvidenceBundle ─────────────────────────────────────────────────
+
+
+async def export_evidence_bundle(params: dict[str, Any], agent_id: str) -> dict[str, Any]:
+    """Emit the evidence bundle as JSON (and optionally PDF).
+
+    P2 fix: the bundle persists the head hash at generation time. Subsequent calls
+    to cstp.verifyEvidenceChain use that stored hash to detect tail truncation.
+
+    Params:
+        format        — "json" (default) or "pdf" or "both"
+        output_dir    — directory to write bundle files (default: ./bundles)
+        db_path       — optional override for the provenance DB path
+        mappings_dir  — optional override for the YAML rules directory
+
+    Returns:
+        json_path      — path to JSON bundle file (if format includes json)
+        pdf_path       — path to PDF bundle file (if format includes pdf)
+        chain_head_hash — head hash persisted at generation time
+        chain_intact   — result of verify_chain using the persisted head hash (P2 fix)
+        coverage       — per-class coverage (observed and attested, never blended)
+        insufficient_evidence_count — count of control gaps
+    """
+    db_path = _get_db_path(params)
+    _ensure_db(db_path)
+
+    fmt = params.get("format", "json").lower()
+    output_dir = Path(params.get("output_dir", "bundles"))
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    mappings_dir_override = params.get("mappings_dir")
+    mappings_dir = Path(mappings_dir_override) if mappings_dir_override else MAPPINGS_DIR
+
+    # Run mapping engine
+    events = get_events(db_path)
+    rules = load_rules(mappings_dir)
+    mr = apply_rules(events, rules)
+
+    # P2 fix: load the previously stored head hash to detect tail truncation,
+    # then store the current head hash for future verifications.
+    prev_bundle_hash = get_last_bundle_head_hash(db_path)
+    chain_head = get_head_hash(db_path)
+    store_bundle_head_hash(chain_head or "", "json", db_path)
+    # If a previous bundle hash exists, verify against it (catches tail truncation).
+    # First-time export has no previous hash: fall back to internal-only verification.
+    if prev_bundle_hash:
+        chain_intact = verify_chain(db_path, expected_head_hash=prev_bundle_hash) is None
+    else:
+        chain_intact = verify_chain(db_path) is None
+
+    generated_at = datetime.now(UTC).isoformat()
+    ts_tag = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+
+    result: dict[str, Any] = {
+        "chain_head_hash": chain_head,
+        "chain_intact": chain_intact,
+        "coverage": _mapping_result_to_dict(mr)["coverage"],
+        "insufficient_evidence_count": mr.total_insufficient_evidence,
+        "attested_only_controls": sorted(mr.attested_only_controls),
+    }
+
+    bundle_data: dict[str, Any] = {
+        "version": "1.0",
+        "tool_version": "cstp-f055",
+        "generated_at": generated_at,
+        "chain_head_hash": chain_head,
+        "chain_intact": chain_intact,
+        "coverage": _mapping_result_to_dict(mr)["coverage"],
+        "total_events": len(events),
+        "insufficient_evidence_count": mr.total_insufficient_evidence,
+        "attested_only_controls": sorted(mr.attested_only_controls),
+        "events": [{k: v for k, v in e.items() if k != "payload_json"} for e in events],
+        "mappings": mr.mappings,
+        "insufficient_evidence": mr.insufficient_evidence,
+        "unmapped": mr.unmapped,
+    }
+
+    if fmt in ("json", "both"):
+        json_path = output_dir / f"bundle_{ts_tag}.json"
+        json_path.write_text(
+            json.dumps(bundle_data, indent=2, sort_keys=False, ensure_ascii=False),
+            encoding="utf-8",
+        )
+        result["json_path"] = str(json_path)
+
+    if fmt in ("pdf", "both"):
+        pdf_path = _generate_pdf(mr, bundle_data, output_dir, ts_tag)
+        result["pdf_path"] = str(pdf_path)
+
+    return result
+
+
+def _generate_pdf(
+    mr: MappingResult,
+    bundle_data: dict[str, Any],
+    output_dir: Path,
+    ts_tag: str,
+) -> Path:
+    """Generate a human-readable PDF evidence bundle. Requires reportlab."""
+    try:
+        from reportlab.lib import colors
+        from reportlab.lib.enums import TA_CENTER
+        from reportlab.lib.pagesizes import letter
+        from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+        from reportlab.lib.units import inch
+        from reportlab.platypus import (
+            PageBreak,
+            Paragraph,
+            SimpleDocTemplate,
+            Spacer,
+            Table,
+            TableStyle,
+        )
+    except ImportError as exc:
+        raise RuntimeError(
+            "reportlab is required for PDF generation. "
+            "Install it with: pip install reportlab"
+        ) from exc
+
+    path = output_dir / f"bundle_{ts_tag}.pdf"
+    chain_head = bundle_data["chain_head_hash"]
+    chain_intact = bundle_data["chain_intact"]
+
+    base = getSampleStyleSheet()
+
+    def style(name: str, **kwargs: Any) -> ParagraphStyle:
+        return ParagraphStyle(name, parent=base["Normal"], **kwargs)
+
+    accent = colors.HexColor("#0f3460")
+    gap_color = colors.HexColor("#ffdddd")
+    header_color = colors.HexColor("#e8eaf6")
+
+    h1 = style("H1", fontSize=18, fontName="Helvetica-Bold", spaceAfter=8,
+                textColor=accent)
+    h3 = style("H3", fontSize=10, fontName="Helvetica-Bold", spaceAfter=3,
+                textColor=colors.HexColor("#0f3460"), spaceBefore=8)
+    body = style("Body", fontSize=9, leading=13, spaceAfter=4)
+    small = style("Small", fontSize=8, leading=11,
+                  textColor=colors.HexColor("#555555"))
+    ok_style = style("OK", fontSize=9, leading=13, textColor=colors.HexColor("#006600"))
+
+    def tbl_style(hdr_color: Any = None) -> TableStyle:
+        if hdr_color is None:
+            hdr_color = header_color
+        return TableStyle([
+            ("BACKGROUND", (0, 0), (-1, 0), hdr_color),
+            ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+            ("FONTSIZE", (0, 0), (-1, -1), 8),
+            ("GRID", (0, 0), (-1, -1), 0.3, colors.HexColor("#cccccc")),
+            ("VALIGN", (0, 0), (-1, -1), "TOP"),
+            ("LEFTPADDING", (0, 0), (-1, -1), 4),
+            ("RIGHTPADDING", (0, 0), (-1, -1), 4),
+            ("TOPPADDING", (0, 0), (-1, -1), 3),
+            ("BOTTOMPADDING", (0, 0), (-1, -1), 3),
+            ("ROWBACKGROUNDS", (0, 1), (-1, -1),
+             [colors.white, colors.HexColor("#f5f5f5")]),
+        ])
+
+    doc = SimpleDocTemplate(
+        str(path), pagesize=letter,
+        rightMargin=0.75 * inch, leftMargin=0.75 * inch,
+        topMargin=0.75 * inch, bottomMargin=0.75 * inch,
+        title="CSTP Provenance Evidence Bundle",
+        author="Cognition Engines",
+    )
+
+    story: list[Any] = []
+    gen_ts = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
+
+    # Cover
+    story.append(Spacer(1, 0.3 * inch))
+    story.append(Paragraph("CSTP PROVENANCE", style(
+        "Cover", fontSize=24, fontName="Helvetica-Bold",
+        textColor=accent, alignment=TA_CENTER)))
+    story.append(Paragraph(
+        "Agent Decision Evidence Bundle — F055",
+        style("SubCover", fontSize=12, alignment=TA_CENTER,
+              textColor=colors.HexColor("#555"))))
+    story.append(Spacer(1, 0.2 * inch))
+
+    obs = bundle_data["coverage"]["observed"]
+    att = bundle_data["coverage"]["attested"]
+
+    cover_data = [
+        ["Generated", gen_ts],
+        ["Chain integrity", "INTACT" if chain_intact else "BROKEN — do not rely on this bundle"],
+        ["Observed events", str(obs["total_events"])],
+        ["Observed coverage", f"{obs['coverage_pct']}%  ({obs['mapped_events']}/{obs['total_events']})"],
+        ["Attested events", str(att["total_events"])],
+        ["Attested coverage", f"{att['coverage_pct']}%  ({att['mapped_events']}/{att['total_events']})"],
+        ["INSUFFICIENT EVIDENCE", str(bundle_data["insufficient_evidence_count"]) + " gap(s)"],
+        ["Attested-only controls", ", ".join(bundle_data["attested_only_controls"]) or "none"],
+    ]
+    cover_tbl = Table(cover_data, colWidths=[2.0 * inch, 4.5 * inch])
+    cover_tbl.setStyle(TableStyle([
+        ("FONTNAME", (0, 0), (0, -1), "Helvetica-Bold"),
+        ("FONTSIZE", (0, 0), (-1, -1), 9),
+        ("GRID", (0, 0), (-1, -1), 0.3, colors.HexColor("#cccccc")),
+        ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+        ("LEFTPADDING", (0, 0), (-1, -1), 6),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 6),
+        ("TOPPADDING", (0, 0), (-1, -1), 4),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+        ("ROWBACKGROUNDS", (0, 0), (-1, -1),
+         [colors.white, colors.HexColor("#f5f5f5")]),
+        ("TEXTCOLOR", (1, 1), (1, 1),
+         colors.HexColor("#006600") if chain_intact else colors.HexColor("#cc0000")),
+        ("TEXTCOLOR", (1, 6), (1, 6),
+         colors.HexColor("#cc0000") if bundle_data["insufficient_evidence_count"]
+         else colors.HexColor("#006600")),
+    ]))
+    story.append(cover_tbl)
+    story.append(Spacer(1, 0.15 * inch))
+    story.append(Paragraph(
+        f"<b>Chain head hash:</b> "
+        f"<font name='Courier' size='7'>{chain_head or 'N/A'}</font>",
+        small))
+    story.append(Spacer(1, 0.1 * inch))
+    story.append(Paragraph(
+        "<b>Two-class evidence model:</b> Observed events (GitHub PRs, third-party) "
+        "are hash-chained and tamper-evident. Attested events (CSTP decisions) are "
+        "self-reported by the agent and carry lower audit weight. Coverage is reported "
+        "separately — a single blended percentage would obscure the strength of each class.",
+        body))
+    story.append(PageBreak())
+
+    # Section 1: Framework Mappings
+    story.append(Paragraph("Section 1: Framework Control Mappings", h1))
+
+    if mr.mappings:
+        map_data = [["Framework", "Stage", "Control ID", "Control Name",
+                     "Ev. Class", "Status"]]
+        seen: set[tuple[str, str]] = set()
+        for m in mr.mappings:
+            key = (m.get("framework", ""), m.get("function_id", ""))
+            if key in seen:
+                continue
+            seen.add(key)
+            label = (m.get("control_name") or "")[:40]
+            status = "PARTIAL/CONTESTED" if m.get("stretch") else "OK"
+            if m.get("attested_only"):
+                status = "ATTESTED-ONLY"
+            ev_cls = m.get("evidence_class", "observed")
+            map_data.append([
+                Paragraph(m.get("framework", ""), small),
+                Paragraph(m.get("stage", ""), small),
+                Paragraph(m.get("function_id", ""), small),
+                Paragraph(label, small),
+                Paragraph(ev_cls, small),
+                Paragraph(status, small),
+            ])
+        map_tbl = Table(map_data,
+                        colWidths=[1.0 * inch, 1.1 * inch, 0.8 * inch,
+                                   2.2 * inch, 0.8 * inch, 1.1 * inch])
+        map_tbl.setStyle(tbl_style())
+        story.append(map_tbl)
+    else:
+        story.append(Paragraph("No framework mappings produced.", ok_style))
+
+    story.append(PageBreak())
+
+    # Section 2: INSUFFICIENT EVIDENCE Gaps
+    story.append(Paragraph("Section 2: INSUFFICIENT EVIDENCE Gaps", h1))
+    if not mr.insufficient_evidence:
+        story.append(Paragraph("No INSUFFICIENT EVIDENCE gaps detected.", ok_style))
+    else:
+        story.append(Paragraph(
+            "These control stages could not be evidenced from available data. "
+            "Each gap must be resolved before this bundle can be accepted as complete "
+            "evidence in a regulatory examination.", body))
+        for ie in mr.insufficient_evidence:
+            story.append(Paragraph(
+                f"Gap: {ie.get('framework')} / {ie.get('function_id')} — "
+                f"{ie.get('control_name')} (seq {ie.get('seq')})", h3))
+            gap_data = [
+                ["Framework", ie.get("framework", "")],
+                ["Control", f"{ie.get('stage', '')} / {ie.get('function_id', '')}"],
+                ["Control Name", ie.get("control_name", "")],
+                ["Evidence Class", ie.get("evidence_class", "observed")],
+                ["Reason", (ie.get("reason") or "").strip()],
+            ]
+            gap_tbl = Table(gap_data, colWidths=[1.5 * inch, 5.0 * inch])
+            gap_tbl.setStyle(TableStyle([
+                ("FONTNAME", (0, 0), (0, -1), "Helvetica-Bold"),
+                ("FONTSIZE", (0, 0), (-1, -1), 8),
+                ("GRID", (0, 0), (-1, -1), 0.3, colors.HexColor("#cccccc")),
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ("LEFTPADDING", (0, 0), (-1, -1), 4),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 4),
+                ("TOPPADDING", (0, 0), (-1, -1), 3),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 3),
+                ("BACKGROUND", (0, 0), (-1, -1), gap_color),
+            ]))
+            story.append(gap_tbl)
+            story.append(Spacer(1, 0.08 * inch))
+
+    story.append(PageBreak())
+
+    # Section 3: Attested-Only Controls
+    story.append(Paragraph("Section 3: Attested-Only Controls", h1))
+    story.append(Paragraph(
+        "Controls in this section are supported ONLY by attested (self-reported) evidence. "
+        "No observed third-party evidence supports these controls. An auditor will discount "
+        "these heavily — they require corroboration from an independent evidence source.", body))
+    if mr.attested_only_controls:
+        ao_data = [["Control ID", "Framework", "Control Name"]]
+        seen_ao: set[str] = set()
+        for m in mr.mappings:
+            fid = m.get("function_id", "")
+            if fid in mr.attested_only_controls and fid not in seen_ao:
+                seen_ao.add(fid)
+                ao_data.append([fid, m.get("framework", ""), m.get("control_name", "")])
+        if len(ao_data) > 1:
+            ao_tbl = Table(ao_data, colWidths=[1.0 * inch, 1.5 * inch, 4.0 * inch])
+            ao_tbl.setStyle(tbl_style(hdr_color=colors.HexColor("#fff3cd")))
+            story.append(ao_tbl)
+        else:
+            story.append(Paragraph("No attested-only controls identified.", ok_style))
+    else:
+        story.append(Paragraph("No attested-only controls identified.", ok_style))
+
+    story.append(PageBreak())
+
+    # Section 4: Chain Integrity
+    story.append(Paragraph("Section 4: Chain Integrity Verification", h1))
+    story.append(Paragraph(
+        "The observed event store uses a SHA-256 hash chain. Each record's hash covers "
+        "its sequence number, timestamp, event type, evidence class, canonical payload, "
+        "and the hash of the previous record. The head hash is persisted at bundle "
+        "generation time; verification is performed against that stored hash to detect "
+        "tail truncation (P2 fix).", body))
+    chain_data = [
+        ["Chain status", "INTACT — all hashes verified" if chain_intact
+                        else "BROKEN — records have been tampered with"],
+        ["Head hash", chain_head or "N/A"],
+        ["Hash algorithm", "SHA-256"],
+        ["Preimage format",
+         "{seq}\\n{ts}\\n{event_type}\\n{evidence_class}\\n{canonical_json(payload)}\\n{prev_hash}"],
+    ]
+    chain_tbl = Table(chain_data, colWidths=[1.8 * inch, 4.7 * inch])
+    chain_tbl.setStyle(TableStyle([
+        ("FONTNAME", (0, 0), (0, -1), "Helvetica-Bold"),
+        ("FONTSIZE", (0, 0), (-1, -1), 8),
+        ("GRID", (0, 0), (-1, -1), 0.3, colors.HexColor("#cccccc")),
+        ("VALIGN", (0, 0), (-1, -1), "TOP"),
+        ("LEFTPADDING", (0, 0), (-1, -1), 4),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 4),
+        ("TOPPADDING", (0, 0), (-1, -1), 3),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 3),
+        ("ROWBACKGROUNDS", (0, 0), (-1, -1),
+         [colors.white, colors.HexColor("#f5f5f5")]),
+        ("TEXTCOLOR", (1, 0), (1, 0),
+         colors.HexColor("#006600") if chain_intact else colors.HexColor("#cc0000")),
+    ]))
+    story.append(chain_tbl)
+
+    doc.build(story)
+    return path
+
+
+# ── cstp.verifyEvidenceChain ──────────────────────────────────────────────────
+
+
+async def verify_evidence_chain(params: dict[str, Any], agent_id: str) -> dict[str, Any]:
+    """Verify hash chain integrity.
+
+    Uses expected_head_hash (P1 fix) so tail truncation is detectable.
+    If the caller does not supply expected_head_hash, the value from the most
+    recent bundle generation is used (P2 fix). If neither is available, falls
+    back to internal-only verification (tail truncation invisible — warn caller).
+
+    Params:
+        expected_head_hash — optional; overrides the stored bundle head hash
+        db_path            — optional override for the provenance DB path
+
+    Returns:
+        intact         — True if chain is intact (all hashes valid + head matches)
+        broken_at_seq  — seq of broken record, or None if intact
+        head_hash      — current chain head hash
+        expected_hash  — the hash verified against (from param or stored bundle)
+        tail_check     — True if tail-truncation detection was active
+    """
+    db_path = _get_db_path(params)
+    _ensure_db(db_path)
+
+    # Resolve expected_head_hash
+    caller_hash: str | None = params.get("expected_head_hash")
+    stored_hash = get_last_bundle_head_hash(db_path)
+    expected_hash = caller_hash or stored_hash
+
+    tail_check = expected_hash is not None
+    broken_at = verify_chain(db_path, expected_head_hash=expected_hash)
+
+    head_hash = get_head_hash(db_path)
+
+    return {
+        "intact": broken_at is None,
+        "broken_at_seq": broken_at,
+        "head_hash": head_hash,
+        "expected_hash": expected_hash,
+        "tail_check": tail_check,
+    }

--- a/a2a/cstp/storage/provenance.py
+++ b/a2a/cstp/storage/provenance.py
@@ -1,0 +1,232 @@
+"""
+Append-only event store with SHA-256 hash chain for F055 Decision Provenance.
+
+Every event carries an evidence_class (observed | attested) which is included in
+the hash preimage, making it tamper-evident. The two classes must never be blended:
+
+  observed  — third-party events from a system the subject does not control
+               (GitHub PR opens, commits, reviews, approvals, merges)
+  attested  — first-party CSTP records correlated via cstp.linkEvidence
+
+Hash preimage (UTF-8, fields joined by newline):
+    {seq}\\n{ts}\\n{event_type}\\n{evidence_class}\\n{canonical_json(payload)}\\n{prev_hash}
+
+Note: `source` is intentionally excluded from the hash preimage. It identifies the
+ingest origin but does not affect tamper-evidence.
+"""
+
+import hashlib
+import json
+import os
+import sqlite3
+from datetime import UTC, datetime
+from typing import Optional
+
+DEFAULT_DB_PATH = os.environ.get("PROVENANCE_DB", "provenance.db")
+
+EVIDENCE_CLASS_OBSERVED = "observed"
+EVIDENCE_CLASS_ATTESTED = "attested"
+_VALID_CLASSES = frozenset({EVIDENCE_CLASS_OBSERVED, EVIDENCE_CLASS_ATTESTED})
+
+CREATE_SCHEMA_SQL = """
+PRAGMA journal_mode=WAL;
+
+CREATE TABLE IF NOT EXISTS events (
+    seq            INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts             TEXT NOT NULL,
+    source         TEXT NOT NULL,
+    event_type     TEXT NOT NULL,
+    evidence_class TEXT NOT NULL CHECK(evidence_class IN ('observed', 'attested')),
+    payload_json   TEXT NOT NULL,
+    prev_hash      TEXT NOT NULL,
+    hash           TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS bundle_metadata (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    generated_at TEXT NOT NULL,
+    head_hash    TEXT NOT NULL,
+    format       TEXT NOT NULL
+);
+"""
+
+
+def canonical_json(obj: dict) -> str:
+    """Canonical JSON: sorted keys, no whitespace, UTF-8-safe."""
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def compute_hash(
+    seq: int,
+    ts: str,
+    event_type: str,
+    evidence_class: str,
+    payload: dict,
+    prev_hash: str,
+) -> str:
+    """Compute SHA-256 hash for an event record.
+
+    Preimage (UTF-8):
+        "{seq}\\n{ts}\\n{event_type}\\n{evidence_class}\\n{canonical_json(payload)}\\n{prev_hash}"
+    """
+    preimage = (
+        f"{seq}\n{ts}\n{event_type}\n{evidence_class}\n"
+        f"{canonical_json(payload)}\n{prev_hash}"
+    )
+    return hashlib.sha256(preimage.encode("utf-8")).hexdigest()
+
+
+def init_db(db_path: str = DEFAULT_DB_PATH) -> None:
+    """Create tables if they do not exist. Safe to call multiple times."""
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(CREATE_SCHEMA_SQL)
+        conn.commit()
+
+
+def append_event(
+    source: str,
+    event_type: str,
+    evidence_class: str,
+    payload: dict,
+    ts: str | None = None,
+    db_path: str = DEFAULT_DB_PATH,
+) -> tuple[int, str]:
+    """Append an event to the chain. Returns (seq, hash).
+
+    evidence_class must be 'observed' or 'attested'. Enforced both here
+    and by a DB CHECK constraint.
+
+    ts should be an ISO 8601 string from the source data to ensure chain
+    determinism across re-runs. Defaults to current UTC time if omitted.
+    """
+    if evidence_class not in _VALID_CLASSES:
+        raise ValueError(
+            f"evidence_class must be 'observed' or 'attested', got: {evidence_class!r}"
+        )
+    if ts is None:
+        ts = datetime.now(UTC).isoformat()
+
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            "SELECT seq, hash FROM events ORDER BY seq DESC LIMIT 1"
+        ).fetchone()
+
+        prev_hash = row["hash"] if row else ""
+        next_seq = (row["seq"] + 1) if row else 1
+
+        h = compute_hash(next_seq, ts, event_type, evidence_class, payload, prev_hash)
+
+        conn.execute(
+            "INSERT INTO events "
+            "(ts, source, event_type, evidence_class, payload_json, prev_hash, hash) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (ts, source, event_type, evidence_class, canonical_json(payload), prev_hash, h),
+        )
+        conn.commit()
+        return next_seq, h
+
+
+def get_events(
+    db_path: str = DEFAULT_DB_PATH,
+    evidence_class: str | None = None,
+) -> list[dict]:
+    """Return events in seq order as dicts. Optionally filter by evidence_class."""
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        if evidence_class is not None:
+            rows = conn.execute(
+                "SELECT seq, ts, source, event_type, evidence_class, payload_json, prev_hash, hash "
+                "FROM events WHERE evidence_class = ? ORDER BY seq",
+                (evidence_class,),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT seq, ts, source, event_type, evidence_class, payload_json, prev_hash, hash "
+                "FROM events ORDER BY seq"
+            ).fetchall()
+
+    result = []
+    for row in rows:
+        d = dict(row)
+        d["payload"] = json.loads(d["payload_json"])
+        result.append(d)
+    return result
+
+
+def get_head_hash(db_path: str = DEFAULT_DB_PATH) -> Optional[str]:
+    """Return the hash of the most recent event, or None if the store is empty."""
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT hash FROM events ORDER BY seq DESC LIMIT 1"
+        ).fetchone()
+    return row[0] if row else None
+
+
+def verify_chain(
+    db_path: str = DEFAULT_DB_PATH,
+    expected_head_hash: Optional[str] = None,
+) -> Optional[int]:
+    """Walk the entire chain and verify each event's hash.
+
+    Returns the seq of the first broken record, or None if the chain is intact.
+    Returns 0 if the chain is internally intact but its head hash does not match
+    expected_head_hash — indicating tail truncation (deleted events at the end).
+    Callers that omit expected_head_hash see behaviour identical to pre-P1 code.
+    """
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            "SELECT seq, ts, event_type, evidence_class, payload_json, prev_hash, hash "
+            "FROM events ORDER BY seq"
+        ).fetchall()
+
+    prev_hash = ""
+    actual_head_hash = None
+    for row in rows:
+        payload = json.loads(row["payload_json"])
+        expected = compute_hash(
+            row["seq"], row["ts"], row["event_type"],
+            row["evidence_class"], payload, prev_hash,
+        )
+        if expected != row["hash"]:
+            return row["seq"]
+        if row["prev_hash"] != prev_hash:
+            return row["seq"]
+        prev_hash = row["hash"]
+        actual_head_hash = row["hash"]
+
+    if expected_head_hash is not None and actual_head_hash != expected_head_hash:
+        return 0  # Tail truncated: chain internally valid but head doesn't match
+
+    return None
+
+
+def event_count(db_path: str = DEFAULT_DB_PATH) -> int:
+    """Return total number of events in the store."""
+    with sqlite3.connect(db_path) as conn:
+        return conn.execute("SELECT COUNT(*) FROM events").fetchone()[0]
+
+
+def store_bundle_head_hash(
+    head_hash: str,
+    fmt: str,
+    db_path: str = DEFAULT_DB_PATH,
+) -> None:
+    """Persist the head hash at bundle generation time for future verification (P2 fix)."""
+    generated_at = datetime.now(UTC).isoformat()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO bundle_metadata (generated_at, head_hash, format) VALUES (?, ?, ?)",
+            (generated_at, head_hash, fmt),
+        )
+        conn.commit()
+
+
+def get_last_bundle_head_hash(db_path: str = DEFAULT_DB_PATH) -> Optional[str]:
+    """Return the head hash from the most recent bundle generation, or None."""
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT head_hash FROM bundle_metadata ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+    return row[0] if row else None

--- a/tests/test_f055_provenance_service.py
+++ b/tests/test_f055_provenance_service.py
@@ -1,0 +1,1013 @@
+"""Tests for F055 Decision Provenance & Control Evidence.
+
+Mirrors the PoC's 61 passing tests where applicable, plus integration tests
+for the five new CSTP RPC methods.
+
+Two-class evidence model is the non-negotiable design constraint:
+  observed  — third-party events (hash-chained)
+  attested  — first-party CSTP records (self-reported)
+Coverage must be reported separately per class. Any blended metric is a bug.
+"""
+
+import json
+import sqlite3
+import pytest
+from pathlib import Path
+
+from a2a.cstp.storage.provenance import (
+    EVIDENCE_CLASS_OBSERVED,
+    append_event,
+    canonical_json,
+    compute_hash,
+    event_count,
+    get_events,
+    get_head_hash,
+    get_last_bundle_head_hash,
+    init_db,
+    store_bundle_head_hash,
+    verify_chain,
+)
+from a2a.cstp.provenance.mapping import (
+    INSUFFICIENT_EVIDENCE_TAG,
+    MAPPINGS_DIR,
+    apply_rules,
+    load_rules,
+)
+from a2a.cstp.provenance_service import (
+    export_evidence_bundle,
+    ingest_evidence,
+    link_evidence,
+    map_controls,
+    verify_evidence_chain,
+)
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def db(tmp_path):
+    path = str(tmp_path / "test.db")
+    init_db(path)
+    return path
+
+
+@pytest.fixture
+def db_with_observed(db):
+    """A DB with a handful of typical observed PR events."""
+    events = [
+        ("gh", "pr_opened", {"pr_number": 1, "is_agent_authored": True, "agent_type": "Claude",
+                              "title": "Add risk scorer", "approval_count": 0}),
+        ("gh", "pr_review_approved", {"pr_number": 1, "reviewer": "alice"}),
+        ("gh", "pr_merged", {"pr_number": 1, "is_agent_authored": True, "approval_count": 1,
+                              "merged_by": "alice"}),
+        ("gh", "pr_opened", {"pr_number": 2, "is_agent_authored": True, "agent_type": "Claude",
+                              "title": "Agent risk scorer v2", "approval_count": 0}),
+        ("gh", "pr_merged", {"pr_number": 2, "is_agent_authored": True, "approval_count": 0,
+                              "merged_by": "claude-bot"}),  # no human approval — IE gap
+    ]
+    for ts_idx, (source, etype, payload) in enumerate(events):
+        append_event(
+            source=source, event_type=etype, evidence_class=EVIDENCE_CLASS_OBSERVED,
+            payload=payload, ts=f"2026-07-0{ts_idx + 1}T10:00:00Z", db_path=db,
+        )
+    return db
+
+
+@pytest.fixture
+def service_params(db):
+    return {"db_path": db}
+
+
+@pytest.fixture
+def service_params_observed(db_with_observed):
+    return {"db_path": db_with_observed}
+
+
+def _make_event(seq, event_type, payload, evidence_class="observed", ts="2026-07-01T00:00:00Z"):
+    return {
+        "seq": seq,
+        "event_type": event_type,
+        "ts": ts,
+        "payload": payload,
+        "source": "test",
+        "evidence_class": evidence_class,
+    }
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Store: canonical_json
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestCanonicalJson:
+    def test_sorted_keys(self):
+        result = canonical_json({"z": 1, "a": 2, "m": 3})
+        assert result == '{"a":2,"m":3,"z":1}'
+
+    def test_no_whitespace(self):
+        result = canonical_json({"key": "val"})
+        assert " " not in result
+
+    def test_nested(self):
+        result = canonical_json({"b": {"y": 2, "x": 1}, "a": 0})
+        assert result == '{"a":0,"b":{"x":1,"y":2}}'
+
+    def test_unicode_not_escaped(self):
+        result = canonical_json({"k": "café"})
+        assert "café" in result
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Store: compute_hash
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestComputeHash:
+    def test_deterministic(self):
+        h1 = compute_hash(1, "2026-01-01T00:00:00Z", "pr_opened", "observed", {"a": 1}, "")
+        h2 = compute_hash(1, "2026-01-01T00:00:00Z", "pr_opened", "observed", {"a": 1}, "")
+        assert h1 == h2
+
+    def test_differs_on_seq(self):
+        h1 = compute_hash(1, "ts", "et", "observed", {}, "")
+        h2 = compute_hash(2, "ts", "et", "observed", {}, "")
+        assert h1 != h2
+
+    def test_differs_on_payload(self):
+        h1 = compute_hash(1, "ts", "et", "observed", {"a": 1}, "")
+        h2 = compute_hash(1, "ts", "et", "observed", {"a": 2}, "")
+        assert h1 != h2
+
+    def test_differs_on_evidence_class(self):
+        """evidence_class is part of the hash preimage — changing it breaks the chain."""
+        h1 = compute_hash(1, "ts", "et", "observed", {"a": 1}, "")
+        h2 = compute_hash(1, "ts", "et", "attested", {"a": 1}, "")
+        assert h1 != h2
+
+    def test_differs_on_prev_hash(self):
+        h1 = compute_hash(2, "ts", "et", "observed", {}, "abc")
+        h2 = compute_hash(2, "ts", "et", "observed", {}, "def")
+        assert h1 != h2
+
+    def test_genesis_uses_empty_prev(self):
+        h = compute_hash(1, "ts", "pr_opened", "observed", {}, "")
+        assert isinstance(h, str) and len(h) == 64
+
+    def test_payload_key_order_invariant(self):
+        h1 = compute_hash(1, "ts", "et", "observed", {"z": 1, "a": 2}, "")
+        h2 = compute_hash(1, "ts", "et", "observed", {"a": 2, "z": 1}, "")
+        assert h1 == h2
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Store: append / get
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestAppendAndGet:
+    def test_first_event_seq_is_one(self, db):
+        seq, _ = append_event("src", "pr_opened", "observed", {"n": 1},
+                               ts="2026-01-01T00:00:00Z", db_path=db)
+        assert seq == 1
+
+    def test_seq_increments(self, db):
+        seq1, _ = append_event("src", "pr_opened", "observed", {"n": 1},
+                                ts="2026-01-01T00:00:00Z", db_path=db)
+        seq2, _ = append_event("src", "pr_merged", "observed", {"n": 1},
+                                ts="2026-01-02T00:00:00Z", db_path=db)
+        assert seq2 == seq1 + 1
+
+    def test_get_events_order(self, db):
+        for i in range(5):
+            append_event("src", f"et_{i}", "observed", {"i": i},
+                         ts=f"2026-01-0{i+1}T00:00:00Z", db_path=db)
+        events = get_events(db)
+        assert [e["seq"] for e in events] == list(range(1, 6))
+
+    def test_payload_round_trips(self, db):
+        payload = {"pr_number": 42, "title": "test PR", "is_agent": True}
+        append_event("gh", "pr_opened", "observed", payload, ts="2026-01-01T00:00:00Z", db_path=db)
+        events = get_events(db)
+        assert events[0]["payload"] == payload
+
+    def test_evidence_class_stored(self, db):
+        append_event("src", "et", "observed", {}, ts="2026-01-01T00:00:00Z", db_path=db)
+        append_event("src", "et", "attested", {}, ts="2026-01-02T00:00:00Z", db_path=db)
+        events = get_events(db)
+        assert events[0]["evidence_class"] == "observed"
+        assert events[1]["evidence_class"] == "attested"
+
+    def test_filter_by_evidence_class(self, db):
+        append_event("src", "obs_event", "observed", {}, ts="2026-01-01T00:00:00Z", db_path=db)
+        append_event("src", "att_event", "attested", {}, ts="2026-01-02T00:00:00Z", db_path=db)
+        obs_events = get_events(db, evidence_class="observed")
+        att_events = get_events(db, evidence_class="attested")
+        assert len(obs_events) == 1 and obs_events[0]["event_type"] == "obs_event"
+        assert len(att_events) == 1 and att_events[0]["event_type"] == "att_event"
+
+    def test_event_count(self, db):
+        for i in range(7):
+            append_event("src", "evt", "observed", {"i": i},
+                         ts="2026-01-01T00:00:00Z", db_path=db)
+        assert event_count(db) == 7
+
+    def test_invalid_evidence_class_rejected(self, db):
+        with pytest.raises(ValueError, match="evidence_class"):
+            append_event("src", "et", "unknown", {}, db_path=db)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Store: hash chain integrity
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestHashChainIntegrity:
+    def test_empty_chain_is_intact(self, db):
+        assert verify_chain(db) is None
+
+    def test_single_event_intact(self, db):
+        append_event("src", "pr_opened", "observed", {"n": 1},
+                     ts="2026-01-01T00:00:00Z", db_path=db)
+        assert verify_chain(db) is None
+
+    def test_multi_event_intact(self, db):
+        for i in range(10):
+            append_event("src", "pr_opened", "observed", {"i": i},
+                         ts="2026-01-01T00:00:00Z", db_path=db)
+        assert verify_chain(db) is None
+
+    def test_tamper_detection_payload(self, db):
+        for i in range(3):
+            append_event("src", "pr_opened", "observed", {"i": i},
+                         ts="2026-01-01T00:00:00Z", db_path=db)
+        with sqlite3.connect(db) as conn:
+            conn.execute("UPDATE events SET payload_json = ? WHERE seq = 2", ('{"i":99}',))
+            conn.commit()
+        assert verify_chain(db) == 2
+
+    def test_tamper_detection_first_record(self, db):
+        for i in range(3):
+            append_event("src", "pr_opened", "observed", {"i": i},
+                         ts="2026-01-01T00:00:00Z", db_path=db)
+        with sqlite3.connect(db) as conn:
+            conn.execute("UPDATE events SET payload_json = ? WHERE seq = 1",
+                         ('{"tampered":true}',))
+            conn.commit()
+        assert verify_chain(db) == 1
+
+    def test_tamper_detection_evidence_class(self, db):
+        """Changing evidence_class must break the chain (it's in the hash preimage)."""
+        append_event("src", "pr_opened", "observed", {"n": 1},
+                     ts="2026-01-01T00:00:00Z", db_path=db)
+        with sqlite3.connect(db) as conn:
+            conn.execute("UPDATE events SET evidence_class = 'attested' WHERE seq = 1")
+            conn.commit()
+        assert verify_chain(db) == 1
+
+    def test_tail_truncation_invisible_without_expected_hash(self, db):
+        """Deleting tail events is undetectable without expected_head_hash."""
+        for i in range(5):
+            append_event("src", "pr_opened", "observed", {"i": i},
+                         ts=f"2026-01-0{i+1}T00:00:00Z", db_path=db)
+        original_head = get_head_hash(db)
+        with sqlite3.connect(db) as conn:
+            conn.execute("DELETE FROM events WHERE seq > 3")
+            conn.commit()
+        assert verify_chain(db) is None  # truncation invisible
+        assert verify_chain(db, expected_head_hash=original_head) == 0  # detected
+
+    def test_tail_truncation_detected_with_expected_hash(self, db):
+        """With expected_head_hash, truncation returns sentinel 0."""
+        for i in range(5):
+            append_event("src", "pr_opened", "observed", {"i": i},
+                         ts=f"2026-01-0{i+1}T00:00:00Z", db_path=db)
+        original_head = get_head_hash(db)
+        with sqlite3.connect(db) as conn:
+            conn.execute("DELETE FROM events WHERE seq >= 4")
+            conn.commit()
+        result = verify_chain(db, expected_head_hash=original_head)
+        assert result == 0
+
+    def test_correct_chain_passes_with_expected_hash(self, db):
+        for i in range(3):
+            append_event("src", "pr_opened", "observed", {"i": i},
+                         ts=f"2026-01-0{i+1}T00:00:00Z", db_path=db)
+        head = get_head_hash(db)
+        assert verify_chain(db, expected_head_hash=head) is None
+
+    def test_chain_determinism(self, tmp_path):
+        """Same events appended to two fresh DBs must produce identical hashes."""
+        events_data = [
+            ("src", "pr_opened", "observed", {"pr_number": 1}, "2026-07-01T09:00:00Z"),
+            ("src", "pr_review_approved", "observed", {"pr_number": 1}, "2026-07-01T12:00:00Z"),
+            ("src", "pr_merged", "observed", {"pr_number": 1, "approval_count": 1},
+             "2026-07-01T14:00:00Z"),
+        ]
+        db1 = str(tmp_path / "chain1.db")
+        db2 = str(tmp_path / "chain2.db")
+        init_db(db1)
+        init_db(db2)
+        hashes1, hashes2 = [], []
+        for source, etype, ev_class, payload, ts in events_data:
+            _, h1 = append_event(source, etype, ev_class, payload, ts=ts, db_path=db1)
+            _, h2 = append_event(source, etype, ev_class, payload, ts=ts, db_path=db2)
+            hashes1.append(h1)
+            hashes2.append(h2)
+        assert hashes1 == hashes2
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Store: bundle metadata (P2 fix)
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestBundleMetadata:
+    def test_store_and_retrieve_head_hash(self, db):
+        append_event("src", "pr_opened", "observed", {}, ts="2026-01-01T00:00:00Z", db_path=db)
+        head = get_head_hash(db)
+        store_bundle_head_hash(head, "json", db)
+        retrieved = get_last_bundle_head_hash(db)
+        assert retrieved == head
+
+    def test_returns_none_if_no_bundle(self, db):
+        assert get_last_bundle_head_hash(db) is None
+
+    def test_returns_most_recent(self, db):
+        for i in range(3):
+            append_event("src", "pr_opened", "observed", {"i": i},
+                         ts=f"2026-01-0{i+1}T00:00:00Z", db_path=db)
+        h1 = get_head_hash(db)
+        store_bundle_head_hash(h1, "json", db)
+        append_event("src", "pr_merged", "observed", {},
+                     ts="2026-01-04T00:00:00Z", db_path=db)
+        h2 = get_head_hash(db)
+        store_bundle_head_hash(h2, "json", db)
+        assert get_last_bundle_head_hash(db) == h2
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Mapping: load rules
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestLoadRules:
+    def test_loads_both_observed_frameworks(self):
+        rules = load_rules(MAPPINGS_DIR)
+        frameworks = {r["_framework"] for r in rules}
+        assert "SR 11-7" in frameworks
+        assert "NIST AI RMF" in frameworks
+
+    def test_loads_attested_framework(self):
+        rules = load_rules(MAPPINGS_DIR)
+        frameworks = {r["_framework"] for r in rules}
+        assert "CSTP Attested" in frameworks
+
+    def test_rules_have_required_fields(self):
+        rules = load_rules(MAPPINGS_DIR)
+        for rule in rules:
+            assert "id" in rule, f"Missing 'id' in rule {rule}"
+            assert "stage" in rule, f"Missing 'stage' in rule {rule}"
+            assert "control_name" in rule, f"Missing 'control_name' in rule {rule}"
+            assert "match" in rule, f"Missing 'match' in rule {rule}"
+            assert "event_type" in rule["match"], f"Missing match.event_type in rule {rule}"
+
+    def test_ie_rules_have_reason(self):
+        rules = load_rules(MAPPINGS_DIR)
+        for rule in rules:
+            if rule.get("insufficient_evidence"):
+                assert rule.get("reason"), f"IE rule {rule['id']} missing reason"
+
+    def test_map11_is_stretch(self):
+        """MAP-1.1 must be tagged stretch=True per P1 fix."""
+        rules = load_rules(MAPPINGS_DIR)
+        map11 = [r for r in rules if r.get("function_id") == "MAP-1.1"]
+        assert map11, "MAP-1.1 rule not found"
+        assert map11[0].get("stretch") is True
+        assert map11[0].get("confidence") == "low"
+
+    def test_manage11_requires_agent_authored(self):
+        """MANAGE-1.1 must only fire on agent-authored merges (P1 fix)."""
+        rules = load_rules(MAPPINGS_DIR)
+        manage11 = [r for r in rules if r.get("function_id") == "MANAGE-1.1"]
+        assert manage11, "MANAGE-1.1 rule not found"
+        conditions = manage11[0]["match"].get("conditions", [])
+        has_agent_condition = any(
+            c.get("field") == "is_agent_authored" and c.get("equals") is True
+            for c in conditions
+        )
+        assert has_agent_condition, "MANAGE-1.1 must require is_agent_authored=true"
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Mapping: apply rules
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestApplyRules:
+    def test_agent_pr_opens_maps_sr117(self):
+        rules = load_rules(MAPPINGS_DIR)
+        events = [_make_event(1, "pr_opened",
+                               {"pr_number": 1, "is_agent_authored": True})]
+        mr = apply_rules(events, rules)
+        sr_maps = [m for m in mr.mappings if "SR 11-7" in m["framework"]]
+        assert len(sr_maps) >= 1
+
+    def test_human_pr_opens_maps_sr117(self):
+        rules = load_rules(MAPPINGS_DIR)
+        events = [_make_event(1, "pr_opened",
+                               {"pr_number": 1, "is_agent_authored": False})]
+        mr = apply_rules(events, rules)
+        assert mr.observed.mapped_events == 1
+
+    def test_approval_maps_to_mv3(self):
+        rules = load_rules(MAPPINGS_DIR)
+        events = [_make_event(1, "pr_review_approved", {"pr_number": 1, "reviewer": "bob"})]
+        mr = apply_rules(events, rules)
+        mv3 = [m for m in mr.mappings if m.get("function_id") == "MV-3"]
+        assert len(mv3) >= 1
+
+    def test_agent_merge_with_approval_maps_cm1(self):
+        rules = load_rules(MAPPINGS_DIR)
+        events = [_make_event(1, "pr_merged",
+                               {"pr_number": 1, "is_agent_authored": True, "approval_count": 2})]
+        mr = apply_rules(events, rules)
+        cm = [m for m in mr.mappings if "CM" in m.get("function_id", "")]
+        assert len(cm) >= 1
+
+    def test_unknown_event_type_is_unmapped(self):
+        rules = load_rules(MAPPINGS_DIR)
+        events = [_make_event(1, "some_future_event_type", {"pr_number": 1})]
+        mr = apply_rules(events, rules)
+        assert mr.observed.unmapped_events == 1
+        assert mr.observed.mapped_events == 0
+
+    def test_evidence_class_propagated_to_mappings(self):
+        rules = load_rules(MAPPINGS_DIR)
+        events = [
+            _make_event(1, "pr_opened", {"pr_number": 1, "is_agent_authored": True},
+                        evidence_class="observed"),
+        ]
+        mr = apply_rules(events, rules)
+        for m in mr.mappings:
+            if m.get("seq") == 1:
+                assert m["evidence_class"] == "observed"
+
+    def test_attested_events_mapped_separately(self):
+        rules = load_rules(MAPPINGS_DIR)
+        events = [
+            _make_event(1, "pr_opened", {"pr_number": 1, "is_agent_authored": True},
+                        evidence_class="observed"),
+            _make_event(2, "cstp_decision_linked",
+                        {"decision_id": "abc", "event_seqs": [1], "has_outcome": True},
+                        evidence_class="attested"),
+        ]
+        mr = apply_rules(events, rules)
+        assert mr.observed.total_events == 1
+        assert mr.attested.total_events == 1
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Mapping: two-class coverage (THE NON-NEGOTIABLE CONSTRAINT)
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestPerClassCoverage:
+    def test_observed_coverage_computed_separately(self):
+        rules = load_rules(MAPPINGS_DIR)
+        events = [
+            _make_event(1, "pr_opened", {"pr_number": 1, "is_agent_authored": True},
+                        evidence_class="observed"),
+            _make_event(2, "pr_review_approved", {"pr_number": 1}, evidence_class="observed"),
+        ]
+        mr = apply_rules(events, rules)
+        assert mr.observed.total_events == 2
+        assert mr.observed.coverage_pct > 0
+
+    def test_attested_coverage_computed_separately(self):
+        rules = load_rules(MAPPINGS_DIR)
+        events = [
+            _make_event(1, "cstp_decision_linked",
+                        {"decision_id": "x", "event_seqs": [], "has_outcome": False},
+                        evidence_class="attested"),
+        ]
+        mr = apply_rules(events, rules)
+        assert mr.attested.total_events == 1
+        assert mr.attested.coverage_pct > 0
+
+    def test_mapping_result_has_no_blended_coverage(self):
+        """MappingResult must NOT expose a single blended coverage_pct.
+
+        This test fails if a blended coverage number is ever added to MappingResult.
+        A blended metric weakens the strong observed class by mixing it with weaker
+        attested evidence — the most important design invariant of F055.
+        """
+        rules = load_rules(MAPPINGS_DIR)
+        events = [
+            _make_event(1, "pr_opened", {"pr_number": 1, "is_agent_authored": True},
+                        evidence_class="observed"),
+            _make_event(2, "cstp_decision_linked",
+                        {"decision_id": "y", "event_seqs": [1], "has_outcome": True},
+                        evidence_class="attested"),
+        ]
+        mr = apply_rules(events, rules)
+        # Must have separate per-class coverage
+        assert hasattr(mr, "observed") and hasattr(mr.observed, "coverage_pct")
+        assert hasattr(mr, "attested") and hasattr(mr.attested, "coverage_pct")
+        # Must NOT have a single blended coverage_pct on MappingResult itself
+        assert not hasattr(mr, "coverage_pct"), (
+            "MappingResult must not expose a blended coverage_pct. "
+            "Separate observed.coverage_pct and attested.coverage_pct are required."
+        )
+
+    def test_rpc_response_has_no_blended_coverage(self, tmp_path):
+        """cstp.mapControls response must not contain a top-level coverage_pct."""
+        import asyncio
+        db_path = str(tmp_path / "no_blend.db")
+        init_db(db_path)
+        append_event("gh", "pr_opened", "observed",
+                     {"pr_number": 1, "is_agent_authored": True},
+                     ts="2026-01-01T00:00:00Z", db_path=db_path)
+        params = {"db_path": db_path}
+        result = asyncio.get_event_loop().run_until_complete(map_controls(params, "test-agent"))
+        assert "coverage_pct" not in result, (
+            "cstp.mapControls must not return a blended coverage_pct. "
+            "Only coverage.observed.coverage_pct and coverage.attested.coverage_pct are allowed."
+        )
+        assert "coverage" in result
+        assert "observed" in result["coverage"]
+        assert "attested" in result["coverage"]
+
+    def test_bundle_has_no_blended_coverage(self, tmp_path):
+        """exportEvidenceBundle JSON bundle must not contain a top-level coverage_pct."""
+        import asyncio
+        db_path = str(tmp_path / "bundle_blend.db")
+        output_dir = tmp_path / "out"
+        init_db(db_path)
+        append_event("gh", "pr_opened", "observed",
+                     {"pr_number": 1, "is_agent_authored": True},
+                     ts="2026-01-01T00:00:00Z", db_path=db_path)
+        params = {"db_path": db_path, "format": "json", "output_dir": str(output_dir)}
+        result = asyncio.get_event_loop().run_until_complete(
+            export_evidence_bundle(params, "test-agent")
+        )
+        # The service-level result must not have blended coverage
+        assert "coverage_pct" not in result, (
+            "exportEvidenceBundle must not return a blended coverage_pct."
+        )
+        # The JSON bundle file also must not have a top-level coverage_pct
+        json_path = result.get("json_path")
+        assert json_path, "json_path missing from result"
+        bundle = json.loads(Path(json_path).read_text())
+        assert "coverage_pct" not in bundle, (
+            "JSON bundle must not contain a top-level blended coverage_pct."
+        )
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Mapping: attested-only controls
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestAttestedOnlyControls:
+    def test_attested_only_control_flagged(self):
+        """Controls with ONLY attested evidence must be in attested_only_controls."""
+        rules = load_rules(MAPPINGS_DIR)
+        # Only attested event, no observed
+        events = [
+            _make_event(1, "cstp_decision_linked",
+                        {"decision_id": "x", "event_seqs": [], "has_outcome": False,
+                         "stakes": "high"},
+                        evidence_class="attested"),
+        ]
+        mr = apply_rules(events, rules)
+        # Should have some attested-only controls (no observed evidence for these)
+        assert len(mr.attested_only_controls) >= 1
+
+    def test_attested_only_not_flagged_when_observed_covers_same(self):
+        """If observed evidence also covers a control, it must not be attested_only."""
+        rules = load_rules(MAPPINGS_DIR)
+        events = [
+            # Observed event covers MV-1
+            _make_event(1, "pr_opened", {"pr_number": 1, "is_agent_authored": True},
+                        evidence_class="observed"),
+            # Attested event would also cover MV-1 (via CSTP-SR117-MV1-decision-record)
+            _make_event(2, "cstp_decision_linked",
+                        {"decision_id": "x", "event_seqs": [1], "has_outcome": False},
+                        evidence_class="attested"),
+        ]
+        mr = apply_rules(events, rules)
+        # MV-1 must NOT be attested_only because observed event covers it
+        assert "MV-1" not in mr.attested_only_controls
+
+    def test_attested_only_mappings_tagged_in_list(self):
+        rules = load_rules(MAPPINGS_DIR)
+        events = [
+            _make_event(1, "cstp_decision_linked",
+                        {"decision_id": "y", "event_seqs": [], "has_outcome": True},
+                        evidence_class="attested"),
+        ]
+        mr = apply_rules(events, rules)
+        for m in mr.mappings:
+            if m.get("function_id") in mr.attested_only_controls:
+                assert m.get("attested_only") is True
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Mapping: INSUFFICIENT EVIDENCE
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestInsufficientEvidence:
+    def test_agent_merged_no_approval_fires_ie(self):
+        """Agent-authored PR merged with no human approval must raise INSUFFICIENT EVIDENCE."""
+        rules = load_rules(MAPPINGS_DIR)
+        events = [
+            _make_event(1, "pr_opened", {"pr_number": 3, "is_agent_authored": True}),
+            _make_event(2, "pr_merged", {"pr_number": 3, "is_agent_authored": True,
+                                          "approval_count": 0}),
+        ]
+        mr = apply_rules(events, rules)
+        ie = [i for i in mr.insufficient_evidence if i["type"] == INSUFFICIENT_EVIDENCE_TAG]
+        assert len(ie) >= 1
+
+    def test_ie_has_reason_text(self):
+        rules = load_rules(MAPPINGS_DIR)
+        events = [
+            _make_event(1, "pr_merged", {"pr_number": 3, "is_agent_authored": True,
+                                          "approval_count": 0}),
+        ]
+        mr = apply_rules(events, rules)
+        for ie in mr.insufficient_evidence:
+            assert ie["reason"] and len(ie["reason"]) > 20
+
+    def test_agent_merged_with_approval_no_ie(self):
+        rules = load_rules(MAPPINGS_DIR)
+        events = [
+            _make_event(1, "pr_merged", {"pr_number": 2, "is_agent_authored": True,
+                                          "approval_count": 1}),
+        ]
+        mr = apply_rules(events, rules)
+        mv3_ie = [i for i in mr.insufficient_evidence
+                   if i.get("pr_number") == 2 and "MV-3" in i.get("function_id", "")]
+        assert len(mv3_ie) == 0
+
+    def test_manage11_does_not_fire_on_human_merge(self):
+        """MANAGE-1.1 must NOT fire on human-authored merges (P1 fix)."""
+        rules = load_rules(MAPPINGS_DIR)
+        events = [
+            _make_event(1, "pr_merged", {"pr_number": 5, "is_agent_authored": False,
+                                          "approval_count": 2}),
+        ]
+        mr = apply_rules(events, rules)
+        manage11 = [m for m in mr.mappings
+                     if m.get("function_id") == "MANAGE-1.1" and m.get("pr_number") == 5]
+        assert len(manage11) == 0, "MANAGE-1.1 must not fire on human-authored merges"
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# RPC: cstp.ingestEvidence
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestIngestEvidence:
+    @pytest.mark.asyncio
+    async def test_ingest_single_event(self, service_params):
+        params = {
+            **service_params,
+            "events": [{"event_type": "pr_opened", "payload": {"pr_number": 1},
+                        "ts": "2026-01-01T00:00:00Z"}],
+        }
+        result = await ingest_evidence(params, "agent-1")
+        assert result["ingested"] == 1
+        assert result["head_hash"] is not None
+        assert result["first_seq"] == 1
+
+    @pytest.mark.asyncio
+    async def test_ingest_multiple_events(self, service_params):
+        params = {
+            **service_params,
+            "events": [
+                {"event_type": "pr_opened", "payload": {}, "ts": "2026-01-01T00:00:00Z"},
+                {"event_type": "pr_merged", "payload": {}, "ts": "2026-01-02T00:00:00Z"},
+            ],
+        }
+        result = await ingest_evidence(params, "agent-1")
+        assert result["ingested"] == 2
+
+    @pytest.mark.asyncio
+    async def test_all_ingested_events_are_observed(self, service_params):
+        params = {
+            **service_params,
+            "events": [{"event_type": "pr_opened", "payload": {}, "ts": "2026-01-01T00:00:00Z"}],
+        }
+        await ingest_evidence(params, "agent-1")
+        events = get_events(service_params["db_path"])
+        for e in events:
+            assert e["evidence_class"] == "observed"
+
+    @pytest.mark.asyncio
+    async def test_ingest_requires_events(self, service_params):
+        params = {**service_params, "events": []}
+        with pytest.raises(ValueError, match="events"):
+            await ingest_evidence(params, "agent-1")
+
+    @pytest.mark.asyncio
+    async def test_ingest_requires_event_type(self, service_params):
+        params = {**service_params, "events": [{"payload": {}}]}
+        with pytest.raises(ValueError, match="event_type"):
+            await ingest_evidence(params, "agent-1")
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# RPC: cstp.linkEvidence
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestLinkEvidence:
+    @pytest.mark.asyncio
+    async def test_link_creates_attested_event(self, db_with_observed, service_params_observed):
+        params = {
+            **service_params_observed,
+            "decision_id": "dec-abc123",
+            "event_seqs": [1, 2],
+            "has_outcome": True,
+        }
+        result = await link_evidence(params, "agent-1")
+        assert result["linked"] == 2
+        assert result["decision_id"] == "dec-abc123"
+        assert result["attested_seq"] is not None
+
+        # Verify the attested event is in the store
+        att_events = get_events(db_with_observed, evidence_class="attested")
+        assert len(att_events) == 1
+        assert att_events[0]["event_type"] == "cstp_decision_linked"
+        assert att_events[0]["payload"]["decision_id"] == "dec-abc123"
+
+    @pytest.mark.asyncio
+    async def test_link_requires_decision_id(self, service_params_observed):
+        params = {**service_params_observed, "event_seqs": [1]}
+        with pytest.raises(ValueError, match="decision_id"):
+            await link_evidence(params, "agent-1")
+
+    @pytest.mark.asyncio
+    async def test_link_attested_event_has_correct_class(self, service_params):
+        params = {**service_params, "decision_id": "d1", "event_seqs": []}
+        await link_evidence(params, "agent-1")
+        events = get_events(service_params["db_path"])
+        assert all(
+            e["evidence_class"] in ("observed", "attested") for e in events
+        )
+        att = [e for e in events if e["evidence_class"] == "attested"]
+        assert len(att) == 1
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# RPC: cstp.mapControls
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestMapControls:
+    @pytest.mark.asyncio
+    async def test_returns_per_class_coverage(self, service_params_observed):
+        result = await map_controls(service_params_observed, "agent-1")
+        assert "coverage" in result
+        assert "observed" in result["coverage"]
+        assert "attested" in result["coverage"]
+
+    @pytest.mark.asyncio
+    async def test_no_blended_coverage_in_result(self, service_params_observed):
+        """cstp.mapControls must not return a top-level coverage_pct."""
+        result = await map_controls(service_params_observed, "agent-1")
+        assert "coverage_pct" not in result, (
+            "mapControls must not return a blended coverage_pct"
+        )
+
+    @pytest.mark.asyncio
+    async def test_ie_gap_detected_for_unapproved_merge(self, service_params_observed):
+        """PR #2 was merged with no approval — must surface as INSUFFICIENT EVIDENCE."""
+        result = await map_controls(service_params_observed, "agent-1")
+        ie = result["insufficient_evidence"]
+        pr2_ie = [i for i in ie if i.get("pr_number") == 2]
+        assert len(pr2_ie) >= 1, "PR #2 (agent, 0 approvals, merged) must produce IE"
+
+    @pytest.mark.asyncio
+    async def test_returns_attested_only_controls(self, service_params_observed):
+        assert "attested_only_controls" in await map_controls(service_params_observed, "agent-1")
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# RPC: cstp.exportEvidenceBundle (JSON)
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestExportEvidenceBundle:
+    @pytest.mark.asyncio
+    async def test_creates_json_file(self, service_params_observed, tmp_path):
+        params = {
+            **service_params_observed,
+            "format": "json",
+            "output_dir": str(tmp_path / "bundles"),
+        }
+        result = await export_evidence_bundle(params, "agent-1")
+        assert "json_path" in result
+        assert Path(result["json_path"]).exists()
+
+    @pytest.mark.asyncio
+    async def test_json_bundle_required_fields(self, service_params_observed, tmp_path):
+        params = {
+            **service_params_observed,
+            "format": "json",
+            "output_dir": str(tmp_path / "bundles"),
+        }
+        result = await export_evidence_bundle(params, "agent-1")
+        bundle = json.loads(Path(result["json_path"]).read_text())
+        for field in [
+            "version", "tool_version", "generated_at", "chain_head_hash",
+            "chain_intact", "coverage", "total_events",
+            "insufficient_evidence_count", "events", "mappings",
+            "insufficient_evidence", "unmapped", "attested_only_controls",
+        ]:
+            assert field in bundle, f"Missing required field: {field}"
+
+    @pytest.mark.asyncio
+    async def test_bundle_has_no_blended_coverage_pct(self, service_params_observed, tmp_path):
+        """JSON bundle must not contain a top-level blended coverage_pct."""
+        params = {
+            **service_params_observed,
+            "format": "json",
+            "output_dir": str(tmp_path / "bundles"),
+        }
+        result = await export_evidence_bundle(params, "agent-1")
+        bundle = json.loads(Path(result["json_path"]).read_text())
+        assert "coverage_pct" not in bundle, (
+            "JSON bundle must not have a blended coverage_pct at the top level"
+        )
+        assert "observed" in bundle["coverage"]
+        assert "attested" in bundle["coverage"]
+
+    @pytest.mark.asyncio
+    async def test_chain_intact_true_for_valid_chain(self, service_params_observed, tmp_path):
+        params = {
+            **service_params_observed,
+            "format": "json",
+            "output_dir": str(tmp_path / "bundles"),
+        }
+        result = await export_evidence_bundle(params, "agent-1")
+        assert result["chain_intact"] is True
+
+    @pytest.mark.asyncio
+    async def test_chain_intact_false_after_tamper(self, db_with_observed, tmp_path):
+        """Tampered chain must make chain_intact=False (uses stored head hash — P2 fix)."""
+        db_path = db_with_observed
+        params = {
+            "db_path": db_path,
+            "format": "json",
+            "output_dir": str(tmp_path / "bundles"),
+        }
+        # First export to capture head hash
+        await export_evidence_bundle(params, "agent-1")
+        # Tamper and re-export
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("UPDATE events SET payload_json = '{\"tampered\":true}' WHERE seq = 1")
+            conn.commit()
+        result = await export_evidence_bundle(params, "agent-1")
+        assert result["chain_intact"] is False
+
+    @pytest.mark.asyncio
+    async def test_p2_tail_truncation_detected(self, db_with_observed, tmp_path):
+        """Tail truncation must be detected via stored head hash (P2 fix)."""
+        db_path = db_with_observed
+        params = {
+            "db_path": db_path,
+            "format": "json",
+            "output_dir": str(tmp_path / "bundles"),
+        }
+        # First bundle stores the head hash
+        await export_evidence_bundle(params, "agent-1")
+        # Delete tail events
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("DELETE FROM events WHERE seq >= 4")
+            conn.commit()
+        # Second bundle: chain appears internally intact, but head hash won't match
+        result2 = await export_evidence_bundle(params, "agent-1")
+        assert result2["chain_intact"] is False, (
+            "P2 fix: tail truncation must be detected via persisted head hash"
+        )
+
+    @pytest.mark.asyncio
+    async def test_immutable_on_regenerate(self, service_params_observed, tmp_path):
+        """Each export creates a new file, never overwrites."""
+        import asyncio as aio
+        params = {
+            **service_params_observed,
+            "format": "json",
+            "output_dir": str(tmp_path / "bundles"),
+        }
+        r1 = await export_evidence_bundle(params, "agent-1")
+        await aio.sleep(1)  # ensure different timestamp in filename
+        r2 = await export_evidence_bundle(params, "agent-1")
+        assert r1["json_path"] != r2["json_path"]
+        assert Path(r1["json_path"]).exists()
+        assert Path(r2["json_path"]).exists()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# RPC: cstp.verifyEvidenceChain
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestVerifyEvidenceChain:
+    @pytest.mark.asyncio
+    async def test_intact_chain_returns_intact_true(self, service_params_observed):
+        result = await verify_evidence_chain(service_params_observed, "agent-1")
+        assert result["intact"] is True
+        assert result["broken_at_seq"] is None
+
+    @pytest.mark.asyncio
+    async def test_accepts_expected_head_hash(self, service_params_observed):
+        head = get_head_hash(service_params_observed["db_path"])
+        params = {**service_params_observed, "expected_head_hash": head}
+        result = await verify_evidence_chain(params, "agent-1")
+        assert result["intact"] is True
+        assert result["tail_check"] is True
+
+    @pytest.mark.asyncio
+    async def test_wrong_expected_head_hash_returns_broken(self, service_params_observed):
+        params = {**service_params_observed, "expected_head_hash": "0" * 64}
+        result = await verify_evidence_chain(params, "agent-1")
+        assert result["intact"] is False
+        assert result["broken_at_seq"] == 0  # tail sentinel
+
+    @pytest.mark.asyncio
+    async def test_uses_stored_bundle_head_hash(self, db_with_observed, tmp_path):
+        """Without explicit expected_head_hash, uses last bundle head (P2 fix)."""
+        db_path = db_with_observed
+        # Generate a bundle to store the head hash
+        await export_evidence_bundle(
+            {"db_path": db_path, "format": "json", "output_dir": str(tmp_path / "b")},
+            "agent-1",
+        )
+        # Delete tail events — truncation should be detectable via stored hash
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("DELETE FROM events WHERE seq >= 4")
+            conn.commit()
+        result = await verify_evidence_chain({"db_path": db_path}, "agent-1")
+        assert result["intact"] is False
+        assert result["tail_check"] is True
+
+    @pytest.mark.asyncio
+    async def test_tampered_record_returns_broken(self, db_with_observed):
+        with sqlite3.connect(db_with_observed) as conn:
+            conn.execute(
+                "UPDATE events SET payload_json = '{\"tampered\":true}' WHERE seq = 2"
+            )
+            conn.commit()
+        result = await verify_evidence_chain(
+            {"db_path": db_with_observed}, "agent-1"
+        )
+        assert result["intact"] is False
+        assert result["broken_at_seq"] == 2
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Integration: end-to-end workflow
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestEndToEndWorkflow:
+    @pytest.mark.asyncio
+    async def test_full_workflow(self, tmp_path):
+        """Ingest → Link → MapControls → Export → Verify."""
+        db_path = str(tmp_path / "workflow.db")
+        output_dir = str(tmp_path / "bundles")
+        init_db(db_path)
+
+        # 1. Ingest observed events
+        ingest_result = await ingest_evidence({
+            "db_path": db_path,
+            "events": [
+                {"event_type": "pr_opened", "ts": "2026-01-01T10:00:00Z",
+                 "payload": {"pr_number": 10, "is_agent_authored": True, "approval_count": 0}},
+                {"event_type": "pr_review_approved", "ts": "2026-01-01T11:00:00Z",
+                 "payload": {"pr_number": 10, "reviewer": "bob"}},
+                {"event_type": "pr_merged", "ts": "2026-01-01T12:00:00Z",
+                 "payload": {"pr_number": 10, "is_agent_authored": True, "approval_count": 1}},
+            ],
+        }, "test-agent")
+        assert ingest_result["ingested"] == 3
+
+        # 2. Link a CSTP decision to observed events
+        link_result = await link_evidence({
+            "db_path": db_path,
+            "decision_id": "dec-workflow-test",
+            "event_seqs": [1, 2, 3],
+            "has_outcome": True,
+            "stakes": "high",
+        }, "test-agent")
+        assert link_result["linked"] == 3
+
+        # 3. Map controls
+        map_result = await map_controls({"db_path": db_path}, "test-agent")
+        assert map_result["coverage"]["observed"]["total_events"] == 3
+        assert map_result["coverage"]["attested"]["total_events"] == 1
+        assert "coverage_pct" not in map_result  # No blended metric
+
+        # 4. Export bundle
+        export_result = await export_evidence_bundle({
+            "db_path": db_path,
+            "format": "json",
+            "output_dir": output_dir,
+        }, "test-agent")
+        assert export_result["chain_intact"] is True
+        bundle = json.loads(Path(export_result["json_path"]).read_text())
+        assert "coverage_pct" not in bundle  # No blended metric in JSON bundle
+        assert bundle["coverage"]["observed"]["total_events"] == 3
+
+        # 5. Verify chain
+        verify_result = await verify_evidence_chain({"db_path": db_path}, "test-agent")
+        assert verify_result["intact"] is True

--- a/tests/test_f055_provenance_service.py
+++ b/tests/test_f055_provenance_service.py
@@ -512,16 +512,15 @@ class TestPerClassCoverage:
             "Separate observed.coverage_pct and attested.coverage_pct are required."
         )
 
-    def test_rpc_response_has_no_blended_coverage(self, tmp_path):
+    async def test_rpc_response_has_no_blended_coverage(self, tmp_path):
         """cstp.mapControls response must not contain a top-level coverage_pct."""
-        import asyncio
         db_path = str(tmp_path / "no_blend.db")
         init_db(db_path)
         append_event("gh", "pr_opened", "observed",
                      {"pr_number": 1, "is_agent_authored": True},
                      ts="2026-01-01T00:00:00Z", db_path=db_path)
         params = {"db_path": db_path}
-        result = asyncio.get_event_loop().run_until_complete(map_controls(params, "test-agent"))
+        result = await map_controls(params, "test-agent")
         assert "coverage_pct" not in result, (
             "cstp.mapControls must not return a blended coverage_pct. "
             "Only coverage.observed.coverage_pct and coverage.attested.coverage_pct are allowed."
@@ -530,9 +529,8 @@ class TestPerClassCoverage:
         assert "observed" in result["coverage"]
         assert "attested" in result["coverage"]
 
-    def test_bundle_has_no_blended_coverage(self, tmp_path):
+    async def test_bundle_has_no_blended_coverage(self, tmp_path):
         """exportEvidenceBundle JSON bundle must not contain a top-level coverage_pct."""
-        import asyncio
         db_path = str(tmp_path / "bundle_blend.db")
         output_dir = tmp_path / "out"
         init_db(db_path)
@@ -540,9 +538,7 @@ class TestPerClassCoverage:
                      {"pr_number": 1, "is_agent_authored": True},
                      ts="2026-01-01T00:00:00Z", db_path=db_path)
         params = {"db_path": db_path, "format": "json", "output_dir": str(output_dir)}
-        result = asyncio.get_event_loop().run_until_complete(
-            export_evidence_bundle(params, "test-agent")
-        )
+        result = await export_evidence_bundle(params, "test-agent")
         # The service-level result must not have blended coverage
         assert "coverage_pct" not in result, (
             "exportEvidenceBundle must not return a blended coverage_pct."

--- a/website/specs/f055-decision-provenance.md
+++ b/website/specs/f055-decision-provenance.md
@@ -1,0 +1,364 @@
+# F055: Decision Provenance & Control Evidence
+
+**Status:** Shipped (v0.16.0)
+**Priority:** High
+**Category:** Compliance & Auditability
+
+## Problem
+
+When an AI agent influences a regulated decision — approves a change, flags a transaction,
+drafts an underwriting recommendation — nobody can hand a regulator a single artifact
+proving *what* the agent reasoned, *who* reviewed it, and *which control framework* that
+review satisfies. Evidence is scattered across PR comments, observability dashboards, and
+CSTP decision logs built for engineers, not auditors.
+
+Every audit becomes forensic reconstruction instead of a five-minute export.
+
+## Solution
+
+F055 makes CSTP able to prove *that* it acted and *which control that satisfies*.
+
+CSTP already records *why* an agent decided something (see F007 `cstp.recordDecision`).
+F055 adds:
+
+1. An **observed evidence hash chain** that ingests third-party events (GitHub PR opens,
+   reviews, approvals, merges) and makes them tamper-evident.
+2. An **attested evidence layer** that links existing CSTP decisions to observed events.
+3. A **YAML rules engine** that maps both evidence classes to SR 11-7 and NIST AI RMF controls.
+4. A **bundle generator** that emits a JSON (and optionally PDF) artifact an auditor can
+   receive in one API call.
+5. A **chain verifier** that detects both internal tampering and tail truncation.
+
+## The Two-Class Evidence Model
+
+This is the intellectually load-bearing part of F055. All evidence falls into exactly one of
+two classes and they must **never be blended**:
+
+### Class OBSERVED
+
+Third-party events from a system of record the subject does not control:
+- GitHub PR opens, commits, code reviews, approvals, merges
+- Ingested via `cstp.ingestEvidence`
+- **Hash-chained and tamper-evident** — any modification to a stored record breaks the chain
+- An auditor trusts observed evidence because the agent did not control the source
+
+### Class ATTESTED
+
+First-party CSTP records self-reported by the agent:
+- Decision records (`cstp.recordDecision`) linked to observed events
+- Linked via `cstp.linkEvidence`, stored as `cstp_decision_linked` events
+- **Self-reported** — the agent wrote this; an auditor discounts it heavily
+- Useful as corroboration, not as primary evidence
+
+### Why the split matters
+
+> "An auditor discounts self-attestation heavily. If you merge these into one number you
+> *weaken* the strong half."
+
+A single blended coverage percentage obscures whether controls are evidenced by tamper-proof
+third-party records or by the agent's own claims. An 82% blended score where 70% is attested
+is very different from an 82% score where 70% is observed.
+
+### Enforcement
+
+- Every evidence item in the schema carries an explicit `evidence_class` column
+  (`"observed"` | `"attested"`). Not nullable. No default.
+- Coverage is computed and reported **separately per class** via `observed.coverage_pct`
+  and `attested.coverage_pct`. There is no blended `coverage_pct` anywhere in the API
+  response, the JSON bundle, or the PDF.
+- A control mapping satisfied *only* by attested evidence is flagged `attested_only: true`
+  and rendered distinctly in the PDF (amber header, "ATTESTED-ONLY" status label).
+- Tests enforce all three invariants (see `tests/test_f055_provenance_service.py`,
+  class `TestPerClassCoverage` and `TestAttestedOnlyControls`).
+
+## API
+
+### `cstp.ingestEvidence`
+
+Ingest observed events into the hash chain.
+
+```json
+{
+  "method": "cstp.ingestEvidence",
+  "params": {
+    "source": "github",
+    "events": [
+      {
+        "event_type": "pr_opened",
+        "ts": "2026-07-01T10:00:00Z",
+        "payload": {
+          "pr_number": 42,
+          "title": "Add risk scorer v2",
+          "is_agent_authored": true,
+          "agent_type": "Claude",
+          "approval_count": 0,
+          "additions": 350,
+          "deletions": 12,
+          "changed_files": 5
+        }
+      },
+      {
+        "event_type": "pr_review_approved",
+        "ts": "2026-07-01T14:00:00Z",
+        "payload": { "pr_number": 42, "reviewer": "alice" }
+      }
+    ]
+  }
+}
+```
+
+Response:
+```json
+{
+  "result": {
+    "ingested": 2,
+    "head_hash": "65b58d83a0b5be919...",
+    "first_seq": 1
+  }
+}
+```
+
+All ingested events receive `evidence_class = "observed"`. This is not overridable.
+
+### `cstp.linkEvidence`
+
+Correlate an existing CSTP decision to observed events. Creates an attested evidence
+record (`cstp_decision_linked`) in the provenance store.
+
+```json
+{
+  "method": "cstp.linkEvidence",
+  "params": {
+    "decision_id": "dec-7e2f9a",
+    "event_seqs": [1, 2, 3],
+    "stakes": "high",
+    "has_outcome": true
+  }
+}
+```
+
+Response:
+```json
+{
+  "result": {
+    "linked": 3,
+    "decision_id": "dec-7e2f9a",
+    "attested_seq": 4
+  }
+}
+```
+
+### `cstp.mapControls`
+
+Run the YAML rules engine over all stored evidence. Returns per-class coverage —
+**never a blended percentage**.
+
+```json
+{ "method": "cstp.mapControls", "params": {} }
+```
+
+Response:
+```json
+{
+  "result": {
+    "coverage": {
+      "observed": {
+        "total_events": 50,
+        "mapped_events": 41,
+        "unmapped_events": 9,
+        "coverage_pct": 82.0
+      },
+      "attested": {
+        "total_events": 3,
+        "mapped_events": 3,
+        "unmapped_events": 0,
+        "coverage_pct": 100.0
+      }
+    },
+    "mappings": [
+      {
+        "seq": 1, "event_type": "pr_opened", "pr_number": 42,
+        "rule_id": "SR11-7-MV1-agent-pr-opened",
+        "framework": "SR 11-7", "stage": "Model Development",
+        "function_id": "MV-1", "control_name": "Agent-Authored Change Documentation",
+        "evidence_class": "observed", "type": "mapping"
+      }
+    ],
+    "insufficient_evidence": [
+      {
+        "seq": 10, "pr_number": 3, "framework": "SR 11-7",
+        "function_id": "MV-3", "control_name": "Independent Human Review and Approval",
+        "evidence_class": "observed", "type": "INSUFFICIENT_EVIDENCE",
+        "reason": "INSUFFICIENT EVIDENCE: Agent-authored PR was merged without any human approval..."
+      }
+    ],
+    "insufficient_evidence_count": 2,
+    "unmapped": [...],
+    "attested_only_controls": ["MV-3"]
+  }
+}
+```
+
+### `cstp.exportEvidenceBundle`
+
+Emit the full evidence bundle as JSON (and optionally PDF).
+
+```json
+{
+  "method": "cstp.exportEvidenceBundle",
+  "params": {
+    "format": "json",
+    "output_dir": "/var/bundles/2026-Q3"
+  }
+}
+```
+
+Response:
+```json
+{
+  "result": {
+    "json_path": "/var/bundles/2026-Q3/bundle_20260809T173649Z.json",
+    "chain_head_hash": "65b58d83a0b5be919...",
+    "chain_intact": true,
+    "coverage": { "observed": {...}, "attested": {...} },
+    "insufficient_evidence_count": 2,
+    "attested_only_controls": ["MV-3"]
+  }
+}
+```
+
+The bundle persists `chain_head_hash` at generation time. Subsequent calls to
+`cstp.verifyEvidenceChain` verify against that stored hash, enabling detection of
+tail truncation (events deleted after the bundle was generated).
+
+### `cstp.verifyEvidenceChain`
+
+Verify hash chain integrity. Accepts `expected_head_hash` to detect tail truncation.
+
+```json
+{
+  "method": "cstp.verifyEvidenceChain",
+  "params": {
+    "expected_head_hash": "65b58d83a0b5be919..."
+  }
+}
+```
+
+Response:
+```json
+{
+  "result": {
+    "intact": true,
+    "broken_at_seq": null,
+    "head_hash": "65b58d83a0b5be919...",
+    "expected_hash": "65b58d83a0b5be919...",
+    "tail_check": true
+  }
+}
+```
+
+If `expected_head_hash` is omitted, the hash from the most recent bundle generation is
+used automatically. If no bundle has been generated, tail-truncation detection is inactive
+and `tail_check` is `false`.
+
+## Hash Chain
+
+The observed evidence store uses a SHA-256 hash chain. Hash preimage (UTF-8):
+
+```
+{seq}\n{ts}\n{event_type}\n{evidence_class}\n{canonical_json(payload)}\n{prev_hash}
+```
+
+Note that `evidence_class` is included in the preimage. Reclassifying an event from
+`observed` to `attested` (or vice versa) breaks the chain at that record.
+
+`source` is intentionally excluded — it identifies the ingest origin but does not affect
+tamper-evidence.
+
+## Control Framework Mappings
+
+Rules are defined in `a2a/cstp/provenance/mappings/`:
+
+| File | Framework | Evidence class |
+|------|-----------|----------------|
+| `sr11-7.yaml` | SR 11-7 (Federal Reserve MRM) | observed |
+| `nist-ai-rmf.yaml` | NIST AI RMF 1.0 | observed |
+| `cstp-attested.yaml` | CSTP Attested | attested |
+
+### Honest-mapping policy (from the PoC)
+
+The mapping is hand-written YAML **on purpose** — an ML-inferred mapping is itself an audit
+liability. Do not "improve" this with a model.
+
+**P1 fixes preserved from PoC (commit `9643d21`):**
+- `verify_chain()` accepts `expected_head_hash` so tail truncation is detectable
+- MAP-1.1 is tagged `confidence: low` / `stretch: true` and renders as `[PARTIAL/CONTESTED]`
+- MANAGE-1.1 only fires when `is_agent_authored: true` (human merges are a category error)
+
+**P2 fix added in this port:**
+- The JSON bundle persists `chain_head_hash` at generation time
+- `cstp.verifyEvidenceChain` defaults to the stored head hash when no explicit hash is given
+- This makes tail truncation detectable without the caller needing to remember the head hash
+
+## Honesty
+
+The original PoC produced 82.0% observed coverage with 2 genuine evidence gaps on PR #3
+(agent-authored code merged by its own author with zero human approval). **That gap-finding
+is the product.** Do not tune, stretch, or reclassify any mapping to make coverage numbers
+look better.
+
+The two-class split makes attested-only controls appear weaker — that is the correct and
+desired outcome. An attested-only control should look weak to an auditor, because it is.
+
+If a port surfaces a mapping that cannot be honestly justified, emit `INSUFFICIENT_EVIDENCE`
+with a plain-English reason rather than stretching it.
+
+## Storage
+
+The provenance DB is a SQLite WAL file at `$PROVENANCE_DB` (default:
+`~/.cstp/provenance.db`), separate from the decision store. Schema:
+
+```sql
+CREATE TABLE events (
+    seq            INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts             TEXT NOT NULL,
+    source         TEXT NOT NULL,
+    event_type     TEXT NOT NULL,
+    evidence_class TEXT NOT NULL CHECK(evidence_class IN ('observed', 'attested')),
+    payload_json   TEXT NOT NULL,
+    prev_hash      TEXT NOT NULL,
+    hash           TEXT NOT NULL
+);
+
+CREATE TABLE bundle_metadata (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    generated_at TEXT NOT NULL,
+    head_hash    TEXT NOT NULL,
+    format       TEXT NOT NULL
+);
+```
+
+## Out of Scope
+
+- Dashboard / web UI for provenance
+- EU AI Act control mapping (stubbed — pending legal review; do not add ML inference)
+- Multi-tenant billing or SOC 2
+- Any ML-inferred control mapping
+- Migrating the PoC repo
+
+## Integration Points
+
+- F007 (`cstp.recordDecision`): Decisions recorded here can be linked to observed events
+  via `cstp.linkEvidence`, creating attested evidence entries
+- F045 (Graph): Decision graph edges can be exported as observed events to trace reasoning chains
+- F047 (Session Context): Session context can include provenance coverage summary
+- F050 (Structured Storage): Provenance DB uses the same SQLite WAL pattern
+
+## Phases
+
+1. **P1 (this PR):** All five RPC methods, two-class evidence model, SR 11-7 + NIST AI RMF
+   + CSTP-attested YAML rules, JSON bundle, chain verification with tail-truncation detection
+2. **P2:** PDF bundle improvements — executive sign-off section, regulatory text citations,
+   per-model evidence grouping
+3. **P3:** EU AI Act Annex III mapping (requires legal review of each rule)
+4. **P4:** Streaming ingest webhook for real-time GitHub event ingestion


### PR DESCRIPTION
## Summary

Implements F055 — the full decision provenance and control-evidence layer for CSTP. Ported from provenance-poc (commit `9643d21`) with P1 fixes carried forward and the P2 tail-truncation fix added.

### Five new CSTP methods

| Method | Description |
|--------|-------------|
| `cstp.ingestEvidence` | Ingest observed events into the SHA-256 hash chain |
| `cstp.linkEvidence` | Link a CSTP decision to observed events (creates attested record) |
| `cstp.mapControls` | Run YAML rules engine; return per-class coverage |
| `cstp.exportEvidenceBundle` | Emit JSON (+ optional PDF) audit bundle |
| `cstp.verifyEvidenceChain` | Verify chain integrity; detect tail truncation |

### Two-class evidence model (non-negotiable design constraint)

Evidence falls into exactly one class — never blended:

- **OBSERVED**: Third-party events the subject doesn't control (GitHub PR history). Hash-chained, tamper-evident. `evidence_class` is included in the hash preimage so reclassification breaks the chain.
- **ATTESTED**: First-party CSTP records, self-reported by the agent via `cstp.linkEvidence`.

Enforcement:
- `evidence_class TEXT NOT NULL CHECK(evidence_class IN ('observed', 'attested'))` — no nullable, no default
- Coverage exposed as `observed.coverage_pct` and `attested.coverage_pct` — `MappingResult` has **no** `coverage_pct` attribute at all
- Controls satisfied only by attested evidence are flagged `attested_only: true`
- `test_mapping_result_has_no_blended_coverage` fails if a blended attribute is ever added

### P1 + P2 fixes from PoC adversarial review

**P1 (carried forward):**
- `verify_chain(expected_head_hash)` returns `seq=0` on tail truncation (chain internally valid but head doesn't match)
- MAP-1.1 tagged `confidence: low / stretch: true` — renders as `[PARTIAL/CONTESTED]`
- MANAGE-1.1 only fires when `is_agent_authored: true`

**P2 (added in this port):**
- Bundle export persists `chain_head_hash` to `bundle_metadata` table at generation time
- Subsequent `cstp.verifyEvidenceChain` calls auto-load stored hash — tail truncation detectable without caller book-keeping
- `test_p2_tail_truncation_detected` verifies the flow end-to-end

## Files changed

| File | Change |
|------|--------|
| `a2a/cstp/storage/provenance.py` | New — hash-chained SQLite event store with `bundle_metadata` |
| `a2a/cstp/provenance/__init__.py` | New — package init |
| `a2a/cstp/provenance/mapping.py` | New — YAML rules engine, per-class `EvidenceClassStats` |
| `a2a/cstp/provenance/mappings/sr11-7.yaml` | New — SR 11-7 MRM rules (P1 fixes applied) |
| `a2a/cstp/provenance/mappings/nist-ai-rmf.yaml` | New — NIST AI RMF rules (P1 fixes applied) |
| `a2a/cstp/provenance/mappings/cstp-attested.yaml` | New — attested CSTP decision rules |
| `a2a/cstp/provenance_service.py` | New — 5 async service functions |
| `tests/test_f055_provenance_service.py` | New — 82 tests, all passing |
| `website/specs/f055-decision-provenance.md` | New — feature spec |
| `a2a/cstp/dispatcher.py` | Modified — registers 5 new cstp.* methods |

## Test plan

- [x] `python -m pytest tests/test_f055_provenance_service.py -v` — 82/82 passed
- [x] `ruff check src/ tests/ a2a/` — no errors
- [x] Pre-existing failures in `test_f041_compaction.py` confirmed to exist on `main` before this change (not introduced by F055)
- [ ] Integration: run `cstp-server` with `VECTOR_BACKEND=memory`, call `cstp.ingestEvidence` + `cstp.mapControls` end-to-end

## Out of scope (observed, not acted on)

- `test_f041_compaction.py` has 2 pre-existing failures on `main` — not related to F055
- PDF bundle generation requires `reportlab` (optional dep); graceful error returned if not installed — consider adding to `[all]` extras in a follow-up
- EU AI Act Annex III mapping is stubbed in spec as P3 (pending legal review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)