### PR TITLE
fix(F055): resolve 13 security findings in provenance audit subsystem

### DIFF
--- a/a2a/cstp/provenance/mapping.py
+++ b/a2a/cstp/provenance/mapping.py
@@ -9,6 +9,10 @@ Coverage is computed and reported SEPARATELY per evidence class — never blende
 
 A control satisfied only by attested evidence is flagged attested_only=True and
 must be rendered distinctly in any bundle output (including PDF).
+
+Evidence class isolation: each YAML file declares its evidence_class at the top
+level. Rules from that file only match events of the same class — observed rules
+never match attested events and vice versa (finding 7).
 """
 
 from dataclasses import dataclass, field
@@ -51,16 +55,22 @@ class MappingResult:
 
 
 def load_rules(mappings_dir: Path = MAPPINGS_DIR) -> list[dict]:
-    """Load all YAML rule files from mappings_dir. Returns combined list of rules."""
+    """Load all YAML rule files from mappings_dir. Returns combined list of rules.
+
+    Each rule carries '_evidence_class' from the file header so that
+    _rule_matches can enforce class isolation (finding 7).
+    """
     all_rules = []
     for yaml_file in sorted(mappings_dir.glob("*.yaml")):
         with open(yaml_file) as f:
             data = yaml.safe_load(f)
         framework = data.get("framework", yaml_file.stem)
+        file_evidence_class = data.get("evidence_class", "observed")
         for rule in data.get("rules", []):
             rule = dict(rule)
             rule["_framework"] = framework
             rule["_file"] = yaml_file.name
+            rule["_evidence_class"] = file_evidence_class
             all_rules.append(rule)
     return all_rules
 
@@ -84,7 +94,19 @@ def _check_condition(payload: dict, condition: dict) -> bool:
 
 
 def _rule_matches(event: dict, rule: dict) -> bool:
-    """Return True if a rule's match block applies to this event."""
+    """Return True if a rule's match block applies to this event.
+
+    Evidence class isolation (finding 7): a rule from an 'observed' file only
+    matches observed events; a rule from an 'attested' file only matches attested
+    events. This prevents high-trust observed credit from being awarded to
+    self-reported attested events and vice versa.
+    """
+    # Class isolation: reject cross-class matches
+    rule_class = rule.get("_evidence_class", "observed")
+    event_class = event.get("evidence_class", "observed")
+    if rule_class != event_class:
+        return False
+
     match = rule.get("match", {})
     if match.get("event_type") != event.get("event_type"):
         return False

--- a/a2a/cstp/provenance/mappings/nist-ai-rmf.yaml
+++ b/a2a/cstp/provenance/mappings/nist-ai-rmf.yaml
@@ -7,6 +7,11 @@ description: >
   All rules in this file produce observed-class evidence (third-party GitHub events).
   Reference: https://airc.nist.gov/RMF
 
+  Finding 8 — human actor signal required:
+  MEASURE-2.5 (Human Review) requires actor_is_human=true on pr_review_approved events.
+  MANAGE-1.1 (Approved Deployment) requires human_approval_count>0 on pr_merged events.
+  These conditions fail closed when the upstream webhook does not supply the fields.
+
 rules:
   # GOVERN: Policies and accountability for AI risk management
   - id: "NIST-GOVERN-1.1-agent-disclosure"
@@ -42,17 +47,23 @@ rules:
     match:
       event_type: "pr_opened"
 
-  # MEASURE: Analysis and evaluation of AI risk
+  # MEASURE: Analysis and evaluation of AI risk via verified human review
+  # Finding 8 fix: actor_is_human must be true — bot approvals do not constitute
+  # an independent risk evaluation. Fails closed if actor_is_human is absent.
   - id: "NIST-MEASURE-2.5-human-review"
     stage: "MEASURE"
     function_id: "MEASURE-2.5"
     control_name: "AI Risk Evaluation via Human Review"
     description: >
       MEASURE-2.5 requires evaluating AI risks through independent assessment.
-      A human reviewer's approval constitutes a documented risk evaluation:
-      a qualified person attested that the AI output is acceptable for deployment.
+      A verified human reviewer's approval constitutes a documented risk evaluation:
+      a qualified human attested that the AI output is acceptable for deployment.
+      actor_is_human must be true — a bot approval is not an independent evaluation.
     match:
       event_type: "pr_review_approved"
+      conditions:
+        - field: "actor_is_human"
+          equals: true
 
   # MEASURE: Review comments as risk evaluation evidence
   - id: "NIST-MEASURE-2.6-review-challenge"
@@ -66,9 +77,10 @@ rules:
     match:
       event_type: "pr_review_comment"
 
-  # MANAGE: Risk response — approved deployment (agent-authored only)
+  # MANAGE: Risk response — approved deployment (agent-authored, human-reviewed only)
+  # Finding 8 fix: human_approval_count>0 required. Bot approvals do not constitute
+  # risk response — a bot approving an agent's output is not independent oversight.
   # is_agent_authored condition required: MANAGE-1.1 is "AI Risk Response".
-  # Claiming AI risk management credit for purely human-authored merges is a category error.
   - id: "NIST-MANAGE-1.1-approved-deployment"
     stage: "MANAGE"
     function_id: "MANAGE-1.1"
@@ -76,11 +88,12 @@ rules:
     description: >
       MANAGE-1.1 requires responding to identified AI risks with appropriate actions.
       Merging a reviewed and approved agent-authored change demonstrates that the risk
-      evaluation was completed and the organization accepted the residual risk for deployment.
+      evaluation was completed and the organization accepted the residual risk for
+      deployment. human_approval_count must be >0 to confirm human oversight.
     match:
       event_type: "pr_merged"
       conditions:
-        - field: "approval_count"
+        - field: "human_approval_count"
           gt: 0
         - field: "is_agent_authored"
           equals: true
@@ -103,6 +116,28 @@ rules:
           equals: true
         - field: "approval_count"
           equals: 0
+
+  # MANAGE: INSUFFICIENT EVIDENCE — agent change deployed with bot-only approvals
+  # Finding 8: approvals from bots do not satisfy MANAGE-2.2 human oversight requirement.
+  - id: "NIST-MANAGE-2.2-ie-bot-approval-only"
+    stage: "MANAGE"
+    function_id: "MANAGE-2.2"
+    control_name: "Human Oversight of AI Decisions"
+    insufficient_evidence: true
+    reason: >
+      INSUFFICIENT EVIDENCE: Agent-authored change was merged with approval(s) but
+      human_approval_count is absent or zero. NIST AI RMF MANAGE-2.2 requires human
+      oversight — approvals from bots or automated agents do not constitute independent
+      human oversight of AI decisions. Upstream webhook must supply human_approval_count.
+    match:
+      event_type: "pr_merged"
+      conditions:
+        - field: "is_agent_authored"
+          equals: true
+        - field: "approval_count"
+          gt: 0
+        - field: "human_approval_count"
+          truthy: false
 
   # GOVERN: Commit-level agent attribution as governance record
   - id: "NIST-GOVERN-6.1-commit-attribution"

--- a/a2a/cstp/provenance/mappings/sr11-7.yaml
+++ b/a2a/cstp/provenance/mappings/sr11-7.yaml
@@ -7,6 +7,14 @@ description: >
   All rules in this file produce observed-class evidence (third-party GitHub events).
   Reference: https://www.federalreserve.gov/supervisionreg/srletters/sr1107a1.pdf
 
+  Finding 8 — human actor signal required:
+  Rules that assert "Independent Human Review" now require actor_is_human=true on
+  approval events, and human_approval_count>0 on merge events. If the upstream
+  GitHub webhook integration does not supply these fields, the rules fail closed
+  (no control credit) and the IE rules below surface the gap. Required upstream
+  signals: actor_is_human (bool) on pr_review_approved events;
+  human_approval_count (int) on pr_merged events.
+
 rules:
   # Model Development stage: agent-authored code change documented
   - id: "SR11-7-MV1-agent-pr-opened"
@@ -37,17 +45,23 @@ rules:
         - field: "is_agent_authored"
           equals: false
 
-  # Model Validation stage: independent human reviewer approved the change
+  # Model Validation stage: verified human reviewer approved the change
+  # Finding 8 fix: actor_is_human must be true — bot approvals do not satisfy MV-3.
+  # Fails closed: if actor_is_human is absent or false, this rule does not fire.
   - id: "SR11-7-MV3-human-approval"
     stage: "Model Validation"
     function_id: "MV-3"
     control_name: "Independent Human Review and Approval"
     description: >
       SR 11-7 MV-3 requires independent review of model outputs and decisions.
-      A human reviewer's approval provides evidence of independent oversight
-      of the agent-generated or human-generated code change.
+      A verified human reviewer's approval provides evidence of independent oversight.
+      actor_is_human must be true — approvals from bots or agents do not satisfy
+      the independence requirement.
     match:
       event_type: "pr_review_approved"
+      conditions:
+        - field: "actor_is_human"
+          equals: true
 
   # Model Validation stage: review feedback (CHANGES_REQUESTED or COMMENTED)
   - id: "SR11-7-MV3-review-feedback"
@@ -62,6 +76,8 @@ rules:
       event_type: "pr_review_comment"
 
   # Change Management stage: approved agent-authored change was merged
+  # Finding 8 fix: human_approval_count>0 required — bot-only approval_count
+  # does not satisfy CM-1. Fails closed if human_approval_count is absent or 0.
   - id: "SR11-7-CM1-approved-agent-merge"
     stage: "Change Management"
     function_id: "CM-1"
@@ -69,38 +85,39 @@ rules:
     description: >
       SR 11-7 CM-1 requires documented approval before deploying model changes.
       Merging an agent-authored PR with prior human approval satisfies this control.
+      human_approval_count must be >0 to confirm approvals came from human actors.
     match:
       event_type: "pr_merged"
       conditions:
         - field: "is_agent_authored"
           equals: true
-        - field: "approval_count"
+        - field: "human_approval_count"
           gt: 0
 
-  # Change Management stage: human-authored change merged (informational)
+  # Change Management stage: human-authored change merged with human approval
   - id: "SR11-7-CM1-human-merge"
     stage: "Change Management"
     function_id: "CM-1"
     control_name: "Human Change Deployment"
     description: >
-      Human-authored change merged after review. Tracked for completeness
+      Human-authored change merged after human review. Tracked for completeness
       of change management evidence.
     match:
       event_type: "pr_merged"
       conditions:
         - field: "is_agent_authored"
           equals: false
-        - field: "approval_count"
+        - field: "human_approval_count"
           gt: 0
 
-  # INSUFFICIENT EVIDENCE: agent-authored PR merged without any human approval
+  # INSUFFICIENT EVIDENCE: agent-authored PR merged without any approval at all
   - id: "SR11-7-MV3-ie-no-approval-on-merge"
     stage: "Model Validation"
     function_id: "MV-3"
     control_name: "Independent Human Review and Approval"
     insufficient_evidence: true
     reason: >
-      INSUFFICIENT EVIDENCE: Agent-authored PR was merged without any human approval.
+      INSUFFICIENT EVIDENCE: Agent-authored PR was merged without any approval.
       SR 11-7 MV-3 requires independent review of agent/model outputs before deployment.
       Self-merge of agent-authored code without a second reviewer violates the independence
       requirement and creates an unverifiable change in the audit trail.
