### PR TITLE
fix(F041): resolve wisdom recency-filter time-brittleness

### DIFF
--- a/a2a/cstp/compaction_service.py
+++ b/a2a/cstp/compaction_service.py
@@ -385,6 +385,8 @@ def build_wisdom(
     decisions: list[dict[str, Any]],
     min_decisions: int = 5,
     category_filter: str | None = None,
+    *,
+    now: datetime | None = None,
 ) -> list[WisdomEntry]:
     """Aggregate decisions into category-level wisdom entries.
 
@@ -396,11 +398,13 @@ def build_wisdom(
         decisions: All decision dicts.
         min_decisions: Minimum reviewed decisions per category.
         category_filter: Optional single-category filter.
+        now: Reference time for age calculation (injectable for testing).
 
     Returns:
         List of WisdomEntry aggregates per category.
     """
-    now = datetime.now(UTC)
+    if now is None:
+        now = datetime.now(UTC)
 
     # Group reviewed decisions by category
     by_category: dict[str, list[dict[str, Any]]] = defaultdict(list)

--- a/tests/test_f041_compaction.py
+++ b/tests/test_f041_compaction.py
@@ -837,10 +837,10 @@ class TestBuildWisdom:
     def test_recent_decisions_excluded(self) -> None:
         """Only wisdom-age (90+ day) decisions count."""
         decisions = self._wisdom_decisions(count=10)
-        # Override to recent dates
+        # Override to recent dates (5 days before NOW)
         for d in decisions:
             d["date"] = (NOW - timedelta(days=5)).isoformat()
-        wisdom = build_wisdom(decisions, min_decisions=1)
+        wisdom = build_wisdom(decisions, min_decisions=1, now=NOW)
         assert len(wisdom) == 0
 
     def test_multiple_categories(self) -> None:

--- a/tests/test_f041_compaction_integration.py
+++ b/tests/test_f041_compaction_integration.py
@@ -174,9 +174,23 @@ class TestWisdomInSessionContext:
         mock_guardrails: AsyncMock,
     ) -> None:
         """Wisdom should be empty when all decisions are recent."""
-        # Only recent decisions (< 90 days old)
+        from datetime import UTC, datetime, timedelta
+
+        # Use genuinely recent dates (5 days ago from now) so the
+        # wall-clock age check in build_wisdom correctly classifies them
+        # as non-wisdom-age regardless of when the test runs.
+        recent_date = (datetime.now(UTC) - timedelta(days=5)).isoformat()
         mock_load.return_value = [
-            _make_decision(decision_id=f"r{i}", age_days=5)
+            {
+                "id": f"r{i}",
+                "summary": f"Test decision r{i}",
+                "decision": f"Test decision r{i}",
+                "category": "architecture",
+                "confidence": 0.9,
+                "status": "reviewed",
+                "outcome": "success",
+                "date": recent_date,
+            }
             for i in range(10)
         ]
         mock_query.return_value = MockQueryResponse()


### PR DESCRIPTION
## Summary

- `build_wisdom` used `datetime.now(UTC)` internally to evaluate decision age, but tests created decisions at a fixed past date (`NOW = 2026-02-15`). As the calendar advanced past ~April 2026, those fixture decisions aged beyond 90 days and were classified as wisdom-age — causing the assertions to fail.
- Pre-existing bug on `main`; NOT caused by any recent PR.

## Root-cause verdict: **time-brittle test** (not a production-code bug)

Evidence:
- `determine_compaction_level` already accepts an injectable `now` parameter (present since F041 was written), confirming the pattern was intended.
- `build_wisdom` was missing the same `now` parameter, coupling its behavior to wall-clock time.
- Both failing tests set up fixture decisions at `NOW - 5 days` where `NOW = 2026-02-15`, then called `build_wisdom` or `get_session_context → build_wisdom` without freezing time. From `2026-08-09`, those dates are ~179 days old — above the 90-day wisdom threshold.
- The production recency filter itself is correct: `determine_compaction_level` correctly returns `"wisdom"` for decisions ≥ 90 days old.

## Changes

| File | Change |
|------|--------|
| `a2a/cstp/compaction_service.py` | Add `now: datetime \| None = None` keyword-only parameter to `build_wisdom`; matches the pattern in `determine_compaction_level`. Production callers pass nothing → wall-clock behavior unchanged. |
| `tests/test_f041_compaction.py` | Pass `now=NOW` to `build_wisdom` in `test_recent_decisions_excluded` so age is evaluated relative to the same reference time as the fixture dates. |
| `tests/test_f041_compaction_integration.py` | Replace `_make_decision(age_days=5)` (computes against fixed `NOW`) with inline `datetime.now(UTC) - timedelta(days=5)` so the fixture always represents genuinely recent decisions regardless of wall-clock. |

## Verification

Full test suite: **1169 passed, 9 skipped, 0 failed** (Python 3.12 locally; CI targets Python 3.11, where the same change is equally valid).

```
tests/test_f041_compaction.py::TestBuildWisdom::test_recent_decisions_excluded PASSED
tests/test_f041_compaction_integration.py::TestWisdomInSessionContext::test_wisdom_empty_when_no_old_decisions PASSED
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)