@@ -111,6 +128,29 @@ rules:
           equals: true
         - field: "approval_count"
           equals: 0
+
+  # INSUFFICIENT EVIDENCE: agent-authored PR merged with approvals but none from humans
+  # Finding 8: bot or agent approvals do not satisfy MV-3 independence requirement.
+  - id: "SR11-7-MV3-ie-bot-approval-only"
+    stage: "Model Validation"
+    function_id: "MV-3"
+    control_name: "Independent Human Review and Approval"
+    insufficient_evidence: true
+    reason: >
+      INSUFFICIENT EVIDENCE: Agent-authored PR was merged with approval(s), but
+      human_approval_count is absent or zero, indicating all approvals may be from
+      bots or automated agents. SR 11-7 MV-3 requires INDEPENDENT HUMAN review —
+      a bot approving its own or another agent's output does not constitute independent
+      oversight. Upstream webhook must supply human_approval_count to evidence this control.
+    match:
+      event_type: "pr_merged"
+      conditions:
+        - field: "is_agent_authored"
+          equals: true
+        - field: "approval_count"
+          gt: 0
+        - field: "human_approval_count"
+          truthy: false
 
   # INSUFFICIENT EVIDENCE: human PR merged without any review
   - id: "SR11-7-CM1-ie-no-approval-human"

--- a/a2a/cstp/provenance_service.py
+++ b/a2a/cstp/provenance_service.py
@@ -13,6 +13,7 @@ See website/specs/f055-decision-provenance.md for the full design spec.
 import json
 import logging
 import os
+import uuid
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -27,11 +28,15 @@ from .storage.provenance import (
     EVIDENCE_CLASS_ATTESTED,
     EVIDENCE_CLASS_OBSERVED,
     append_event,
-    get_events,
+    append_events_batch,
+    get_head,
     get_head_hash,
-    get_last_bundle_head_hash,
+    get_last_bundle_checkpoint,
+    get_seq_for_hash,
     init_db,
-    store_bundle_head_hash,
+    store_bundle_checkpoint,
+    validate_observed_seqs,
+    verify_at_checkpoint,
     verify_chain,
 )
 
@@ -44,12 +49,24 @@ DEFAULT_PROVENANCE_DB = os.environ.get(
 
 
 def _get_db_path(params: dict[str, Any]) -> str:
-    return params.get("db_path") or DEFAULT_PROVENANCE_DB
+    """Return the server-configured provenance DB path.
+
+    The path is determined by the PROVENANCE_DB environment variable or the
+    compiled-in default. RPC callers cannot override the path — doing so would
+    allow any authenticated agent to redirect reads/writes to an arbitrary file.
+    """
+    return DEFAULT_PROVENANCE_DB
 
 
 def _ensure_db(db_path: str) -> None:
     Path(db_path).parent.mkdir(parents=True, exist_ok=True)
     init_db(db_path)
+
+
+def _unique_ts_tag() -> str:
+    """Generate a unique timestamp tag for bundle filenames (microseconds + UUID)."""
+    now = datetime.now(UTC)
+    return now.strftime("%Y%m%dT%H%M%S") + f"_{now.microsecond:06d}_{uuid.uuid4().hex[:8]}Z"
 
 
 # ── cstp.ingestEvidence ───────────────────────────────────────────────────────
@@ -61,10 +78,12 @@ async def ingest_evidence(params: dict[str, Any], agent_id: str) -> dict[str, An
     Params:
         events   — list of event dicts, each with: event_type, ts, source, payload
         source   — default source label if not specified per-event (default: "external")
-        db_path  — optional override for the provenance DB path
 
     All ingested events receive evidence_class='observed'. The caller cannot override
     this — observed events must come from external systems only.
+
+    The entire batch is validated before any event is committed. If any event is
+    invalid, no events are appended (atomic batch semantics).
 
     Returns:
         ingested      — count of events appended
@@ -79,9 +98,9 @@ async def ingest_evidence(params: dict[str, Any], agent_id: str) -> dict[str, An
         raise ValueError("'events' must be a non-empty list")
 
     default_source = params.get("source", "external")
-    ingested = 0
-    first_seq: int | None = None
 
+    # Validate ALL events before committing any (atomic batch — finding 11)
+    validated: list[tuple[str, str, str, dict, str | None]] = []
     for ev in raw_events:
         if not isinstance(ev, dict):
             raise ValueError("Each event must be a dict")
@@ -90,24 +109,23 @@ async def ingest_evidence(params: dict[str, Any], agent_id: str) -> dict[str, An
             raise ValueError("Each event must have 'event_type'")
 
         payload = ev.get("payload", {})
+        # Reject non-dict payloads before they can poison the store (finding 10)
+        if not isinstance(payload, dict):
+            raise ValueError(
+                f"Event payload must be a dict, got: {type(payload).__name__}"
+            )
+
         ts = ev.get("ts")
         source = ev.get("source") or default_source
+        validated.append((source, event_type, EVIDENCE_CLASS_OBSERVED, payload, ts))
 
-        seq, _ = append_event(
-            source=source,
-            event_type=event_type,
-            evidence_class=EVIDENCE_CLASS_OBSERVED,
-            payload=payload,
-            ts=ts,
-            db_path=db_path,
-        )
-        if first_seq is None:
-            first_seq = seq
-        ingested += 1
-
+    # Append atomically in one transaction (finding 11)
+    results = append_events_batch(validated, db_path)
+    first_seq = results[0][0] if results else None
     head_hash = get_head_hash(db_path)
+
     return {
-        "ingested": ingested,
+        "ingested": len(results),
         "head_hash": head_hash,
         "first_seq": first_seq,
     }
@@ -129,7 +147,6 @@ async def link_evidence(params: dict[str, Any], agent_id: str) -> dict[str, Any]
         event_seqs   — list of observed event sequence numbers being linked
         stakes       — stakes level from the CSTP decision (optional, for mapping)
         has_outcome  — whether the decision has a recorded outcome (optional)
-        db_path      — optional override for the provenance DB path
 
     Returns:
         linked        — count of event seqs linked
@@ -146,6 +163,9 @@ async def link_evidence(params: dict[str, Any], agent_id: str) -> dict[str, Any]
     event_seqs = params.get("event_seqs", [])
     if not isinstance(event_seqs, list):
         raise ValueError("'event_seqs' must be a list")
+
+    # Validate event_seqs: must exist, be observed class, no duplicates (finding 4)
+    validate_observed_seqs(event_seqs, db_path)
 
     stakes = params.get("stakes")
     has_outcome = params.get("has_outcome", False)
@@ -214,7 +234,6 @@ async def map_controls(params: dict[str, Any], agent_id: str) -> dict[str, Any]:
     Controls satisfied only by attested evidence are flagged attested_only=True.
 
     Params:
-        db_path       — optional override for the provenance DB path
         mappings_dir  — optional override for the YAML rules directory
 
     Returns:
@@ -230,11 +249,17 @@ async def map_controls(params: dict[str, Any], agent_id: str) -> dict[str, Any]:
     mappings_dir_override = params.get("mappings_dir")
     mappings_dir = Path(mappings_dir_override) if mappings_dir_override else MAPPINGS_DIR
 
-    events = get_events(db_path)
+    events = get_events_from_db(db_path)
     rules = load_rules(mappings_dir)
     mr = apply_rules(events, rules)
 
     return _mapping_result_to_dict(mr)
+
+
+def get_events_from_db(db_path: str) -> list[dict]:
+    """Load all events from the provenance DB (thin wrapper for service use)."""
+    from .storage.provenance import get_events
+    return get_events(db_path)
 
 
 # ── cstp.exportEvidenceBundle ─────────────────────────────────────────────────
@@ -243,27 +268,34 @@ async def map_controls(params: dict[str, Any], agent_id: str) -> dict[str, Any]:
 async def export_evidence_bundle(params: dict[str, Any], agent_id: str) -> dict[str, Any]:
     """Emit the evidence bundle as JSON (and optionally PDF).
 
-    P2 fix: the bundle persists the head hash at generation time. Subsequent calls
-    to cstp.verifyEvidenceChain use that stored hash to detect tail truncation.
+    The bundle checkpoint is only promoted after successful chain verification
+    to prevent a tampered chain from self-healing on the next export (finding 5+6).
+    Verification uses verify_at_checkpoint so legitimate chain growth after the
+    previous export does not falsely report the chain broken (finding 5+6).
 
     Params:
         format        — "json" (default) or "pdf" or "both"
         output_dir    — directory to write bundle files (default: ./bundles)
-        db_path       — optional override for the provenance DB path
         mappings_dir  — optional override for the YAML rules directory
 
     Returns:
         json_path      — path to JSON bundle file (if format includes json)
         pdf_path       — path to PDF bundle file (if format includes pdf)
-        chain_head_hash — head hash persisted at generation time
-        chain_intact   — result of verify_chain using the persisted head hash (P2 fix)
+        chain_head_hash — head hash at generation time
+        chain_intact   — result of checkpoint-based verification
         coverage       — per-class coverage (observed and attested, never blended)
         insufficient_evidence_count — count of control gaps
     """
     db_path = _get_db_path(params)
     _ensure_db(db_path)
 
+    # Validate format before creating directories (finding 13)
     fmt = params.get("format", "json").lower()
+    if fmt not in ("json", "pdf", "both"):
+        raise ValueError(
+            f"Unsupported bundle format: {fmt!r}. Must be 'json', 'pdf', or 'both'."
+        )
+
     output_dir = Path(params.get("output_dir", "bundles"))
     output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -271,24 +303,38 @@ async def export_evidence_bundle(params: dict[str, Any], agent_id: str) -> dict[
     mappings_dir = Path(mappings_dir_override) if mappings_dir_override else MAPPINGS_DIR
 
     # Run mapping engine
-    events = get_events(db_path)
+    events = get_events_from_db(db_path)
     rules = load_rules(mappings_dir)
     mr = apply_rules(events, rules)
 
-    # P2 fix: load the previously stored head hash to detect tail truncation,
-    # then store the current head hash for future verifications.
-    prev_bundle_hash = get_last_bundle_head_hash(db_path)
-    chain_head = get_head_hash(db_path)
-    store_bundle_head_hash(chain_head or "", "json", db_path)
-    # If a previous bundle hash exists, verify against it (catches tail truncation).
-    # First-time export has no previous hash: fall back to internal-only verification.
-    if prev_bundle_hash:
-        chain_intact = verify_chain(db_path, expected_head_hash=prev_bundle_hash) is None
+    # Checkpoint state machine (findings 5+6):
+    #
+    # :286 fix — use verify_at_checkpoint so legitimate new events beyond the last
+    # checkpoint do NOT cause a false "chain broken" result.
+    #
+    # :282 fix — only store a new checkpoint after successful verification. If the
+    # chain is broken, the checkpoint stays at the last trusted state, preventing
+    # the tampered head from being recorded as "trusted" and self-healing on the
+    # next verify call.
+    prev_checkpoint = get_last_bundle_checkpoint(db_path)
+    head = get_head(db_path)
+    chain_head = head[1] if head else None
+    chain_head_seq = head[0] if head else 0
+
+    if prev_checkpoint:
+        cp_seq, cp_hash = prev_checkpoint
+        broken_at = verify_at_checkpoint(db_path, cp_seq, cp_hash)
+        chain_intact = broken_at is None
     else:
-        chain_intact = verify_chain(db_path) is None
+        broken_at = verify_chain(db_path)
+        chain_intact = broken_at is None
+
+    # Only promote checkpoint when chain is intact
+    if chain_intact and head:
+        store_bundle_checkpoint(chain_head_seq, chain_head or "", fmt, db_path)
 
     generated_at = datetime.now(UTC).isoformat()
-    ts_tag = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    ts_tag = _unique_ts_tag()
 
     result: dict[str, Any] = {
         "chain_head_hash": chain_head,
@@ -316,10 +362,15 @@ async def export_evidence_bundle(params: dict[str, Any], agent_id: str) -> dict[
 
     if fmt in ("json", "both"):
         json_path = output_dir / f"bundle_{ts_tag}.json"
-        json_path.write_text(
-            json.dumps(bundle_data, indent=2, sort_keys=False, ensure_ascii=False),
-            encoding="utf-8",
-        )
+        # O_EXCL: fail if file already exists to prevent clobbering immutable bundles
+        try:
+            with open(json_path, "x", encoding="utf-8") as f:
+                f.write(json.dumps(bundle_data, indent=2, sort_keys=False, ensure_ascii=False))
+        except FileExistsError:
+            ts_tag = _unique_ts_tag()
+            json_path = output_dir / f"bundle_{ts_tag}.json"
+            with open(json_path, "x", encoding="utf-8") as f:
+                f.write(json.dumps(bundle_data, indent=2, sort_keys=False, ensure_ascii=False))
         result["json_path"] = str(json_path)
 
     if fmt in ("pdf", "both"):
@@ -353,7 +404,8 @@ def _generate_pdf(
     except ImportError as exc:
         raise RuntimeError(
             "reportlab is required for PDF generation. "
-            "Install it with: pip install reportlab"
+            "Install it with: pip install 'cognition-agent-decisions[pdf]' "
+            "or: pip install reportlab"
         ) from exc
 
     path = output_dir / f"bundle_{ts_tag}.pdf"
@@ -565,16 +617,16 @@ def _generate_pdf(
     story.append(Paragraph(
         "The observed event store uses a SHA-256 hash chain. Each record's hash covers "
         "its sequence number, timestamp, event type, evidence class, canonical payload, "
-        "and the hash of the previous record. The head hash is persisted at bundle "
-        "generation time; verification is performed against that stored hash to detect "
-        "tail truncation (P2 fix).", body))
+        "and the hash of the previous record (as canonical JSON). The checkpoint is "
+        "stored at bundle generation time; verification is performed against that "
+        "checkpoint to detect tail truncation and tampering.", body))
     chain_data = [
         ["Chain status", "INTACT — all hashes verified" if chain_intact
                         else "BROKEN — records have been tampered with"],
         ["Head hash", chain_head or "N/A"],
         ["Hash algorithm", "SHA-256"],
         ["Preimage format",
-         "{seq}\\n{ts}\\n{event_type}\\n{evidence_class}\\n{canonical_json(payload)}\\n{prev_hash}"],
+         'canonical_json({"seq":N,"ts":T,"event_type":E,"evidence_class":C,"payload":P,"prev_hash":H})'],
     ]
     chain_tbl = Table(chain_data, colWidths=[1.8 * inch, 4.7 * inch])
     chain_tbl.setStyle(TableStyle([
@@ -603,34 +655,54 @@ def _generate_pdf(
 async def verify_evidence_chain(params: dict[str, Any], agent_id: str) -> dict[str, Any]:
     """Verify hash chain integrity.
 
-    Uses expected_head_hash (P1 fix) so tail truncation is detectable.
-    If the caller does not supply expected_head_hash, the value from the most
-    recent bundle generation is used (P2 fix). If neither is available, falls
-    back to internal-only verification (tail truncation invisible — warn caller).
+    Uses verify_at_checkpoint so tail-truncation is detectable while allowing
+    the chain to grow beyond the last checkpoint without false positives.
+
+    If the caller supplies expected_head_hash, the seq for that hash is looked
+    up in the chain and used as the checkpoint. If the stored bundle checkpoint
+    exists (from a previous export), that is used. Otherwise falls back to
+    internal-only verification (tail truncation invisible — warn caller via
+    tail_check=False in the response).
 
     Params:
-        expected_head_hash — optional; overrides the stored bundle head hash
-        db_path            — optional override for the provenance DB path
+        expected_head_hash — optional; overrides the stored bundle checkpoint
 
     Returns:
-        intact         — True if chain is intact (all hashes valid + head matches)
+        intact         — True if chain is intact up to the checkpoint
         broken_at_seq  — seq of broken record, or None if intact
         head_hash      — current chain head hash
-        expected_hash  — the hash verified against (from param or stored bundle)
+        expected_hash  — the hash verified against
         tail_check     — True if tail-truncation detection was active
     """
     db_path = _get_db_path(params)
     _ensure_db(db_path)
 
-    # Resolve expected_head_hash
     caller_hash: str | None = params.get("expected_head_hash")
-    stored_hash = get_last_bundle_head_hash(db_path)
-    expected_hash = caller_hash or stored_hash
+    tail_check = False
+    broken_at: int | None = None
+    expected_hash: str | None = None
 
-    tail_check = expected_hash is not None
-    broken_at = verify_chain(db_path, expected_head_hash=expected_hash)
+    if caller_hash:
+        # Look up where this hash sits in the chain
+        seq = get_seq_for_hash(caller_hash, db_path)
+        if seq is None:
+            broken_at = 0  # hash not found in current chain
+        else:
+            broken_at = verify_at_checkpoint(db_path, seq, caller_hash)
+        tail_check = True
+        expected_hash = caller_hash
+    else:
+        stored_checkpoint = get_last_bundle_checkpoint(db_path)
+        if stored_checkpoint:
+            cp_seq, cp_hash = stored_checkpoint
+            broken_at = verify_at_checkpoint(db_path, cp_seq, cp_hash)
+            tail_check = True
+            expected_hash = cp_hash
+        else:
+            broken_at = verify_chain(db_path)
 
-    head_hash = get_head_hash(db_path)
+    head = get_head(db_path)
+    head_hash = head[1] if head else None
 
     return {
         "intact": broken_at is None,

--- a/a2a/cstp/storage/provenance.py
+++ b/a2a/cstp/storage/provenance.py
@@ -8,11 +8,19 @@ the hash preimage, making it tamper-evident. The two classes must never be blend
                (GitHub PR opens, commits, reviews, approvals, merges)
   attested  — first-party CSTP records correlated via cstp.linkEvidence
 
-Hash preimage (UTF-8, fields joined by newline):
-    {seq}\\n{ts}\\n{event_type}\\n{evidence_class}\\n{canonical_json(payload)}\\n{prev_hash}
+Hash preimage (UTF-8, canonical JSON of an ordered dict):
+    {"evidence_class":..., "event_type":..., "payload":..., "prev_hash":..., "seq":..., "ts":...}
+
+All six fields are JSON-encoded, so any embedded delimiters in string values are
+escaped — the preimage is injective and cannot be forged by swapping field values.
+
+Chain format version: 2 (format version 1 used a newline-delimited string preimage).
 
 Note: `source` is intentionally excluded from the hash preimage. It identifies the
 ingest origin but does not affect tamper-evidence.
+
+BREAKING: version 2 changes the hash preimage. Any store written with version 1
+will fail verify_chain. F055 is unreleased, so this is acceptable.
 """
 
 import hashlib
@@ -24,6 +32,8 @@ from typing import Optional
 
 DEFAULT_DB_PATH = os.environ.get("PROVENANCE_DB", "provenance.db")
 
+CHAIN_FORMAT_VERSION = 2
+
 EVIDENCE_CLASS_OBSERVED = "observed"
 EVIDENCE_CLASS_ATTESTED = "attested"
 _VALID_CLASSES = frozenset({EVIDENCE_CLASS_OBSERVED, EVIDENCE_CLASS_ATTESTED})
@@ -31,8 +41,13 @@ _VALID_CLASSES = frozenset({EVIDENCE_CLASS_OBSERVED, EVIDENCE_CLASS_ATTESTED})
 CREATE_SCHEMA_SQL = """
 PRAGMA journal_mode=WAL;
 
+CREATE TABLE IF NOT EXISTS schema_metadata (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS events (
-    seq            INTEGER PRIMARY KEY AUTOINCREMENT,
+    seq            INTEGER PRIMARY KEY,
     ts             TEXT NOT NULL,
     source         TEXT NOT NULL,
     event_type     TEXT NOT NULL,
@@ -45,6 +60,7 @@ CREATE TABLE IF NOT EXISTS events (
 CREATE TABLE IF NOT EXISTS bundle_metadata (
     id           INTEGER PRIMARY KEY AUTOINCREMENT,
     generated_at TEXT NOT NULL,
+    head_seq     INTEGER NOT NULL DEFAULT 0,
     head_hash    TEXT NOT NULL,
     format       TEXT NOT NULL
 );
@@ -66,12 +82,19 @@ def compute_hash(
 ) -> str:
     """Compute SHA-256 hash for an event record.
 
-    Preimage (UTF-8):
-        "{seq}\\n{ts}\\n{event_type}\\n{evidence_class}\\n{canonical_json(payload)}\\n{prev_hash}"
+    Preimage: canonical JSON of the six-field ordered dict. JSON-encoding each
+    field makes the preimage injective — no two distinct (seq, ts, event_type,
+    evidence_class, payload, prev_hash) tuples produce the same byte string.
     """
-    preimage = (
-        f"{seq}\n{ts}\n{event_type}\n{evidence_class}\n"
-        f"{canonical_json(payload)}\n{prev_hash}"
+    preimage = canonical_json(
+        {
+            "seq": seq,
+            "ts": ts,
+            "event_type": event_type,
+            "evidence_class": evidence_class,
+            "payload": payload,
+            "prev_hash": prev_hash,
+        }
     )
     return hashlib.sha256(preimage.encode("utf-8")).hexdigest()
 
@@ -80,6 +103,10 @@ def init_db(db_path: str = DEFAULT_DB_PATH) -> None:
     """Create tables if they do not exist. Safe to call multiple times."""
     with sqlite3.connect(db_path) as conn:
         conn.executescript(CREATE_SCHEMA_SQL)
+        conn.execute(
+            "INSERT OR IGNORE INTO schema_metadata (key, value) VALUES (?, ?)",
+            ("chain_format_version", str(CHAIN_FORMAT_VERSION)),
+        )
         conn.commit()
 
 
@@ -91,13 +118,11 @@ def append_event(
     ts: str | None = None,
     db_path: str = DEFAULT_DB_PATH,
 ) -> tuple[int, str]:
-    """Append an event to the chain. Returns (seq, hash).
+    """Append a single event to the chain. Returns (seq, hash).
 
-    evidence_class must be 'observed' or 'attested'. Enforced both here
-    and by a DB CHECK constraint.
-
-    ts should be an ISO 8601 string from the source data to ensure chain
-    determinism across re-runs. Defaults to current UTC time if omitted.
+    Uses BEGIN IMMEDIATE to prevent concurrent-append races: only one writer
+    can read the head and insert the next record at a time. The seq is inserted
+    explicitly (not via AUTOINCREMENT) so the hash preimage matches the stored row.
     """
     if evidence_class not in _VALID_CLASSES:
         raise ValueError(
@@ -106,12 +131,14 @@ def append_event(
     if ts is None:
         ts = datetime.now(UTC).isoformat()
 
-    with sqlite3.connect(db_path) as conn:
-        conn.row_factory = sqlite3.Row
+    conn = sqlite3.connect(db_path, timeout=30)
+    conn.isolation_level = None  # manual transaction control
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.execute("BEGIN IMMEDIATE")
         row = conn.execute(
             "SELECT seq, hash FROM events ORDER BY seq DESC LIMIT 1"
         ).fetchone()
-
         prev_hash = row["hash"] if row else ""
         next_seq = (row["seq"] + 1) if row else 1
 
@@ -119,12 +146,72 @@ def append_event(
 
         conn.execute(
             "INSERT INTO events "
-            "(ts, source, event_type, evidence_class, payload_json, prev_hash, hash) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (ts, source, event_type, evidence_class, canonical_json(payload), prev_hash, h),
+            "(seq, ts, source, event_type, evidence_class, payload_json, prev_hash, hash) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (next_seq, ts, source, event_type, evidence_class, canonical_json(payload), prev_hash, h),
         )
-        conn.commit()
+        conn.execute("COMMIT")
         return next_seq, h
+    except Exception:
+        conn.execute("ROLLBACK")
+        raise
+    finally:
+        conn.close()
+
+
+def append_events_batch(
+    events: list[tuple[str, str, str, dict, str | None]],
+    db_path: str = DEFAULT_DB_PATH,
+) -> list[tuple[int, str]]:
+    """Atomically append multiple events. All succeed or none are committed.
+
+    events — list of (source, event_type, evidence_class, payload, ts) tuples.
+    Returns list of (seq, hash) pairs in insertion order.
+    """
+    for _, _, evidence_class, _, _ in events:
+        if evidence_class not in _VALID_CLASSES:
+            raise ValueError(
+                f"evidence_class must be 'observed' or 'attested', got: {evidence_class!r}"
+            )
+
+    now = datetime.now(UTC).isoformat()
+    results: list[tuple[int, str]] = []
+
+    conn = sqlite3.connect(db_path, timeout=30)
+    conn.isolation_level = None
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        row = conn.execute(
+            "SELECT seq, hash FROM events ORDER BY seq DESC LIMIT 1"
+        ).fetchone()
+        prev_hash = row["hash"] if row else ""
+        next_seq = (row["seq"] + 1) if row else 1
+
+        for source, event_type, evidence_class, payload, ts in events:
+            if ts is None:
+                ts = now
+            h = compute_hash(next_seq, ts, event_type, evidence_class, payload, prev_hash)
+            conn.execute(
+                "INSERT INTO events "
+                "(seq, ts, source, event_type, evidence_class, payload_json, prev_hash, hash) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    next_seq, ts, source, event_type, evidence_class,
+                    canonical_json(payload), prev_hash, h,
+                ),
+            )
+            results.append((next_seq, h))
+            prev_hash = h
+            next_seq += 1
+
+        conn.execute("COMMIT")
+        return results
+    except Exception:
+        conn.execute("ROLLBACK")
+        raise
+    finally:
+        conn.close()
 
 
 def get_events(
@@ -154,13 +241,64 @@ def get_events(
     return result
 
 
-def get_head_hash(db_path: str = DEFAULT_DB_PATH) -> Optional[str]:
-    """Return the hash of the most recent event, or None if the store is empty."""
+def get_head(db_path: str = DEFAULT_DB_PATH) -> Optional[tuple[int, str]]:
+    """Return (seq, hash) of the most recent event, or None if the store is empty."""
     with sqlite3.connect(db_path) as conn:
         row = conn.execute(
-            "SELECT hash FROM events ORDER BY seq DESC LIMIT 1"
+            "SELECT seq, hash FROM events ORDER BY seq DESC LIMIT 1"
         ).fetchone()
+    return (row[0], row[1]) if row else None
+
+
+def get_head_hash(db_path: str = DEFAULT_DB_PATH) -> Optional[str]:
+    """Return the hash of the most recent event, or None if the store is empty."""
+    head = get_head(db_path)
+    return head[1] if head else None
+
+
+def get_seq_for_hash(event_hash: str, db_path: str = DEFAULT_DB_PATH) -> Optional[int]:
+    """Return the seq of the event with the given hash, or None if not found."""
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute("SELECT seq FROM events WHERE hash = ?", (event_hash,)).fetchone()
     return row[0] if row else None
+
+
+def validate_observed_seqs(event_seqs: list[int], db_path: str = DEFAULT_DB_PATH) -> None:
+    """Validate that all seqs exist, have evidence_class='observed', and have no duplicates.
+
+    Raises ValueError if any check fails. Empty list is valid (no-op).
+    """
+    if not event_seqs:
+        return
+
+    seen: set[int] = set()
+    for seq in event_seqs:
+        if seq in seen:
+            raise ValueError(
+                f"event_seqs contains duplicate sequence number: {seq}"
+            )
+        seen.add(seq)
+
+    placeholders = ",".join("?" * len(event_seqs))
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            f"SELECT seq, evidence_class FROM events WHERE seq IN ({placeholders})",
+            event_seqs,
+        ).fetchall()
+
+    found: dict[int, str] = {row[0]: row[1] for row in rows}
+    missing = set(event_seqs) - set(found)
+    if missing:
+        raise ValueError(
+            f"event_seqs references nonexistent sequences: {sorted(missing)}"
+        )
+
+    non_observed = [seq for seq, ec in found.items() if ec != EVIDENCE_CLASS_OBSERVED]
+    if non_observed:
+        raise ValueError(
+            f"event_seqs must only reference observed events; "
+            f"sequences with wrong evidence_class: {sorted(non_observed)}"
+        )
 
 
 def verify_chain(
@@ -202,10 +340,89 @@ def verify_chain(
     return None
 
 
+def verify_at_checkpoint(
+    db_path: str,
+    checkpoint_seq: int,
+    checkpoint_hash: str,
+) -> Optional[int]:
+    """Verify all events up to and including checkpoint_seq.
+
+    Allows the chain to extend beyond checkpoint_seq — valid growth after a
+    bundle export does not trigger a false positive.
+
+    Returns:
+        None  — all hashes valid and the hash at checkpoint_seq matches checkpoint_hash
+        0     — checkpoint_seq is absent from the chain (tail truncated past or at it)
+        seq   — hash or prev_hash mismatch at seq (record tampered)
+    """
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            "SELECT seq, ts, event_type, evidence_class, payload_json, prev_hash, hash "
+            "FROM events WHERE seq <= ? ORDER BY seq",
+            (checkpoint_seq,),
+        ).fetchall()
+
+    found_seqs = {row["seq"] for row in rows}
+    if checkpoint_seq not in found_seqs:
+        return 0  # checkpoint record was deleted
+
+    prev_hash = ""
+    for row in rows:
+        payload = json.loads(row["payload_json"])
+        expected = compute_hash(
+            row["seq"], row["ts"], row["event_type"],
+            row["evidence_class"], payload, prev_hash,
+        )
+        if expected != row["hash"]:
+            return row["seq"]
+        if row["prev_hash"] != prev_hash:
+            return row["seq"]
+        if row["seq"] == checkpoint_seq and row["hash"] != checkpoint_hash:
+            return 0  # hash at checkpoint doesn't match stored checkpoint
+        prev_hash = row["hash"]
+
+    return None
+
+
 def event_count(db_path: str = DEFAULT_DB_PATH) -> int:
     """Return total number of events in the store."""
     with sqlite3.connect(db_path) as conn:
         return conn.execute("SELECT COUNT(*) FROM events").fetchone()[0]
+
+
+def store_bundle_checkpoint(
+    head_seq: int,
+    head_hash: str,
+    fmt: str,
+    db_path: str = DEFAULT_DB_PATH,
+) -> None:
+    """Persist the trusted checkpoint (seq + hash) at bundle generation time."""
+    generated_at = datetime.now(UTC).isoformat()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO bundle_metadata (generated_at, head_seq, head_hash, format) "
+            "VALUES (?, ?, ?, ?)",
+            (generated_at, head_seq, head_hash, fmt),
+        )
+        conn.commit()
+
+
+def get_last_bundle_checkpoint(
+    db_path: str = DEFAULT_DB_PATH,
+) -> Optional[tuple[int, str]]:
+    """Return (head_seq, head_hash) of the most recent trusted bundle checkpoint, or None."""
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT head_seq, head_hash FROM bundle_metadata ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+    if row is None:
+        return None
+    seq, h = row[0], row[1]
+    if seq == 0:
+        # Legacy record without seq — treat as no trusted checkpoint
+        return None
+    return (seq, h)
 
 
 def store_bundle_head_hash(
@@ -213,20 +430,13 @@ def store_bundle_head_hash(
     fmt: str,
     db_path: str = DEFAULT_DB_PATH,
 ) -> None:
-    """Persist the head hash at bundle generation time for future verification (P2 fix)."""
-    generated_at = datetime.now(UTC).isoformat()
-    with sqlite3.connect(db_path) as conn:
-        conn.execute(
-            "INSERT INTO bundle_metadata (generated_at, head_hash, format) VALUES (?, ?, ?)",
-            (generated_at, head_hash, fmt),
-        )
-        conn.commit()
+    """Compatibility wrapper: persist head hash + current head seq as checkpoint."""
+    head = get_head(db_path)
+    head_seq = head[0] if head else 0
+    store_bundle_checkpoint(head_seq, head_hash, fmt, db_path)
 
 
 def get_last_bundle_head_hash(db_path: str = DEFAULT_DB_PATH) -> Optional[str]:
-    """Return the head hash from the most recent bundle generation, or None."""
-    with sqlite3.connect(db_path) as conn:
-        row = conn.execute(
-            "SELECT head_hash FROM bundle_metadata ORDER BY id DESC LIMIT 1"
-        ).fetchone()
-    return row[0] if row else None
+    """Compatibility wrapper: return the head hash from the most recent bundle, or None."""
+    checkpoint = get_last_bundle_checkpoint(db_path)
+    return checkpoint[1] if checkpoint else None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,11 @@ dev = [
     "ruff>=0.2.0",
     "httpx>=0.27.0",
 ]
+pdf = [
+    "reportlab>=4.0",
+]
 all = [
-    "cognition-agent-decisions[a2a,mcp,dev]",
+    "cognition-agent-decisions[a2a,mcp,dev,pdf]",
 ]
 
 [project.urls]

--- a/tests/test_f055_provenance_service.py
+++ b/tests/test_f055_provenance_service.py
@@ -7,12 +7,26 @@ Two-class evidence model is the non-negotiable design constraint:
   observed  — third-party events (hash-chained)
   attested  — first-party CSTP records (self-reported)
 Coverage must be reported separately per class. Any blended metric is a bug.
+
+Finding 3 — db_path removed from RPC params:
+  Service functions no longer accept db_path via params. All service-layer
+  tests inject the test DB via monkeypatch on DEFAULT_PROVENANCE_DB. Storage-layer
+  tests (TestAppendAndGet, TestHashChainIntegrity, etc.) still pass db_path
+  directly to the storage functions — that API is not changed.
+
+Finding 8 — human actor signal required:
+  Tests that previously used approval_count>0 without actor_is_human/human_approval_count
+  have been updated deliberately: those events encoded the buggy behavior. Updated events
+  now include actor_is_human=True and human_approval_count as appropriate.
 """
 
 import json
 import sqlite3
+import threading
 import pytest
 from pathlib import Path
+
+import a2a.cstp.provenance_service as _svc
 
 from a2a.cstp.storage.provenance import (
     EVIDENCE_CLASS_OBSERVED,
@@ -21,10 +35,14 @@ from a2a.cstp.storage.provenance import (
     compute_hash,
     event_count,
     get_events,
+    get_head,
     get_head_hash,
+    get_last_bundle_checkpoint,
     get_last_bundle_head_hash,
     init_db,
     store_bundle_head_hash,
+    validate_observed_seqs,
+    verify_at_checkpoint,
     verify_chain,
 )
 from a2a.cstp.provenance.mapping import (
@@ -47,40 +65,61 @@ from a2a.cstp.provenance_service import (
 
 @pytest.fixture
 def db(tmp_path):
+    """Low-level storage DB fixture. Does NOT patch the service default."""
     path = str(tmp_path / "test.db")
     init_db(path)
     return path
 
 
 @pytest.fixture
-def db_with_observed(db):
-    """A DB with a handful of typical observed PR events."""
+def db_with_observed(db, monkeypatch):
+    """DB fixture with pre-loaded observed PR events.
+
+    Also patches DEFAULT_PROVENANCE_DB so service-layer tests that take this
+    fixture directly (without going through service_params_observed) correctly
+    route to this temp DB.
+
+    Events include actor_is_human and human_approval_count fields required by
+    the finding-8 human-actor rules (updated deliberately from the prior
+    buggy behavior).
+    """
     events = [
         ("gh", "pr_opened", {"pr_number": 1, "is_agent_authored": True, "agent_type": "Claude",
                               "title": "Add risk scorer", "approval_count": 0}),
-        ("gh", "pr_review_approved", {"pr_number": 1, "reviewer": "alice"}),
+        ("gh", "pr_review_approved", {"pr_number": 1, "reviewer": "alice",
+                                       "actor_is_human": True}),
         ("gh", "pr_merged", {"pr_number": 1, "is_agent_authored": True, "approval_count": 1,
-                              "merged_by": "alice"}),
+                              "human_approval_count": 1, "merged_by": "alice"}),
         ("gh", "pr_opened", {"pr_number": 2, "is_agent_authored": True, "agent_type": "Claude",
                               "title": "Agent risk scorer v2", "approval_count": 0}),
         ("gh", "pr_merged", {"pr_number": 2, "is_agent_authored": True, "approval_count": 0,
-                              "merged_by": "claude-bot"}),  # no human approval — IE gap
+                              "human_approval_count": 0, "merged_by": "claude-bot"}),
     ]
     for ts_idx, (source, etype, payload) in enumerate(events):
         append_event(
             source=source, event_type=etype, evidence_class=EVIDENCE_CLASS_OBSERVED,
             payload=payload, ts=f"2026-07-0{ts_idx + 1}T10:00:00Z", db_path=db,
         )
+    monkeypatch.setattr(_svc, "DEFAULT_PROVENANCE_DB", db)
     return db
 
 
 @pytest.fixture
-def service_params(db):
+def service_params(db, monkeypatch):
+    """Service-layer params fixture. Patches DEFAULT_PROVENANCE_DB to test DB.
+
+    Returns a dict that still includes db_path for any test code that reads the
+    path directly (e.g. to call get_events). The service ignores db_path in params
+    (finding 3 fix).
+    """
+    monkeypatch.setattr(_svc, "DEFAULT_PROVENANCE_DB", db)
     return {"db_path": db}
 
 
 @pytest.fixture
-def service_params_observed(db_with_observed):
+def service_params_observed(db_with_observed, monkeypatch):
+    """service_params variant with pre-loaded observed events."""
+    monkeypatch.setattr(_svc, "DEFAULT_PROVENANCE_DB", db_with_observed)
     return {"db_path": db_with_observed}
 
 
@@ -157,6 +196,21 @@ class TestComputeHash:
         h2 = compute_hash(1, "ts", "et", "observed", {"a": 2, "z": 1}, "")
         assert h1 == h2
 
+    def test_hash_preimage_injective(self):
+        """Finding 1: (ts='a\\nb', event_type='c') and (ts='a', event_type='b\\nc') must differ.
+
+        The old newline-delimited preimage collapsed these two tuples to the same
+        byte string. The canonical-JSON preimage encodes each field separately so
+        no two distinct (seq, ts, event_type, ...) tuples share a preimage.
+        FAILS before fix, PASSES after.
+        """
+        h1 = compute_hash(1, "a\nb", "c", "observed", {}, "")
+        h2 = compute_hash(1, "a", "b\nc", "observed", {}, "")
+        assert h1 != h2, (
+            "Hash preimage must be injective — collisions allow hash chain forgery "
+            "by swapping field values without changing the hash"
+        )
+
 
 # ══════════════════════════════════════════════════════════════════════════════
 # Store: append / get
@@ -212,6 +266,36 @@ class TestAppendAndGet:
     def test_invalid_evidence_class_rejected(self, db):
         with pytest.raises(ValueError, match="evidence_class"):
             append_event("src", "et", "unknown", {}, db_path=db)
+
+    def test_concurrent_append_produces_valid_chain(self, db):
+        """Finding 2: concurrent appenders must not break the chain.
+
+        Before fix (no BEGIN IMMEDIATE): two threads could read the same head seq,
+        compute the next hash with the same next_seq, then INSERT — one gets the
+        right seq, the other has a hash that doesn't match its actual row.
+        After fix (BEGIN IMMEDIATE + explicit seq): writes serialize, chain stays intact.
+        FAILS (non-deterministically) before fix, PASSES reliably after.
+        """
+        errors: list[Exception] = []
+
+        def appender(i: int) -> None:
+            try:
+                append_event(
+                    "src", f"et_{i}", "observed", {"i": i},
+                    ts=f"2026-{(i % 12) + 1:02d}-01T00:00:00Z", db_path=db,
+                )
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=appender, args=(i,)) for i in range(1, 11)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Concurrent append errors: {errors}"
+        assert verify_chain(db) is None, "Concurrent appends left the chain broken"
+        assert event_count(db) == 10, "Some events were lost under concurrent writes"
 
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -314,6 +398,57 @@ class TestHashChainIntegrity:
 
 
 # ══════════════════════════════════════════════════════════════════════════════
+# Store: verify_at_checkpoint
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestVerifyAtCheckpoint:
+    def test_intact_chain_passes_at_head(self, db):
+        for i in range(5):
+            append_event("src", "evt", "observed", {"i": i},
+                         ts=f"2026-01-0{i+1}T00:00:00Z", db_path=db)
+        head = get_head(db)
+        assert head is not None
+        assert verify_at_checkpoint(db, head[0], head[1]) is None
+
+    def test_valid_extension_passes(self, db):
+        """Finding 5+6: chain growth beyond checkpoint must NOT be flagged as broken."""
+        for i in range(3):
+            append_event("src", "evt", "observed", {"i": i},
+                         ts=f"2026-01-0{i+1}T00:00:00Z", db_path=db)
+        checkpoint = get_head(db)
+        assert checkpoint is not None
+        # Add two more events (valid extension)
+        for i in range(3, 5):
+            append_event("src", "evt", "observed", {"i": i},
+                         ts=f"2026-01-0{i+1}T00:00:00Z", db_path=db)
+        # Checkpoint at seq 3 must still pass even though chain has grown to seq 5
+        assert verify_at_checkpoint(db, checkpoint[0], checkpoint[1]) is None
+
+    def test_tail_truncation_detected(self, db):
+        """Checkpoint record deleted — verify_at_checkpoint returns 0."""
+        for i in range(5):
+            append_event("src", "evt", "observed", {"i": i},
+                         ts=f"2026-01-0{i+1}T00:00:00Z", db_path=db)
+        checkpoint = get_head(db)
+        assert checkpoint is not None
+        with sqlite3.connect(db) as conn:
+            conn.execute("DELETE FROM events WHERE seq >= 4")
+            conn.commit()
+        assert verify_at_checkpoint(db, checkpoint[0], checkpoint[1]) == 0
+
+    def test_tampered_record_detected(self, db):
+        for i in range(5):
+            append_event("src", "evt", "observed", {"i": i},
+                         ts=f"2026-01-0{i+1}T00:00:00Z", db_path=db)
+        head = get_head(db)
+        assert head is not None
+        with sqlite3.connect(db) as conn:
+            conn.execute("UPDATE events SET payload_json = '{\"x\":99}' WHERE seq = 3")
+            conn.commit()
+        assert verify_at_checkpoint(db, head[0], head[1]) == 3
+
+
+# ══════════════════════════════════════════════════════════════════════════════
 # Store: bundle metadata (P2 fix)
 # ══════════════════════════════════════════════════════════════════════════════
 
@@ -339,6 +474,46 @@ class TestBundleMetadata:
         h2 = get_head_hash(db)
         store_bundle_head_hash(h2, "json", db)
         assert get_last_bundle_head_hash(db) == h2
+
+    def test_checkpoint_stores_seq(self, db):
+        """Checkpoint stores head_seq so verify_at_checkpoint can verify without head comparison."""
+        for i in range(5):
+            append_event("src", "evt", "observed", {"i": i},
+                         ts=f"2026-01-0{i+1}T00:00:00Z", db_path=db)
+        h = get_head_hash(db)
+        store_bundle_head_hash(h, "json", db)
+        cp = get_last_bundle_checkpoint(db)
+        assert cp is not None
+        assert cp == (5, h)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Store: validate_observed_seqs
+# ══════════════════════════════════════════════════════════════════════════════
+
+class TestValidateObservedSeqs:
+    def test_empty_list_is_valid(self, db):
+        validate_observed_seqs([], db)  # should not raise
+
+    def test_valid_observed_seqs_pass(self, db):
+        for _ in range(3):
+            append_event("src", "evt", "observed", {}, ts="2026-01-01T00:00:00Z", db_path=db)
+        validate_observed_seqs([1, 2, 3], db)  # should not raise
+
+    def test_rejects_nonexistent_seq(self, db):
+        append_event("src", "evt", "observed", {}, ts="2026-01-01T00:00:00Z", db_path=db)
+        with pytest.raises(ValueError, match="nonexistent"):
+            validate_observed_seqs([999], db)
+
+    def test_rejects_attested_seq(self, db):
+        append_event("src", "evt", "attested", {}, ts="2026-01-01T00:00:00Z", db_path=db)
+        with pytest.raises(ValueError, match="observed"):
+            validate_observed_seqs([1], db)
+
+    def test_rejects_duplicate_seqs(self, db):
+        append_event("src", "evt", "observed", {}, ts="2026-01-01T00:00:00Z", db_path=db)
+        with pytest.raises(ValueError, match="duplicate"):
+            validate_observed_seqs([1, 1], db)
 
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -366,6 +541,17 @@ class TestLoadRules:
             assert "match" in rule, f"Missing 'match' in rule {rule}"
             assert "event_type" in rule["match"], f"Missing match.event_type in rule {rule}"
 
+    def test_rules_carry_evidence_class(self):
+        """Finding 7: each rule must carry _evidence_class from its YAML file."""
+        rules = load_rules(MAPPINGS_DIR)
+        for rule in rules:
+            assert "_evidence_class" in rule, f"Rule {rule.get('id')} missing _evidence_class"
+        observed_frameworks = {r["_framework"] for r in rules if r["_evidence_class"] == "observed"}
+        attested_frameworks = {r["_framework"] for r in rules if r["_evidence_class"] == "attested"}
+        assert "SR 11-7" in observed_frameworks
+        assert "NIST AI RMF" in observed_frameworks
+        assert "CSTP Attested" in attested_frameworks
+
     def test_ie_rules_have_reason(self):
         rules = load_rules(MAPPINGS_DIR)
         for rule in rules:
@@ -392,6 +578,30 @@ class TestLoadRules:
         )
         assert has_agent_condition, "MANAGE-1.1 must require is_agent_authored=true"
 
+    def test_mv3_human_approval_requires_actor_is_human(self):
+        """Finding 8: SR11-7 MV-3 human-approval rule must require actor_is_human."""
+        rules = load_rules(MAPPINGS_DIR)
+        mv3_approval = [r for r in rules if r.get("id") == "SR11-7-MV3-human-approval"]
+        assert mv3_approval, "SR11-7-MV3-human-approval rule not found"
+        conditions = mv3_approval[0]["match"].get("conditions", [])
+        has_human_condition = any(
+            c.get("field") == "actor_is_human" and c.get("equals") is True
+            for c in conditions
+        )
+        assert has_human_condition, "MV-3 human-approval must require actor_is_human=true"
+
+    def test_cm1_requires_human_approval_count(self):
+        """Finding 8: CM-1 approved-agent-merge must require human_approval_count>0."""
+        rules = load_rules(MAPPINGS_DIR)
+        cm1 = [r for r in rules if r.get("id") == "SR11-7-CM1-approved-agent-merge"]
+        assert cm1, "SR11-7-CM1-approved-agent-merge rule not found"
+        conditions = cm1[0]["match"].get("conditions", [])
+        has_human_count = any(
+            c.get("field") == "human_approval_count" and c.get("gt", -1) >= 0
+            for c in conditions
+        )
+        assert has_human_count, "CM-1 must require human_approval_count>0"
+
 
 # ══════════════════════════════════════════════════════════════════════════════
 # Mapping: apply rules
@@ -413,17 +623,21 @@ class TestApplyRules:
         mr = apply_rules(events, rules)
         assert mr.observed.mapped_events == 1
 
-    def test_approval_maps_to_mv3(self):
+    def test_approval_maps_to_mv3_when_actor_is_human(self):
+        """Finding 8 (updated): approval must have actor_is_human=True to map to MV-3."""
         rules = load_rules(MAPPINGS_DIR)
-        events = [_make_event(1, "pr_review_approved", {"pr_number": 1, "reviewer": "bob"})]
+        events = [_make_event(1, "pr_review_approved",
+                               {"pr_number": 1, "reviewer": "bob", "actor_is_human": True})]
         mr = apply_rules(events, rules)
         mv3 = [m for m in mr.mappings if m.get("function_id") == "MV-3"]
         assert len(mv3) >= 1
 
-    def test_agent_merge_with_approval_maps_cm1(self):
+    def test_agent_merge_with_human_approval_maps_cm1(self):
+        """Finding 8 (updated): merge must have human_approval_count>0 to map to CM-1."""
         rules = load_rules(MAPPINGS_DIR)
         events = [_make_event(1, "pr_merged",
-                               {"pr_number": 1, "is_agent_authored": True, "approval_count": 2})]
+                               {"pr_number": 1, "is_agent_authored": True,
+                                "approval_count": 2, "human_approval_count": 2})]
         mr = apply_rules(events, rules)
         cm = [m for m in mr.mappings if "CM" in m.get("function_id", "")]
         assert len(cm) >= 1
@@ -459,6 +673,73 @@ class TestApplyRules:
         assert mr.observed.total_events == 1
         assert mr.attested.total_events == 1
 
+    def test_bot_approval_does_not_satisfy_mv3(self):
+        """Finding 8 regression: bot approval (no actor_is_human) must not map to MV-3.
+
+        FAILS before fix (MV-3 fires unconditionally on pr_review_approved).
+        PASSES after fix (actor_is_human must be True).
+        """
+        rules = load_rules(MAPPINGS_DIR)
+        events = [_make_event(1, "pr_review_approved",
+                               {"pr_number": 1, "reviewer": "dependabot[bot]"})]
+        mr = apply_rules(events, rules)
+        mv3_maps = [m for m in mr.mappings if m.get("function_id") == "MV-3"]
+        assert len(mv3_maps) == 0, (
+            "Bot approval (no actor_is_human field) must NOT satisfy MV-3 — "
+            "a bot approving an agent's output is not independent human review"
+        )
+
+    def test_no_human_approval_count_no_cm1_credit(self):
+        """Finding 8 regression: approval_count>0 without human_approval_count must not map CM-1.
+
+        FAILS before fix (CM-1 fires on approval_count>0).
+        PASSES after fix (human_approval_count>0 required).
+        """
+        rules = load_rules(MAPPINGS_DIR)
+        events = [_make_event(1, "pr_merged",
+                               {"pr_number": 1, "is_agent_authored": True, "approval_count": 1})]
+        mr = apply_rules(events, rules)
+        cm1 = [m for m in mr.mappings if m.get("function_id") == "CM-1"]
+        assert len(cm1) == 0, (
+            "approval_count>0 without human_approval_count must not satisfy CM-1 — "
+            "bot approvals should not award change management credit"
+        )
+
+    def test_observed_event_does_not_match_attested_rules(self):
+        """Finding 7 regression: observed events must not match attested-class rules.
+
+        FAILS before fix (cstp-attested.yaml rules matched any event with the right
+        event_type regardless of evidence_class).
+        PASSES after fix (class isolation enforced in _rule_matches).
+        """
+        rules = load_rules(MAPPINGS_DIR)
+        # Observed event of type cstp_decision_linked (evidence_class="observed")
+        events = [_make_event(1, "cstp_decision_linked",
+                               {"decision_id": "x", "event_seqs": [], "has_outcome": True},
+                               evidence_class="observed")]
+        mr = apply_rules(events, rules)
+        attested_maps = [m for m in mr.mappings if "CSTP" in m.get("framework", "")]
+        assert len(attested_maps) == 0, (
+            "Observed events must never match attested-class rules — "
+            "doing so awards high-trust observed credit for self-reported data"
+        )
+
+    def test_attested_event_does_not_match_observed_rules(self):
+        """Finding 7 regression: attested events must not match observed-class rules.
+
+        FAILS before fix. PASSES after fix.
+        """
+        rules = load_rules(MAPPINGS_DIR)
+        # Attested event of type pr_opened — must not match SR 11-7 or NIST observed rules
+        events = [_make_event(1, "pr_opened",
+                               {"pr_number": 1, "is_agent_authored": True},
+                               evidence_class="attested")]
+        mr = apply_rules(events, rules)
+        sr_maps = [m for m in mr.mappings if "SR 11-7" in m.get("framework", "")]
+        nist_maps = [m for m in mr.mappings if "NIST" in m.get("framework", "")]
+        assert len(sr_maps) == 0, "Attested events must not match SR 11-7 observed rules"
+        assert len(nist_maps) == 0, "Attested events must not match NIST AI RMF observed rules"
+
 
 # ══════════════════════════════════════════════════════════════════════════════
 # Mapping: two-class coverage (THE NON-NEGOTIABLE CONSTRAINT)
@@ -470,7 +751,8 @@ class TestPerClassCoverage:
         events = [
             _make_event(1, "pr_opened", {"pr_number": 1, "is_agent_authored": True},
                         evidence_class="observed"),
-            _make_event(2, "pr_review_approved", {"pr_number": 1}, evidence_class="observed"),
+            _make_event(2, "pr_review_approved", {"pr_number": 1, "actor_is_human": True},
+                        evidence_class="observed"),
         ]
         mr = apply_rules(events, rules)
         assert mr.observed.total_events == 2
@@ -512,15 +794,16 @@ class TestPerClassCoverage:
             "Separate observed.coverage_pct and attested.coverage_pct are required."
         )
 
-    async def test_rpc_response_has_no_blended_coverage(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_rpc_response_has_no_blended_coverage(self, tmp_path, monkeypatch):
         """cstp.mapControls response must not contain a top-level coverage_pct."""
         db_path = str(tmp_path / "no_blend.db")
         init_db(db_path)
         append_event("gh", "pr_opened", "observed",
                      {"pr_number": 1, "is_agent_authored": True},
                      ts="2026-01-01T00:00:00Z", db_path=db_path)
-        params = {"db_path": db_path}
-        result = await map_controls(params, "test-agent")
+        monkeypatch.setattr(_svc, "DEFAULT_PROVENANCE_DB", db_path)
+        result = await map_controls({}, "test-agent")
         assert "coverage_pct" not in result, (
             "cstp.mapControls must not return a blended coverage_pct. "
             "Only coverage.observed.coverage_pct and coverage.attested.coverage_pct are allowed."
@@ -529,7 +812,8 @@ class TestPerClassCoverage:
         assert "observed" in result["coverage"]
         assert "attested" in result["coverage"]
 
-    async def test_bundle_has_no_blended_coverage(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_bundle_has_no_blended_coverage(self, tmp_path, monkeypatch):
         """exportEvidenceBundle JSON bundle must not contain a top-level coverage_pct."""
         db_path = str(tmp_path / "bundle_blend.db")
         output_dir = tmp_path / "out"
@@ -537,8 +821,9 @@ class TestPerClassCoverage:
         append_event("gh", "pr_opened", "observed",
                      {"pr_number": 1, "is_agent_authored": True},
                      ts="2026-01-01T00:00:00Z", db_path=db_path)
-        params = {"db_path": db_path, "format": "json", "output_dir": str(output_dir)}
-        result = await export_evidence_bundle(params, "test-agent")
+        monkeypatch.setattr(_svc, "DEFAULT_PROVENANCE_DB", db_path)
+        result = await export_evidence_bundle({"format": "json", "output_dir": str(output_dir)},
+                                               "test-agent")
         # The service-level result must not have blended coverage
         assert "coverage_pct" not in result, (
             "exportEvidenceBundle must not return a blended coverage_pct."
@@ -611,7 +896,7 @@ class TestInsufficientEvidence:
         events = [
             _make_event(1, "pr_opened", {"pr_number": 3, "is_agent_authored": True}),
             _make_event(2, "pr_merged", {"pr_number": 3, "is_agent_authored": True,
-                                          "approval_count": 0}),
+                                          "approval_count": 0, "human_approval_count": 0}),
         ]
         mr = apply_rules(events, rules)
         ie = [i for i in mr.insufficient_evidence if i["type"] == INSUFFICIENT_EVIDENCE_TAG]
@@ -621,17 +906,18 @@ class TestInsufficientEvidence:
         rules = load_rules(MAPPINGS_DIR)
         events = [
             _make_event(1, "pr_merged", {"pr_number": 3, "is_agent_authored": True,
-                                          "approval_count": 0}),
+                                          "approval_count": 0, "human_approval_count": 0}),
         ]
         mr = apply_rules(events, rules)
         for ie in mr.insufficient_evidence:
             assert ie["reason"] and len(ie["reason"]) > 20
 
-    def test_agent_merged_with_approval_no_ie(self):
+    def test_agent_merged_with_human_approval_no_mv3_ie(self):
+        """Finding 8 (updated): merge with human_approval_count>0 must not fire MV-3 IE."""
         rules = load_rules(MAPPINGS_DIR)
         events = [
             _make_event(1, "pr_merged", {"pr_number": 2, "is_agent_authored": True,
-                                          "approval_count": 1}),
+                                          "approval_count": 1, "human_approval_count": 1}),
         ]
         mr = apply_rules(events, rules)
         mv3_ie = [i for i in mr.insufficient_evidence
@@ -643,12 +929,27 @@ class TestInsufficientEvidence:
         rules = load_rules(MAPPINGS_DIR)
         events = [
             _make_event(1, "pr_merged", {"pr_number": 5, "is_agent_authored": False,
-                                          "approval_count": 2}),
+                                          "approval_count": 2, "human_approval_count": 2}),
         ]
         mr = apply_rules(events, rules)
         manage11 = [m for m in mr.mappings
                      if m.get("function_id") == "MANAGE-1.1" and m.get("pr_number") == 5]
         assert len(manage11) == 0, "MANAGE-1.1 must not fire on human-authored merges"
+
+    def test_bot_approval_only_fires_ie(self):
+        """Finding 8: approvals without human_approval_count>0 must fire bot-only IE."""
+        rules = load_rules(MAPPINGS_DIR)
+        events = [
+            _make_event(1, "pr_merged", {"pr_number": 7, "is_agent_authored": True,
+                                          "approval_count": 1}),  # no human_approval_count
+        ]
+        mr = apply_rules(events, rules)
+        bot_ie = [i for i in mr.insufficient_evidence
+                   if i.get("pr_number") == 7 and "bot" in i.get("reason", "").lower()]
+        assert len(bot_ie) >= 1, (
+            "Agent PR merged with approval_count>0 but no human_approval_count "
+            "must surface as INSUFFICIENT EVIDENCE (bot-only approval)"
+        )
 
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -703,6 +1004,49 @@ class TestIngestEvidence:
         with pytest.raises(ValueError, match="event_type"):
             await ingest_evidence(params, "agent-1")
 
+    @pytest.mark.asyncio
+    async def test_ingest_rejects_non_dict_payload(self, service_params):
+        """Finding 10: non-dict payload must be rejected before persisting."""
+        params = {
+            **service_params,
+            "events": [{"event_type": "pr_opened", "payload": ["not", "a", "dict"]}],
+        }
+        with pytest.raises(ValueError, match="dict"):
+            await ingest_evidence(params, "agent-1")
+        # Verify nothing was persisted
+        assert event_count(service_params["db_path"]) == 0
+
+    @pytest.mark.asyncio
+    async def test_ingest_batch_is_atomic(self, service_params):
+        """Finding 11: if any event is invalid, no events in the batch are committed."""
+        params = {
+            **service_params,
+            "events": [
+                {"event_type": "pr_opened", "payload": {}, "ts": "2026-01-01T00:00:00Z"},
+                {"event_type": "pr_merged", "payload": "not_a_dict", "ts": "2026-01-02T00:00:00Z"},
+            ],
+        }
+        with pytest.raises(ValueError, match="dict"):
+            await ingest_evidence(params, "agent-1")
+        # Both events must be absent — atomicity requirement
+        assert event_count(service_params["db_path"]) == 0, (
+            "Finding 11: batch ingest must be atomic — partial commit on error is a bug"
+        )
+
+    @pytest.mark.asyncio
+    async def test_ingest_unsupported_format_rejected(self, service_params, tmp_path):
+        """Finding 13: unsupported format must raise ValueError before creating any files."""
+        params = {
+            **service_params,
+            "format": "jsn",  # typo
+            "output_dir": str(tmp_path / "bundles"),
+        }
+        with pytest.raises(ValueError, match="Unsupported bundle format"):
+            await export_evidence_bundle(params, "agent-1")
+        assert not (tmp_path / "bundles").exists(), (
+            "Finding 13: output_dir must not be created for invalid format"
+        )
+
 
 # ══════════════════════════════════════════════════════════════════════════════
 # RPC: cstp.linkEvidence
@@ -744,6 +1088,56 @@ class TestLinkEvidence:
         )
         att = [e for e in events if e["evidence_class"] == "attested"]
         assert len(att) == 1
+
+    @pytest.mark.asyncio
+    async def test_link_rejects_nonexistent_seq(self, service_params_observed):
+        """Finding 4 regression: linking a nonexistent seq must fail.
+
+        FAILS before fix (link_evidence appended attested record regardless).
+        PASSES after fix (validate_observed_seqs rejects missing seqs).
+        """
+        params = {
+            **service_params_observed,
+            "decision_id": "dec-xyz",
+            "event_seqs": [999],  # seq 999 does not exist
+        }
+        with pytest.raises(ValueError, match="nonexistent"):
+            await link_evidence(params, "agent-1")
+
+    @pytest.mark.asyncio
+    async def test_link_rejects_attested_seq(self, db_with_observed, service_params_observed):
+        """Finding 4 regression: linking an attested seq must fail.
+
+        FAILS before fix. PASSES after fix.
+        """
+        # First, create an attested event (the seq we'll try to reuse)
+        att_result = await link_evidence(
+            {**service_params_observed, "decision_id": "dec-1", "event_seqs": [1]},
+            "agent-1",
+        )
+        attested_seq = att_result["attested_seq"]
+
+        # Now try to link to that attested seq — must be rejected
+        with pytest.raises(ValueError, match="observed"):
+            await link_evidence(
+                {**service_params_observed, "decision_id": "dec-2",
+                 "event_seqs": [attested_seq]},
+                "agent-1",
+            )
+
+    @pytest.mark.asyncio
+    async def test_link_rejects_duplicate_seqs(self, service_params_observed):
+        """Finding 4 regression: duplicate seqs in event_seqs must fail.
+
+        FAILS before fix. PASSES after fix.
+        """
+        params = {
+            **service_params_observed,
+            "decision_id": "dec-xyz",
+            "event_seqs": [1, 1, 2],  # seq 1 duplicated
+        }
+        with pytest.raises(ValueError, match="duplicate"):
+            await link_evidence(params, "agent-1")
 
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -840,17 +1234,15 @@ class TestExportEvidenceBundle:
 
     @pytest.mark.asyncio
     async def test_chain_intact_false_after_tamper(self, db_with_observed, tmp_path):
-        """Tampered chain must make chain_intact=False (uses stored head hash — P2 fix)."""
-        db_path = db_with_observed
+        """Tampered chain must make chain_intact=False (uses stored checkpoint — P2 fix)."""
         params = {
-            "db_path": db_path,
             "format": "json",
             "output_dir": str(tmp_path / "bundles"),
         }
-        # First export to capture head hash
+        # First export to capture head hash / checkpoint
         await export_evidence_bundle(params, "agent-1")
         # Tamper and re-export
-        with sqlite3.connect(db_path) as conn:
+        with sqlite3.connect(db_with_observed) as conn:
             conn.execute("UPDATE events SET payload_json = '{\"tampered\":true}' WHERE seq = 1")
             conn.commit()
         result = await export_evidence_bundle(params, "agent-1")
@@ -858,23 +1250,102 @@ class TestExportEvidenceBundle:
 
     @pytest.mark.asyncio
     async def test_p2_tail_truncation_detected(self, db_with_observed, tmp_path):
-        """Tail truncation must be detected via stored head hash (P2 fix)."""
-        db_path = db_with_observed
+        """Tail truncation must be detected via stored checkpoint (P2 fix)."""
         params = {
-            "db_path": db_path,
             "format": "json",
             "output_dir": str(tmp_path / "bundles"),
         }
-        # First bundle stores the head hash
+        # First bundle stores checkpoint
         await export_evidence_bundle(params, "agent-1")
         # Delete tail events
-        with sqlite3.connect(db_path) as conn:
+        with sqlite3.connect(db_with_observed) as conn:
             conn.execute("DELETE FROM events WHERE seq >= 4")
             conn.commit()
-        # Second bundle: chain appears internally intact, but head hash won't match
+        # Second bundle: chain appears internally intact, but checkpoint mismatch
         result2 = await export_evidence_bundle(params, "agent-1")
         assert result2["chain_intact"] is False, (
-            "P2 fix: tail truncation must be detected via persisted head hash"
+            "P2 fix: tail truncation must be detected via persisted checkpoint"
+        )
+
+    @pytest.mark.asyncio
+    async def test_valid_extension_stays_intact(self, db_with_observed, tmp_path):
+        """Finding 5+6 regression: adding new events after export must not break chain.
+
+        Before fix (:286): verify_chain(db, expected_head_hash=prev_hash) returned 0
+        when the current head differed from prev_hash — treating valid growth as tampering.
+        After fix: verify_at_checkpoint checks only up to the checkpoint seq, so new events
+        do not cause a false positive.
+        FAILS before fix. PASSES after fix.
+        """
+        params = {
+            "format": "json",
+            "output_dir": str(tmp_path / "bundles"),
+        }
+
+        # First export — captures checkpoint at seq 5
+        r1 = await export_evidence_bundle(params, "agent-1")
+        assert r1["chain_intact"] is True
+
+        # Add a new legitimate event (valid chain extension)
+        append_event("src", "pr_opened", "observed", {"pr_number": 99},
+                     ts="2026-08-01T00:00:00Z", db_path=db_with_observed)
+
+        # Second export: checkpoint at seq 5 still valid, chain extended to seq 6
+        r2 = await export_evidence_bundle(params, "agent-1")
+        assert r2["chain_intact"] is True, (
+            "Finding 5+6: valid chain extension must not be reported as broken — "
+            "verify_at_checkpoint allows growth beyond the checkpoint"
+        )
+
+    @pytest.mark.asyncio
+    async def test_tail_deletion_then_verify_remains_detected(self, db_with_observed, tmp_path):
+        """Finding 5+6 regression: tampering must remain detected after re-export (no self-healing).
+
+        Before fix (:282): export stored the NEW (truncated) head as checkpoint even when
+        chain_intact=False. The next verify_evidence_chain then used that head as the
+        expected hash and reported intact — self-healing the tampered state.
+        After fix: checkpoint is only promoted when chain_intact=True.
+        FAILS before fix. PASSES after fix.
+        """
+        params = {
+            "format": "json",
+            "output_dir": str(tmp_path / "bundles"),
+        }
+
+        # First export (intact) — stores trusted checkpoint
+        r1 = await export_evidence_bundle(params, "agent-1")
+        assert r1["chain_intact"] is True
+
+        # Delete tail events (tamper)
+        with sqlite3.connect(db_with_observed) as conn:
+            conn.execute("DELETE FROM events WHERE seq >= 4")
+            conn.commit()
+
+        # Second export: must detect the tampering
+        r2 = await export_evidence_bundle(params, "agent-1")
+        assert r2["chain_intact"] is False, "Tail deletion must be detected on re-export"
+
+        # Subsequent verify: must STILL detect tampering — checkpoint was not promoted
+        verify_result = await verify_evidence_chain({}, "agent-1")
+        assert verify_result["intact"] is False, (
+            "Finding 5+6: tampering must remain detected after re-export — "
+            "checkpoint must not be self-healed to a tampered state"
+        )
+
+    @pytest.mark.asyncio
+    async def test_unsupported_format_rejected_before_creating_dirs(self, service_params_observed,
+                                                                      tmp_path):
+        """Finding 13: unsupported format must raise ValueError, not create dirs."""
+        bundle_dir = tmp_path / "bundles"
+        params = {
+            **service_params_observed,
+            "format": "jsn",  # typo
+            "output_dir": str(bundle_dir),
+        }
+        with pytest.raises(ValueError, match="Unsupported bundle format"):
+            await export_evidence_bundle(params, "agent-1")
+        assert not bundle_dir.exists(), (
+            "Finding 13: output_dir must not be created when format is invalid"
         )
 
     @pytest.mark.asyncio
@@ -887,7 +1358,7 @@ class TestExportEvidenceBundle:
             "output_dir": str(tmp_path / "bundles"),
         }
         r1 = await export_evidence_bundle(params, "agent-1")
-        await aio.sleep(1)  # ensure different timestamp in filename
+        await aio.sleep(1)  # extra guard for ts-based names
         r2 = await export_evidence_bundle(params, "agent-1")
         assert r1["json_path"] != r2["json_path"]
         assert Path(r1["json_path"]).exists()
@@ -922,18 +1393,17 @@ class TestVerifyEvidenceChain:
 
     @pytest.mark.asyncio
     async def test_uses_stored_bundle_head_hash(self, db_with_observed, tmp_path):
-        """Without explicit expected_head_hash, uses last bundle head (P2 fix)."""
-        db_path = db_with_observed
-        # Generate a bundle to store the head hash
+        """Without explicit expected_head_hash, uses last bundle checkpoint (P2 fix)."""
+        # Generate a bundle to store the checkpoint
         await export_evidence_bundle(
-            {"db_path": db_path, "format": "json", "output_dir": str(tmp_path / "b")},
+            {"format": "json", "output_dir": str(tmp_path / "b")},
             "agent-1",
         )
-        # Delete tail events — truncation should be detectable via stored hash
-        with sqlite3.connect(db_path) as conn:
+        # Delete tail events — truncation should be detectable via stored checkpoint
+        with sqlite3.connect(db_with_observed) as conn:
             conn.execute("DELETE FROM events WHERE seq >= 4")
             conn.commit()
-        result = await verify_evidence_chain({"db_path": db_path}, "agent-1")
+        result = await verify_evidence_chain({}, "agent-1")
         assert result["intact"] is False
         assert result["tail_check"] is True
 
@@ -944,9 +1414,7 @@ class TestVerifyEvidenceChain:
                 "UPDATE events SET payload_json = '{\"tampered\":true}' WHERE seq = 2"
             )
             conn.commit()
-        result = await verify_evidence_chain(
-            {"db_path": db_with_observed}, "agent-1"
-        )
+        result = await verify_evidence_chain({}, "agent-1")
         assert result["intact"] is False
         assert result["broken_at_seq"] == 2
 
@@ -957,29 +1425,29 @@ class TestVerifyEvidenceChain:
 
 class TestEndToEndWorkflow:
     @pytest.mark.asyncio
-    async def test_full_workflow(self, tmp_path):
+    async def test_full_workflow(self, tmp_path, monkeypatch):
         """Ingest → Link → MapControls → Export → Verify."""
         db_path = str(tmp_path / "workflow.db")
         output_dir = str(tmp_path / "bundles")
         init_db(db_path)
+        monkeypatch.setattr(_svc, "DEFAULT_PROVENANCE_DB", db_path)
 
-        # 1. Ingest observed events
+        # 1. Ingest observed events (with human actor signals — finding 8)
         ingest_result = await ingest_evidence({
-            "db_path": db_path,
             "events": [
                 {"event_type": "pr_opened", "ts": "2026-01-01T10:00:00Z",
                  "payload": {"pr_number": 10, "is_agent_authored": True, "approval_count": 0}},
                 {"event_type": "pr_review_approved", "ts": "2026-01-01T11:00:00Z",
-                 "payload": {"pr_number": 10, "reviewer": "bob"}},
+                 "payload": {"pr_number": 10, "reviewer": "bob", "actor_is_human": True}},
                 {"event_type": "pr_merged", "ts": "2026-01-01T12:00:00Z",
-                 "payload": {"pr_number": 10, "is_agent_authored": True, "approval_count": 1}},
+                 "payload": {"pr_number": 10, "is_agent_authored": True,
+                              "approval_count": 1, "human_approval_count": 1}},
             ],
         }, "test-agent")
         assert ingest_result["ingested"] == 3
 
         # 2. Link a CSTP decision to observed events
         link_result = await link_evidence({
-            "db_path": db_path,
             "decision_id": "dec-workflow-test",
             "event_seqs": [1, 2, 3],
             "has_outcome": True,
@@ -988,14 +1456,13 @@ class TestEndToEndWorkflow:
         assert link_result["linked"] == 3
 
         # 3. Map controls
-        map_result = await map_controls({"db_path": db_path}, "test-agent")
+        map_result = await map_controls({}, "test-agent")
         assert map_result["coverage"]["observed"]["total_events"] == 3
         assert map_result["coverage"]["attested"]["total_events"] == 1
         assert "coverage_pct" not in map_result  # No blended metric
 
         # 4. Export bundle
         export_result = await export_evidence_bundle({
-            "db_path": db_path,
             "format": "json",
             "output_dir": output_dir,
         }, "test-agent")
@@ -1005,5 +1472,5 @@ class TestEndToEndWorkflow:
         assert bundle["coverage"]["observed"]["total_events"] == 3
 
         # 5. Verify chain
-        verify_result = await verify_evidence_chain({"db_path": db_path}, "test-agent")
+        verify_result = await verify_evidence_chain({}, "test-agent")
         assert verify_result["intact"] is True


### PR DESCRIPTION
## Summary

Fixes all 13 verified security findings from the code review of PR #193 (F055 Decision Provenance & Control Evidence). This subsystem produces SHA-256 hash-chained compliance bundles mapped to SR 11-7 and NIST AI RMF controls for regulatory audit — every finding is security-relevant.

## Finding Checklist

- [x] **F1 — Injective hash preimage**: `compute_hash` now uses `canonical_json({seq, ts, event_type, evidence_class, payload, prev_hash})` as the preimage. Old newline-joined string allowed `(ts="a\nb", event_type="c")` == `(ts="a", event_type="b\nc")` — enabling hash chain forgery by swapping field values without changing the hash.

- [x] **F2 — Hash chain race condition**: `append_event` now uses `BEGIN IMMEDIATE` + explicit seq computation. Old code read the current head under default isolation, allowing two concurrent writers to assign the same `next_seq` and produce conflicting hashes.

- [x] **F3 — db_path RPC parameter escape**: `_get_db_path()` always returns `DEFAULT_PROVENANCE_DB`; the `db_path` param is ignored. Previously any RPC caller could supply an arbitrary filesystem path and read/write a different database.

- [x] **F4 — link_evidence accepts arbitrary seqs**: `validate_observed_seqs()` rejects nonexistent seqs, attested-class seqs, and duplicate seqs. Previously `link_evidence` would write an attested record referencing phantom or wrong-class events.

- [x] **F5 — Chain-growth false positive on verify**: `verify_at_checkpoint()` verifies only up to `checkpoint_seq`, not the current head. The old code compared the current head to the stored bundle hash — any valid chain extension triggered "broken".

- [x] **F6 — Checkpoint self-healing after tamper**: Checkpoint (`store_bundle_checkpoint`) is now only promoted when `chain_intact=True`. Old code stored the new (possibly tampered) head as the trusted checkpoint even when verification failed, making the next call report "intact".

- [x] **F7 — Evidence class isolation in rule engine**: `_rule_matches()` now enforces class isolation. Each YAML file declares `evidence_class` at the top level; rules from that file only match events of the same class. Old code let observed events match attested rules and vice versa, awarding the wrong trust tier.

- [x] **F8 — Bot approvals satisfy human-review controls**: SR 11-7 MV-3 and NIST MEASURE-2.5 now require `actor_is_human: true` on `pr_review_approved`. CM-1 and MANAGE-1.1 now require `human_approval_count > 0` on `pr_merged`. Fail closed: if upstream webhook omits these fields the rules do not fire and two new IE rules surface the gap. **Required upstream signals**: `actor_is_human` (bool) on `pr_review_approved` events; `human_approval_count` (int) on `pr_merged` events.

- [x] **F9 — PDF optional dependency undeclared**: Added `[pdf]` extra (`reportlab>=4.0`) to `pyproject.toml`; `[all]` now includes it. Error message updated to mention `pip install cognition-agent-decisions[pdf]`.

- [x] **F10 — Non-dict payload accepted**: `ingest_evidence` now rejects events where `payload` is not a `dict` (e.g. a list or string) before persisting anything.

- [x] **F11 — Non-atomic batch ingest**: `append_events_batch` validates all events first, then commits in one `BEGIN IMMEDIATE` transaction. Old code committed partial batches on error.

- [x] **F12 — Bundle filename collision**: `_unique_ts_tag()` now uses microseconds + UUID4 suffix. Two exports within the same second previously produced the same filename; the second silently overwrote the first (breaking the `O_EXCL` immutability guarantee).

- [x] **F13 — Format validated after directory creation**: `export_evidence_bundle` now validates the `format` parameter before creating `output_dir`. Old code created the directory then raised, leaving an empty dir artifact.

## BREAKING CHANGES

### Hash preimage format v1 → v2

The `compute_hash` preimage format has changed from a newline-delimited string to canonical JSON. **Any existing provenance database is incompatible** with the new `verify_chain` and `verify_at_checkpoint` implementations. All stored hashes will fail verification. Migration required for any persisted provenance databases.

### db_path RPC parameter removed

`ingest_evidence`, `link_evidence`, `map_controls`, `export_evidence_bundle`, and `verify_evidence_chain` no longer accept `db_path` in params. The service always uses `DEFAULT_PROVENANCE_DB`. Callers must remove the parameter; passing it has no effect.

## Upstream signal requirements (Finding 8)

Two new fields must be supplied by the upstream GitHub webhook integration:

| Field | Event | Type | Purpose |
|---|---|---|---|
| `actor_is_human` | `pr_review_approved` | `bool` | Distinguishes human reviewer from bot reviewer |
| `human_approval_count` | `pr_merged` | `int` | Count of approvals from verified human actors |

If these fields are absent, the human-review rules (`MV-3`, `CM-1`, `MEASURE-2.5`, `MANAGE-1.1`) produce **no control credit** (fail closed). The new IE rules `SR11-7-MV3-ie-bot-approval-only` and `NIST-MANAGE-2.2-ie-bot-approval-only` surface the gap explicitly in the evidence bundle.

## Test plan

- [x] 111 tests passing (up from 82 before this PR); 0 regressions in the full 1280-test suite
- [x] `ruff check src/ tests/ a2a/` — all checks pass
- [x] P1 regression tests for findings 1, 2, 4, 5+6, 7, 8 — each test encodes the vulnerable behavior in its docstring and passes only after the fix

## Out-of-scope observations

- Finding 4 limitation: `validate_observed_seqs` cannot verify that event seqs belong to the correct `decision_id` (no per-decision scoping in the schema). This is a design gap worth tracking.
- `a2a/cstp/graphdb/` has similar `db_path` exposure pattern as F3 — not in scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)