### PR TITLE
docs: v0.16.0 docs, UTF-8 file IO, and spec-index corrections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,11 @@ Decision intelligence layer for AI agents providing semantic search, guardrails,
 ## Build and run
 
 ```bash
-# Install all dependencies (core + a2a + mcp + dev)
+# Install all dependencies (core + a2a + mcp + dev + pdf)
 pip install -e ".[all]"
+
+# PDF evidence bundles only (F055) — reportlab
+pip install -e ".[pdf]"
 
 # Run CSTP server (defaults: VECTOR_BACKEND=chromadb, EMBEDDING_PROVIDER=gemini)
 cstp-server
@@ -54,7 +57,9 @@ ruff check --fix src/ tests/ a2a/
 mypy src/ a2a/
 ```
 
-Ruff config: line-length 100, target Python 3.11, rules `E F I N W UP B C4 SIM`. See `pyproject.toml [tool.ruff]` for ignored rules.
+Ruff config: line-length 100, target Python 3.11, rules `E F I N W UP B C4 SIM PLW1514`. `PLW1514` (text IO must name an encoding) is preview-gated, so `preview` and `explicit-preview-rules` are both on — the latter keeps the rest of the preview ruleset out. See `pyproject.toml [tool.ruff]` for ignored rules.
+
+`scripts/` and `dashboard/` are outside the lint scope; `scripts/` currently has 40 pre-existing style errors.
 
 ## Architecture
 
@@ -63,11 +68,14 @@ AI Agents → POST /cstp (JSON-RPC 2.0, Bearer auth)
   → a2a/server.py → CstpDispatcher → *_service.py handlers
     → VectorStore (chromadb | memory)  + EmbeddingProvider (gemini)
     → GraphStore (networkx | memory)   + JSONL persistence (F045)
+    → Provenance store (SQLite WAL, hash-chained) — F055, separate DB
     → src/cognition_engines/ (SemanticIndex, GuardrailEngine, PatternDetector)
     → YAML files (decisions/guardrails)
 ```
 
 Vector storage and embeddings are abstracted behind `VectorStore` and `EmbeddingProvider` ABCs (F048). Graph storage is abstracted behind `GraphStore` ABC (F045). Services access backends via factory singletons (`get_vector_store()`, `get_embedding_provider()`, `get_graph_store()`). Backend selection is driven by `VECTOR_BACKEND`, `EMBEDDING_PROVIDER`, and `GRAPH_BACKEND` env vars.
+
+F055 provenance evidence lives in its own SQLite WAL database at `PROVENANCE_DB` (default `~/.cstp/provenance.db`), deliberately separate from the decision store. The path is server-configured only — RPC callers cannot override it.
 
 **Key constraint**: `src/cognition_engines/` must never import from `a2a/`. Core uses dataclasses, the a2a layer uses Pydantic.
 
@@ -79,6 +87,7 @@ Vector storage and embeddings are abstracted behind `VectorStore` and `Embedding
 - Naming: modules `snake_case`, classes `PascalCase`, constants `UPPER_SNAKE`, CSTP methods `cstp.camelCase`, handlers `_handle_snake_case`
 - Test files: `test_<module>.py` or `test_f0XX_<feature>.py`
 - Use `pathlib.Path` for file operations (cross-platform)
+- **Always pass `encoding="utf-8"` to text-mode file IO** (`open`, `os.fdopen`, `read_text`, `write_text`). The platform default is cp1252 on Windows, which silently mis-decodes non-ASCII rather than raising — and Linux CI cannot see it. Enforced by ruff `PLW1514`, but that rule does not catch `os.fdopen` or untyped `read_text`, so it is a safety net, not a guarantee
 - Mock all external APIs (ChromaDB, Gemini) in tests — tests must run offline
 - Use `MemoryStore` + mock `EmbeddingProvider` via factory injection (`set_vector_store()` / `set_embedding_provider()`) instead of patching internal HTTP functions
 - Config pattern: YAML → env var → default (see `a2a/config.py`)
@@ -110,6 +119,11 @@ Vector storage and embeddings are abstracted behind `VectorStore` and `Embedding
 - `a2a/cstp/graphdb/memory.py` — In-memory graph backend (tests/dev)
 - `a2a/cstp/graphdb/factory.py` — Graph backend selection via `GRAPH_BACKEND` env var
 - `a2a/cstp/graph_service.py` — Graph business logic (link, query, init from YAML)
+- `a2a/cstp/guardrails_service.py` — Guardrail evaluation + `CelGuardrailEvaluator` (F054)
+- `a2a/cstp/provenance_service.py` — F055 evidence ingest, control mapping, bundle export
+- `a2a/cstp/provenance/mapping.py` — F055 YAML rules engine
+- `a2a/cstp/provenance/mappings/` — SR 11-7, NIST AI RMF, CSTP-attested control rules
+- `a2a/cstp/storage/provenance.py` — F055 hash-chained SQLite evidence store
 - `a2a/config.py` — Server configuration (YAML + env)
 - `guardrails/cornerstone.yaml` — Default guardrail rules
 - `config/server.yaml` — Default server config

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ Cognition Engines gives AI agents a memory of their decisions — what they deci
 ## Key Capabilities
 
 - **Decision Memory**: Semantic search over past decisions with hybrid retrieval (vector + BM25)
-- **Guardrails**: Policy enforcement that blocks unsafe actions before they happen
+- **Guardrails**: Policy enforcement that blocks unsafe actions before they happen, with [CEL](https://github.com/google/cel-spec) expressions for arbitrary conditions
 - **Calibration**: Brier scoring tracks whether confidence predictions match actual outcomes
+- **Provenance & Control Evidence**: Hash-chained audit evidence mapped to SR 11-7 and NIST AI RMF, exportable as a single bundle
 - **Deliberation Traces**: Auto-captures the reasoning chain (queries, guardrail checks) leading to each decision
 - **Bridge Search**: Query by structure ("what does it look like?") or function ("what problem does it solve?")
 - **MCP + JSON-RPC**: Framework-agnostic — works with Claude Code, Claude Desktop, OpenClaw, LangChain, or raw curl
@@ -142,6 +143,13 @@ Each agent's thoughts are tracked separately via composite keys (`agent:{id}:dec
 | `get_graph` | Query subgraph around a decision with configurable depth and edge type filters |
 | `get_neighbors` | Lightweight neighbor query - direct connections for a decision with edge types and weights |
 
+### Circuit Breaker Tools (F030)
+
+| Tool | Purpose |
+|------|---------|
+| `get_circuit_state` | Current breaker state (`closed` / `open` / `half_open`) for a category |
+| `list_breakers` | All tripped and recovering breakers |
+
 ## JSON-RPC API
 
 All tools are also available via JSON-RPC 2.0 at `POST /cstp`:
@@ -167,7 +175,21 @@ curl -X POST http://localhost:8100/cstp \
   }'
 ```
 
-**Available methods:** `cstp.queryDecisions`, `cstp.checkGuardrails`, `cstp.recordDecision`, `cstp.reviewDecision`, `cstp.getCalibration`, `cstp.getDecision`, `cstp.getReasonStats`, `cstp.updateDecision`, `cstp.recordThought`, `cstp.preAction`, `cstp.getSessionContext`, `cstp.ready`, `cstp.linkDecisions`, `cstp.getGraph`, `cstp.getNeighbors`, `cstp.debugTracker`, `cstp.checkDrift`, `cstp.reindex`, `cstp.listGuardrails`, `cstp.attributeOutcomes`
+**Available methods** (34 registered in `a2a/cstp/dispatcher.py`):
+
+| Group | Methods |
+|-------|---------|
+| Decisions | `cstp.queryDecisions`, `cstp.recordDecision`, `cstp.updateDecision`, `cstp.getDecision`, `cstp.listDecisions`, `cstp.recordThought` |
+| Guardrails | `cstp.checkGuardrails`, `cstp.listGuardrails` |
+| Calibration | `cstp.reviewDecision`, `cstp.getCalibration`, `cstp.getStats`, `cstp.getReasonStats`, `cstp.attributeOutcomes`, `cstp.checkDrift` |
+| Agentic loop | `cstp.preAction`, `cstp.getSessionContext`, `cstp.ready` |
+| Graph (F045) | `cstp.linkDecisions`, `cstp.getGraph`, `cstp.getNeighbors` |
+| Compaction (F041) | `cstp.compact`, `cstp.getCompacted`, `cstp.setPreserve`, `cstp.getWisdom` |
+| Circuit breakers (F030) | `cstp.listBreakers`, `cstp.getCircuitState`, `cstp.resetCircuit` |
+| Provenance (F055) | `cstp.ingestEvidence`, `cstp.linkEvidence`, `cstp.mapControls`, `cstp.exportEvidenceBundle`, `cstp.verifyEvidenceChain` |
+| Ops | `cstp.reindex`, `cstp.debugTracker` |
+
+The F055 provenance methods are JSON-RPC only — they have no MCP tool equivalents.
 
 ### Auto-Linking
 
@@ -240,6 +262,69 @@ action: block
 message: "High-stakes decisions require ≥50% confidence"
 ```
 
+### CEL Expression Guardrails (F054)
+
+Conditions can also be written as [CEL](https://github.com/google/cel-spec) expressions, which reach
+fields the legacy key/value form cannot — in particular the caller-supplied `context` dict:
+
+```yaml
+id: require-architecture-review
+description: Architecture decisions require an architecture review
+condition: "action.category == 'architecture' && !action.context.architecture_review"
+action: block
+message: "Architecture decisions require architecture_review: true"
+```
+
+The activation exposes `action.description`, `.stakes`, `.confidence`, `.category`, `.tags`,
+`.reason_count`, `.pattern`, `.quality_score`, `.has_tags`, `.has_pattern`, and everything else
+the caller passed under `action.context.*`. Full boolean logic, comparisons, `in`, `size()`, and
+`contains()` are available.
+
+Legacy key/value conditions are auto-converted to CEL at evaluation time, so existing guardrail
+files keep working unchanged — no migration needed. Evaluation **fails open**: a guardrail whose
+expression fails to compile or raises at runtime is skipped and logged, never treated as a block.
+
+See the [guardrails authoring guide](https://cognition-engines.ai/reference/guardrails-authoring) for
+the full field reference.
+
+### Decision Provenance & Control Evidence (F055)
+
+Turns CSTP's decision history into an artifact an auditor can accept. Evidence falls into exactly
+two classes that are **never blended into one number**:
+
+- **Observed** — third-party events from a system the agent does not control (GitHub PR opens,
+  reviews, approvals, merges). Ingested via `cstp.ingestEvidence` and SHA-256 hash-chained, so any
+  later edit breaks the chain.
+- **Attested** — first-party CSTP decision records linked to observed events via `cstp.linkEvidence`.
+  Self-reported, and an auditor discounts them accordingly.
+
+Coverage is reported separately per class. A control satisfied only by attested evidence is flagged
+`attested_only`. Hand-written YAML rules in `a2a/cstp/provenance/mappings/` map evidence to
+**SR 11-7** (Federal Reserve MRM) and **NIST AI RMF 1.0** controls; where evidence does not honestly
+support a control, the mapper emits `INSUFFICIENT_EVIDENCE` with a plain-English reason rather than
+stretching the mapping.
+
+```bash
+# Map stored evidence to controls
+curl -X POST http://localhost:8100/cstp \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -d '{"jsonrpc":"2.0","method":"cstp.mapControls","params":{},"id":1}'
+
+# Export the auditor-facing bundle
+curl -X POST http://localhost:8100/cstp \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -d '{"jsonrpc":"2.0","method":"cstp.exportEvidenceBundle","params":{"format":"json"},"id":1}'
+```
+
+Evidence lives in its own SQLite WAL database, separate from the decision store:
+
+```bash
+PROVENANCE_DB=~/.cstp/provenance.db   # default
+```
+
+PDF bundles need the optional `pdf` extra (`pip install -e ".[pdf]"`, included in `[all]`). JSON
+bundles have no extra dependency. See [website/specs/f055-decision-provenance.md](website/specs/f055-decision-provenance.md).
+
 ## Roadmap
 
 See [docs/features/INDEX.md](docs/features/INDEX.md) for the complete feature catalog and [TODO.md](TODO.md) for prioritized work items.
@@ -252,14 +337,17 @@ See [docs/features/INDEX.md](docs/features/INDEX.md) for the complete feature ca
 | v0.11.0 | Pre-Action Hook, Session Context, Website (F046-F048) | ✅ Shipped |
 | v0.14.0 | Multi-Agent Isolation, Live Deliberation Viewer, Memory Compaction, Graph Storage (F041, F044-F045, F049) | ✅ Shipped |
 | v0.15.0 | SQLite Storage, Auto-Migration, 8-42x Performance, Enriched Search, Dashboard Integration (F050) | ✅ Shipped |
+| v0.16.0 | Full Stack Demo, Circuit Breakers, CEL Guardrails, Decision Provenance (F051, F030, F054, F055) | 🚧 On `main`, unreleased |
+
+`pyproject.toml` still reports `0.15.0`; the v0.16.0 features above are merged to `main` but not yet tagged.
 
 ### Upcoming
 
 | Priority | Features |
 |----------|----------|
-| **P1** | F051 Docker-Compose Full Stack Demo ✅, F030 Circuit Breakers, Weaviate/pgvector backends |
-| **P2** | F052 Dashboard Export (Grafana/Prometheus), F053 Query Deduplication Cache |
-| **P3** | F034 Decomposed Confidence, F035-F039 Multi-Agent Federation, F043 Distributed Merge |
+| **P1** | F054-b Decision Admission Gate, Weaviate/pgvector backends |
+| **P2** | F052 Dashboard Export (Grafana/Prometheus), F053 Query Deduplication Cache, F055 P2 PDF bundle improvements |
+| **P3** | F034 Decomposed Confidence, F035-F039 Multi-Agent Federation, F043 Distributed Merge, F055 P3 EU AI Act mapping |
 
 ### Research Foundations
 
@@ -273,28 +361,33 @@ See [docs/features/INDEX.md](docs/features/INDEX.md) for the complete feature ca
 ```
 cognition-agent-decisions/
 ├── a2a/cstp/                  # CSTP services
-│   ├── dispatcher.py          # JSON-RPC routing (15 methods)
+│   ├── dispatcher.py          # JSON-RPC routing (34 methods)
 │   ├── query_service.py       # Hybrid retrieval
 │   ├── decision_service.py    # Record, update, retrieve
 │   ├── calibration_service.py # Brier scoring, rolling windows
-│   ├── guardrails_service.py  # Policy evaluation
+│   ├── guardrails_service.py  # Policy evaluation + F054 CEL evaluator
 │   ├── preaction_service.py   # F046 Pre-action hook
 │   ├── session_context_service.py # F047 Session context
 │   ├── deliberation_tracker.py # F023 Auto-capture
+│   ├── provenance_service.py  # F055 Evidence ingest, mapping, bundles
+│   ├── provenance/            # F055 Control framework mapping
+│   │   ├── mapping.py         # YAML rules engine
+│   │   └── mappings/          # sr11-7, nist-ai-rmf, cstp-attested
 │   ├── vectordb/              # F048 Pluggable vector storage
 │   │   ├── chromadb.py        # ChromaDB backend
 │   │   └── memory.py          # In-memory backend (testing)
 │   └── embeddings/            # F048 Pluggable embeddings
 │       └── gemini.py          # Gemini backend
-├── a2a/mcp_server.py          # MCP Server (14+ tools)
+├── a2a/mcp_server.py          # MCP Server (17 tools)
 ├── a2a/cstp/storage/          # F050 Pluggable decision storage
 │   ├── sqlite.py              # SQLite backend (WAL, FTS5)
 │   ├── yaml_fs.py             # YAML backend (legacy)
-│   └── memory.py              # In-memory backend (testing)
+│   ├── memory.py              # In-memory backend (testing)
+│   └── provenance.py          # F055 Hash-chained evidence store
 ├── a2a/server.py              # FastAPI server
 ├── dashboard/                 # Web dashboard (Flask)
 ├── demo/                      # Full stack demo (docker compose)
-├── docs/features/             # Feature specs (F001-F053)
+├── docs/features/             # Feature specs (F001-F055)
 ├── guardrails/                # YAML guardrail definitions
 ├── tests/                     # Test suite
 ├── website/                   # VitePress docs (cognition-engines.ai)

--- a/TODO.md
+++ b/TODO.md
@@ -67,13 +67,45 @@ Semantic decay for old resolved decisions.
 - [x] MCP tool registration for graph endpoints — PR #130
 - Spec: `docs/features/F045-graph-storage-layer.md`
 
-### F030: Circuit Breaker Guardrails
+### F030: Circuit Breaker Guardrails ✅
 Adaptive guardrails that trip based on outcome patterns.
-- [ ] Track failure counts per category/pattern
-- [ ] Auto-trip after N failures in a window
-- [ ] `cstp.listBreakers` endpoint
-- [ ] Manual reset via `cstp.resetBreaker`
+- [x] Track failure counts per category/pattern
+- [x] Auto-trip after N failures in a window
+- [x] `cstp.listBreakers` endpoint
+- [x] `cstp.getCircuitState` endpoint
+- [x] Manual reset via `cstp.resetCircuit` (named `resetBreaker` in the original spec)
+- [x] `get_circuit_state` / `list_breakers` MCP tools
 - Spec: `docs/features/F030-circuit-breaker-guardrails.md`
+
+### F054: CEL Expression Guardrails ✅
+Replace rigid JSONB condition matching with CEL expressions.
+- [x] `CelGuardrailEvaluator` with per-expression program caching
+- [x] `condition` accepts a CEL string or `{"cel": "..."}` dict
+- [x] Legacy key/value conditions auto-convert to CEL at load time
+- [x] `action.context.*` reachable from expressions — closes the MCP guardrail gap
+- [x] Fail-open on compile/eval errors
+- [x] `cel-python>=0.4,<1.0` added to core dependencies
+- Spec: `docs/features/F054-cel-guardrails.md`
+
+### F055: Decision Provenance & Control Evidence ✅
+Hash-chained audit evidence mapped to SR 11-7 and NIST AI RMF.
+- [x] Two-class evidence model (`observed` / `attested`), never blended
+- [x] `cstp.ingestEvidence`, `cstp.linkEvidence`, `cstp.mapControls`
+- [x] `cstp.exportEvidenceBundle` (JSON; PDF via the `pdf` extra)
+- [x] `cstp.verifyEvidenceChain` with tail-truncation detection
+- [x] YAML rules for SR 11-7, NIST AI RMF 1.0, CSTP-attested
+- [x] Security hardening — 13 findings resolved (chain format v2, `db_path` escape removed, fail-closed bot approvals)
+- [ ] P2: PDF bundle improvements — executive sign-off, regulatory citations, per-model grouping
+- [ ] P3: EU AI Act Annex III mapping (needs legal review per rule)
+- [ ] P4: Streaming ingest webhook for real-time GitHub events
+- [ ] MCP tool wrappers (currently JSON-RPC only)
+- Spec: `website/specs/f055-decision-provenance.md`
+
+### F054-b: Decision Admission Gate
+Reject status updates and conversational fragments before they pollute the decision store.
+- [ ] Structural scoring + embedding classifier + LLM tiebreaker
+- [ ] Renumber off the colliding `F054` ID
+- Spec: `docs/features/F054-decision-admission-gate.md`
 
 ### Weaviate backend (F048 P2)
 - [ ] Implement `vectordb/weaviate.py` with native hybrid search

--- a/a2a/config.py
+++ b/a2a/config.py
@@ -147,7 +147,7 @@ class Config:
         if not path.exists():
             return cls()
 
-        content = path.read_text()
+        content = path.read_text(encoding="utf-8")
         data = yaml.safe_load(content)
         if not data:
             return cls()

--- a/a2a/cstp/attribution_service.py
+++ b/a2a/cstp/attribution_service.py
@@ -106,7 +106,7 @@ async def find_pending_decisions(
 
     for yaml_file in base.rglob("*-decision-*.yaml"):
         try:
-            with open(yaml_file) as f:
+            with open(yaml_file, encoding="utf-8") as f:
                 data = yaml.safe_load(f)
 
             if not data:
@@ -195,7 +195,7 @@ async def update_decision_outcome(
         return True
 
     try:
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
 
         data["status"] = "reviewed"
@@ -207,7 +207,7 @@ async def update_decision_outcome(
         # Atomic write
         temp_fd, temp_path = tempfile.mkstemp(suffix=".yaml", dir=path.parent)
         try:
-            with os.fdopen(temp_fd, "w") as f:
+            with os.fdopen(temp_fd, "w", encoding="utf-8") as f:
                 yaml.dump(data, f, default_flow_style=False, sort_keys=False)
             os.replace(temp_path, path)
             return True

--- a/a2a/cstp/calibration_service.py
+++ b/a2a/cstp/calibration_service.py
@@ -270,7 +270,7 @@ async def _scan_decisions(
 
     for yaml_file in base.rglob("*-decision-*.yaml"):
         try:
-            with open(yaml_file) as f:
+            with open(yaml_file, encoding="utf-8") as f:
                 data = yaml.safe_load(f)
 
             if not data:

--- a/a2a/cstp/compaction_service.py
+++ b/a2a/cstp/compaction_service.py
@@ -359,7 +359,7 @@ async def set_preserve(
             dir=file_path.parent,
         )
         try:
-            with os.fdopen(temp_fd, "w") as f:
+            with os.fdopen(temp_fd, "w", encoding="utf-8") as f:
                 yaml.dump(data, f, default_flow_style=False, sort_keys=False)
             os.replace(temp_path, file_path)
         except Exception:

--- a/a2a/cstp/decision_service.py
+++ b/a2a/cstp/decision_service.py
@@ -762,7 +762,7 @@ def write_decision_file(
     filename = f"{now.strftime('%Y-%m-%d')}-decision-{decision_id}.yaml"
     file_path = year_month_dir / filename
 
-    with open(file_path, "w") as f:
+    with open(file_path, "w", encoding="utf-8") as f:
         yaml.dump(decision_data, f, default_flow_style=False, sort_keys=False)
 
     return str(file_path)
@@ -842,7 +842,7 @@ async def get_decision(request: GetDecisionRequest) -> GetDecisionResponse:
     # Read the first match
     yaml_file = matches[0]
     try:
-        with open(yaml_file) as f:
+        with open(yaml_file, encoding="utf-8") as f:
             data = yaml.safe_load(f)
 
         if not data:
@@ -1167,7 +1167,7 @@ async def find_decision(
     # Search pattern: decisions/YYYY/MM/*-decision-{id}.yaml
     for yaml_file in base.rglob(f"*-decision-{decision_id}.yaml"):
         try:
-            with open(yaml_file) as f:
+            with open(yaml_file, encoding="utf-8") as f:
                 data = yaml.safe_load(f)
             return (yaml_file, data)
         except Exception as e:
@@ -1339,7 +1339,7 @@ async def update_decision(
 
     # Write back
     try:
-        with open(file_path, "w") as f:
+        with open(file_path, "w", encoding="utf-8") as f:
             yaml.dump(data, f, default_flow_style=False, sort_keys=False)
     except Exception as e:
         return {"success": False, "error": f"Failed to write: {e}"}
@@ -1404,7 +1404,7 @@ async def append_thought(
 
     # Write back
     try:
-        with open(file_path, "w") as f:
+        with open(file_path, "w", encoding="utf-8") as f:
             yaml.dump(data, f, default_flow_style=False, sort_keys=False)
     except Exception as e:
         return {"success": False, "error": f"Failed to write: {e}"}
@@ -1481,7 +1481,7 @@ async def review_decision(
             dir=path.parent,
         )
         try:
-            with os.fdopen(temp_fd, "w") as f:
+            with os.fdopen(temp_fd, "w", encoding="utf-8") as f:
                 yaml.dump(data, f, default_flow_style=False, sort_keys=False)
             os.replace(temp_path, path)
         except Exception:

--- a/a2a/cstp/embeddings/gemini.py
+++ b/a2a/cstp/embeddings/gemini.py
@@ -44,7 +44,7 @@ def _load_gemini_key() -> str:
     for path in _get_secrets_paths():
         gemini_env = path / "gemini.env"
         if gemini_env.exists():
-            for line in gemini_env.read_text().splitlines():
+            for line in gemini_env.read_text(encoding="utf-8").splitlines():
                 if line.startswith("GEMINI_API_KEY="):
                     _cached_api_key = line.split("=", 1)[1].strip().strip('"').strip("'")
                     return _cached_api_key

--- a/a2a/cstp/guardrails_service.py
+++ b/a2a/cstp/guardrails_service.py
@@ -450,7 +450,7 @@ def _load_guardrails_from_paths(paths: list[Path]) -> list[Guardrail]:
             continue
         for yaml_path in dir_path.glob("*.yaml"):
             try:
-                content = yaml_path.read_text()
+                content = yaml_path.read_text(encoding="utf-8")
 
                 # Use PyYAML if available (preferred)
                 try:

--- a/a2a/cstp/provenance/mapping.py
+++ b/a2a/cstp/provenance/mapping.py
@@ -62,8 +62,10 @@ def load_rules(mappings_dir: Path = MAPPINGS_DIR) -> list[dict]:
     """
     all_rules = []
     for yaml_file in sorted(mappings_dir.glob("*.yaml")):
-        with open(yaml_file) as f:
-            data = yaml.safe_load(f)
+        # encoding is explicit: the rule files carry non-ASCII control text that
+        # reaches auditor-facing bundles, and the platform default (cp1252 on
+        # Windows) mis-decodes it silently rather than raising.
+        data = yaml.safe_load(yaml_file.read_text(encoding="utf-8"))
         framework = data.get("framework", yaml_file.stem)
         file_evidence_class = data.get("evidence_class", "observed")
         for rule in data.get("rules", []):

--- a/a2a/cstp/query_service.py
+++ b/a2a/cstp/query_service.py
@@ -266,7 +266,7 @@ async def load_all_decisions(
 
     for yaml_file in base.rglob("*-decision-*.yaml"):
         try:
-            with open(yaml_file) as f:
+            with open(yaml_file, encoding="utf-8") as f:
                 data = yaml.safe_load(f)
 
             if not data:

--- a/a2a/cstp/reason_stats_service.py
+++ b/a2a/cstp/reason_stats_service.py
@@ -220,7 +220,7 @@ async def load_decisions_with_reasons(
 
     for yaml_file in base.rglob("*-decision-*.yaml"):
         try:
-            with open(yaml_file) as f:
+            with open(yaml_file, encoding="utf-8") as f:
                 data = yaml.safe_load(f)
 
             if not data:

--- a/a2a/cstp/storage/migrate.py
+++ b/a2a/cstp/storage/migrate.py
@@ -32,7 +32,7 @@ def _parse_yaml_decision(yaml_file: Path) -> tuple[str, dict[str, Any]] | None:
         Tuple of (decision_id, data_dict) or None if parsing fails.
     """
     try:
-        with open(yaml_file) as f:
+        with open(yaml_file, encoding="utf-8") as f:
             data = yaml.safe_load(f)
 
         if not data or not isinstance(data, dict):

--- a/a2a/cstp/storage/yaml_fs.py
+++ b/a2a/cstp/storage/yaml_fs.py
@@ -69,7 +69,7 @@ class YAMLFileSystemStore(DecisionStore):
         try:
             fd, temp_path = tempfile.mkstemp(suffix=".yaml", dir=str(year_month_dir))
             try:
-                with os.fdopen(fd, "w") as f:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
                     yaml.dump(data, f, default_flow_style=False, sort_keys=False)
                 os.replace(temp_path, file_path)
             except Exception:
@@ -208,7 +208,7 @@ class YAMLFileSystemStore(DecisionStore):
         pattern = f"*-decision-{decision_id}.yaml"
         for yaml_file in self._base.rglob(pattern):
             try:
-                with open(yaml_file) as f:
+                with open(yaml_file, encoding="utf-8") as f:
                     data = yaml.safe_load(f)
                 if data:
                     return (yaml_file, data)
@@ -225,7 +225,7 @@ class YAMLFileSystemStore(DecisionStore):
 
         for yaml_file in self._base.rglob("*-decision-*.yaml"):
             try:
-                with open(yaml_file) as f:
+                with open(yaml_file, encoding="utf-8") as f:
                     data = yaml.safe_load(f)
                 if not data:
                     continue
@@ -251,7 +251,7 @@ class YAMLFileSystemStore(DecisionStore):
                 suffix=".yaml", dir=str(file_path.parent)
             )
             try:
-                with os.fdopen(fd, "w") as f:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
                     yaml.dump(data, f, default_flow_style=False, sort_keys=False)
                 os.replace(temp_path, file_path)
             except Exception:

--- a/docs/features/F054-decision-admission-gate.md
+++ b/docs/features/F054-decision-admission-gate.md
@@ -1,5 +1,8 @@
 # F054 — Decision Admission Gate
 
+> **⚠️ ID collision:** the `F054` number is also used by [CEL Expression Guardrails](F054-cel-guardrails.md),
+> which has shipped. This spec is tracked as **F054-b** in `INDEX.md` until it is renumbered.
+>
 > **Status:** Draft v1
 > **Priority:** P1
 > **Depends on:** F027 (Decision Quality), F050 (SQLite Storage)

--- a/docs/features/INDEX.md
+++ b/docs/features/INDEX.md
@@ -34,6 +34,14 @@ All feature specs live in `docs/features/`. One file per feature, consistent nam
 | F044 | Agent Work Discovery | v0.12.0 | `F044-agent-work-discovery.md` |
 | F045 | Decision Graph Storage Layer | v0.12.0 | `F045-graph-storage-layer.md` |
 | F048 | Multi-Vector-DB Support | v0.12.0 | `F048-multi-vectordb.md` |
+| F049 | Live Deliberation Viewer | v0.14.0 | *(in changelog, no standalone spec)* |
+| F050 | SQLite Storage Layer | v0.15.0 | `F050-*` |
+| F030 | Circuit Breaker Guardrails | v0.16.0 (unreleased) | `F030-circuit-breaker-guardrails.md` |
+| F051 | Docker-Compose Full Stack Demo | v0.16.0 (unreleased) | `F051-docker-compose-demo.md` |
+| F054 | CEL Expression Guardrails | v0.16.0 (unreleased) | `F054-cel-guardrails.md` |
+| F055 | Decision Provenance & Control Evidence | v0.16.0 (unreleased) | `../../website/specs/f055-decision-provenance.md` |
+
+*v0.16.0 features are merged to `main`; `pyproject.toml` still reports `0.15.0` and no tag has been cut.*
 
 ## Roadmap
 
@@ -41,7 +49,7 @@ All feature specs live in `docs/features/`. One file per feature, consistent nam
 |----|---------|--------|------|
 | F020 | Structured Reasoning Traces | Internal | `F020-reasoning-traces.md` |
 | F029 | Task Router | MIT/Google Scaling Research | `F029-task-router.md` |
-| F030 | Circuit Breaker Guardrails | AutoGPT + ai16z | `F030-circuit-breaker-guardrails.md` |
+| ~~F030~~ | ~~Circuit Breaker Guardrails~~ | ~~AutoGPT + ai16z~~ | *Shipped in v0.16.0 (unreleased)* |
 | F031 | Source Trust Scoring | ai16z Trust Scores | `F031-source-trust-scoring.md` |
 | F032 | Error Amplification Tracking | MIT 17.2x Error Finding | `F032-error-amplification-tracking.md` |
 | F033 | Censor Layer | Minsky Ch 27 | `F033-censor-layer.md` |
@@ -62,9 +70,18 @@ All feature specs live in `docs/features/`. One file per feature, consistent nam
 | ~~F048~~ | ~~Multi-Vector-DB Support~~ | ~~Infrastructure~~ | *Shipped in v0.12.0* |
 | ~~F049~~ | ~~Live Deliberation Viewer~~ | ~~Dashboard + debugTracker~~ | *Shipped in v0.14.0* |
 | ~~F050~~ | ~~SQLite Storage Layer~~ | ~~Infrastructure~~ | *Shipped in v0.15.0* |
-| F051 | Docker-Compose Full Stack Demo | Adoption | `F051-docker-compose-demo.md` |
+| ~~F051~~ | ~~Docker-Compose Full Stack Demo~~ | ~~Adoption~~ | *Shipped in v0.16.0 (unreleased)* |
 | F052 | Pre-Built Decision Quality Dashboard | Observability | `F052-dashboard-export.md` |
 | F053 | Query Deduplication Cache | Performance | `F053-query-deduplication.md` |
+| ~~F054~~ | ~~CEL Expression Guardrails~~ | ~~Acteon Action Gateway~~ | *Shipped in v0.16.0 (unreleased)* |
+| F054-b | Decision Admission Gate | Decision logging pollution | `F054-decision-admission-gate.md` |
+| ~~F055~~ | ~~Decision Provenance & Control Evidence~~ | ~~SR 11-7 / NIST AI RMF~~ | *Shipped in v0.16.0 (unreleased)* |
+
+## ID Conflicts
+
+| ID | Note |
+|----|------|
+| F054 | Two specs claim this number: `F054-cel-guardrails.md` (shipped) and `F054-decision-admission-gate.md` (draft). The latter is tracked as **F054-b** until renumbered — same convention used previously for F031-b. |
 
 ## Retired IDs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,5 +85,9 @@ line-length = 100
 target-version = "py311"
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "N", "W", "UP", "B", "C4", "SIM"]
+# PLW1514 (text IO must name an encoding) is preview-gated; explicit-preview-rules
+# keeps it opt-in without enabling the rest of the preview ruleset.
+preview = true
+explicit-preview-rules = true
+select = ["E", "F", "I", "N", "W", "UP", "B", "C4", "SIM", "PLW1514"]
 ignore = ["E501", "SIM108", "I001", "UP045", "SIM110", "SIM105", "SIM102"]  # Ignore style rules that require refactoring

--- a/scripts/cstp.py
+++ b/scripts/cstp.py
@@ -35,7 +35,7 @@ def load_config() -> tuple[str, str]:
     """Load CSTP config from .secrets/cstp.env."""
     env_path = Path(__file__).parent.parent / ".secrets" / "cstp.env"
     if env_path.exists():
-        for line in env_path.read_text().splitlines():
+        for line in env_path.read_text(encoding="utf-8").splitlines():
             if "=" in line and not line.startswith("#"):
                 key, value = line.split("=", 1)
                 os.environ.setdefault(key.strip(), value.strip())

--- a/src/cognition_engines/accelerators/semantic_index.py
+++ b/src/cognition_engines/accelerators/semantic_index.py
@@ -34,7 +34,7 @@ def load_gemini_key() -> str:
 
     for path in secrets_paths:
         if path.exists():
-            for line in path.read_text().splitlines():
+            for line in path.read_text(encoding="utf-8").splitlines():
                 if line.startswith("GEMINI_API_KEY="):
                     GEMINI_API_KEY = line.split("=", 1)[1].strip().strip('"').strip("'")
                     return GEMINI_API_KEY

--- a/src/cognition_engines/guardrails/audit.py
+++ b/src/cognition_engines/guardrails/audit.py
@@ -117,7 +117,7 @@ class AuditLog:
         filename = f"{date_str}-{record.decision_id}.json"
 
         path = self.log_dir / filename
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8") as f:
             json.dump(record.to_dict(), f, indent=2)
 
     def query_violations(
@@ -144,7 +144,7 @@ class AuditLog:
                 continue  # Skip files older than cutoff
 
             try:
-                with open(path) as f:
+                with open(path, encoding="utf-8") as f:
                     record = json.load(f)
 
                 for eval in record.get("evaluations", []):
@@ -178,7 +178,7 @@ class AuditLog:
 
         for path in self.log_dir.glob("*.json"):
             try:
-                with open(path) as f:
+                with open(path, encoding="utf-8") as f:
                     record = json.load(f)
 
                 total_decisions += 1

--- a/src/cognition_engines/guardrails/engine.py
+++ b/src/cognition_engines/guardrails/engine.py
@@ -341,7 +341,7 @@ class GuardrailEngine:
 
     def load_from_file(self, path: Path) -> int:
         """Load guardrails from YAML file."""
-        content = path.read_text()
+        content = path.read_text(encoding="utf-8")
         return self.load_from_yaml(content)
 
     def load_from_directory(self, directory: Path) -> int:
@@ -359,7 +359,7 @@ class GuardrailEngine:
 
     def _load_from_file_dedup(self, path: Path, existing_ids: set) -> int:
         """Load guardrails from file, skipping duplicates."""
-        content = path.read_text()
+        content = path.read_text(encoding="utf-8")
         data = None
 
         try:

--- a/src/cognition_engines/patterns/detector.py
+++ b/src/cognition_engines/patterns/detector.py
@@ -133,7 +133,7 @@ class PatternDetector:
 
         for path in yaml_files:
             try:
-                content = path.read_text()
+                content = path.read_text(encoding="utf-8")
                 data = self._parse_yaml(content)
                 if data and isinstance(data, dict):
                     if "decision" in data or "title" in data:

--- a/tests/test_attribution_service.py
+++ b/tests/test_attribution_service.py
@@ -42,7 +42,7 @@ def create_pending_decision(
         data["pr"] = pr
 
     file_path = year_dir / f"2026-02-05-decision-{decision_id}.yaml"
-    with open(file_path, "w") as f:
+    with open(file_path, "w", encoding="utf-8") as f:
         yaml.dump(data, f)
 
     return file_path
@@ -108,10 +108,10 @@ class TestFindPendingDecisions:
         path = create_pending_decision(tmp_path, "dec1", "owner/repo", pr=1)
 
         # Mark as reviewed
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
         data["status"] = "reviewed"
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8") as f:
             yaml.dump(data, f)
 
         results = await find_pending_decisions(
@@ -195,7 +195,7 @@ class TestUpdateDecisionOutcome:
         assert result is True
 
         # Verify file was updated
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
 
         assert data["status"] == "reviewed"
@@ -218,7 +218,7 @@ class TestUpdateDecisionOutcome:
         assert result is True
 
         # Verify file was NOT updated
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
 
         assert data["status"] == "pending"
@@ -276,6 +276,6 @@ class TestAttributeOutcomes:
         assert len(response.decisions) == 1
 
         # Verify file was NOT modified
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
         assert data["status"] == "pending"

--- a/tests/test_calibration_service.py
+++ b/tests/test_calibration_service.py
@@ -51,7 +51,7 @@ def create_decision(
     }
 
     file_path = year_dir / f"2026-02-05-decision-{decision_id}.yaml"
-    with open(file_path, "w") as f:
+    with open(file_path, "w", encoding="utf-8") as f:
         yaml.dump(data, f)
 
 
@@ -402,5 +402,5 @@ def create_decision_with_project(
         data["feature"] = feature
 
     file_path = year_dir / f"2026-02-05-decision-{decision_id}.yaml"
-    with open(file_path, "w") as f:
+    with open(file_path, "w", encoding="utf-8") as f:
         yaml.dump(data, f)

--- a/tests/test_decision_service.py
+++ b/tests/test_decision_service.py
@@ -286,7 +286,7 @@ class TestWriteDecisionFile:
         assert path.endswith(".yaml")
 
         # Verify content
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             loaded = yaml.safe_load(f)
         assert loaded["id"] == "test1234"
         assert loaded["summary"] == "Test decision"
@@ -393,7 +393,7 @@ class TestRecordDecision:
 
         response = await record_decision(req, decisions_path=str(tmp_path))
 
-        with open(response.path) as f:
+        with open(response.path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
 
         assert data["summary"] == "Use Redis for caching"

--- a/tests/test_f007_record_decision.py
+++ b/tests/test_f007_record_decision.py
@@ -179,7 +179,7 @@ class TestRecordDecisionEndpoint:
 
         # Read the file and verify agent_id
         import yaml
-        with open(response.result["path"]) as f:
+        with open(response.result["path"], encoding="utf-8") as f:
             data = yaml.safe_load(f)
         assert data.get("recorded_by") == "my-agent-id"
 

--- a/tests/test_f008_review_decision.py
+++ b/tests/test_f008_review_decision.py
@@ -120,7 +120,7 @@ class TestReviewDecision:
         assert review_response.status == "reviewed"
 
         # Verify file was updated
-        with open(review_response.path) as f:
+        with open(review_response.path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
 
         assert data["status"] == "reviewed"
@@ -164,7 +164,7 @@ class TestReviewDecision:
 
         assert review_response.success is True
 
-        with open(review_response.path) as f:
+        with open(review_response.path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
 
         assert data["affected_kpis"]["latency"] == -0.3

--- a/tests/test_f009_get_calibration.py
+++ b/tests/test_f009_get_calibration.py
@@ -52,7 +52,7 @@ def create_reviewed_decision(
     }
 
     file_path = year_dir / f"2026-02-05-decision-{decision_id}.yaml"
-    with open(file_path, "w") as f:
+    with open(file_path, "w", encoding="utf-8") as f:
         yaml.dump(data, f)
 
 

--- a/tests/test_f023_deliberation.py
+++ b/tests/test_f023_deliberation.py
@@ -274,7 +274,7 @@ class TestRecordDecisionWithDeliberation:
             path = write_decision_file(yaml_data, decision_id, base_path=tmp)
 
             # Read back and verify
-            with open(path) as f:
+            with open(path, encoding="utf-8") as f:
                 loaded = yaml.safe_load(f)
 
             assert "deliberation" in loaded

--- a/tests/test_f030_circuit_breaker.py
+++ b/tests/test_f030_circuit_breaker.py
@@ -382,7 +382,7 @@ class TestPersistence:
         await mgr.record_outcome(_ctx(), "failure")
 
         assert jsonl.exists()
-        lines = jsonl.read_text().strip().split("\n")
+        lines = jsonl.read_text(encoding="utf-8").strip().split("\n")
         assert len(lines) >= 1
         data = json.loads(lines[-1])
         assert data["scope"] == "global"
@@ -442,7 +442,7 @@ class TestPersistence:
             "last_notification": None,
             "last_activity": 1001.0,
         })
-        jsonl.write_text(f"{valid1}\nNOT VALID JSON\n{valid2}\n")
+        jsonl.write_text(f"{valid1}\nNOT VALID JSON\n{valid2}\n", encoding="utf-8")
 
         configs = {"global": _config()}
         breakers = _load_breakers_from_jsonl(jsonl, configs)
@@ -481,7 +481,7 @@ class TestPersistence:
         }
         _save_all_breakers(breakers, jsonl)
 
-        lines = jsonl.read_text().strip().split("\n")
+        lines = jsonl.read_text(encoding="utf-8").strip().split("\n")
         assert len(lines) == 2
         scopes = {json.loads(line)["scope"] for line in lines}
         assert scopes == {"global", "category:arch"}
@@ -915,7 +915,8 @@ class TestConfigLoading:
             "    cooldown_ms: 3600000\n"
             "    notify: true\n"
             "  - scope: 'global'\n"
-            "    failure_threshold: 10\n"
+            "    failure_threshold: 10\n",
+            encoding="utf-8",
         )
 
         configs = load_breaker_configs(yaml_file)
@@ -942,7 +943,8 @@ class TestConfigLoading:
             "  - scope: 'global'\n"
             "    failure_threshold: 5\n"
             "  - 'not a dict'\n"
-            "  - scope: 'stakes:high'\n"
+            "  - scope: 'stakes:high'\n",
+            encoding="utf-8",
         )
 
         configs = load_breaker_configs(yaml_file)
@@ -954,7 +956,7 @@ class TestConfigLoading:
 
     def test_empty_yaml_file(self, tmp_path: Path) -> None:
         yaml_file = tmp_path / "empty.yaml"
-        yaml_file.write_text("")
+        yaml_file.write_text("", encoding="utf-8")
         configs = load_breaker_configs(yaml_file)
         assert configs == []
 

--- a/tests/test_f041_compaction.py
+++ b/tests/test_f041_compaction.py
@@ -662,7 +662,7 @@ class TestSetPreserve:
             "category": "architecture",
             "status": "reviewed",
         }
-        with open(decision_file, "w") as f:
+        with open(decision_file, "w", encoding="utf-8") as f:
             yaml.dump(data, f)
 
         # Patch DECISIONS_PATH
@@ -681,7 +681,7 @@ class TestSetPreserve:
             assert resp.preserve is True
 
             # Verify file updated
-            with open(decision_file) as f:
+            with open(decision_file, encoding="utf-8") as f:
                 updated = yaml.safe_load(f)
             assert updated["preserve"] is True
         finally:
@@ -721,7 +721,7 @@ class TestSetPreserve:
             "summary": "Test",
             "preserve": True,
         }
-        with open(decision_file, "w") as f:
+        with open(decision_file, "w", encoding="utf-8") as f:
             yaml.dump(data, f)
 
         old_path = ds.DECISIONS_PATH
@@ -732,7 +732,7 @@ class TestSetPreserve:
             assert resp.success is True
             assert resp.preserve is False
 
-            with open(decision_file) as f:
+            with open(decision_file, encoding="utf-8") as f:
                 updated = yaml.safe_load(f)
             assert "preserve" not in updated
         finally:

--- a/tests/test_f045_graph_store.py
+++ b/tests/test_f045_graph_store.py
@@ -109,7 +109,7 @@ class TestJsonlPersistence:
 
     def test_load_empty_file(self, tmp_path: Path) -> None:
         path = tmp_path / "empty.jsonl"
-        path.write_text("")
+        path.write_text("", encoding="utf-8")
         loaded = load_edges_from_jsonl(path)
         assert loaded == []
 
@@ -118,7 +118,8 @@ class TestJsonlPersistence:
         path.write_text(
             '{"source_id": "a", "target_id": "b", "edge_type": "relates_to"}\n'
             "not json\n"
-            '{"source_id": "c", "target_id": "d", "edge_type": "depends_on"}\n'
+            '{"source_id": "c", "target_id": "d", "edge_type": "depends_on"}\n',
+            encoding="utf-8",
         )
         loaded = load_edges_from_jsonl(path)
         assert len(loaded) == 2

--- a/tests/test_f050_migration.py
+++ b/tests/test_f050_migration.py
@@ -34,7 +34,7 @@ def _write_yaml_decision(
     subdir.mkdir(parents=True, exist_ok=True)
     filename = f"{date}-decision-{decision_id}.yaml"
     filepath = subdir / filename
-    filepath.write_text(yaml.dump(data, default_flow_style=False))
+    filepath.write_text(yaml.dump(data, default_flow_style=False), encoding="utf-8")
     return filepath
 
 
@@ -102,12 +102,12 @@ class TestParseYamlDecision:
 
     def test_returns_none_for_empty_file(self, tmp_path: Path) -> None:
         empty = tmp_path / "2026-02-18-decision-empty123.yaml"
-        empty.write_text("")
+        empty.write_text("", encoding="utf-8")
         assert _parse_yaml_decision(empty) is None
 
     def test_returns_none_for_invalid_yaml(self, tmp_path: Path) -> None:
         bad = tmp_path / "2026-02-18-decision-bad12345.yaml"
-        bad.write_text(": : : invalid yaml [[[")
+        bad.write_text(": : : invalid yaml [[[", encoding="utf-8")
         # Should not raise, returns None
         result = _parse_yaml_decision(bad)
         # yaml.safe_load may parse this oddly or return None
@@ -116,7 +116,7 @@ class TestParseYamlDecision:
 
     def test_returns_none_for_non_dict(self, tmp_path: Path) -> None:
         scalar = tmp_path / "2026-02-18-decision-scalar1.yaml"
-        scalar.write_text("just a string")
+        scalar.write_text("just a string", encoding="utf-8")
         assert _parse_yaml_decision(scalar) is None
 
 
@@ -162,7 +162,7 @@ class TestMigrateYamlToStore:
     async def test_skips_malformed_files(self, decisions_dir: Path) -> None:
         # Add a malformed file
         bad = decisions_dir / "2026" / "02" / "2026-02-18-decision-bad00000.yaml"
-        bad.write_text("")
+        bad.write_text("", encoding="utf-8")
 
         store = MemoryDecisionStore()
         await store.initialize()

--- a/tests/test_f054_cel_guardrails.py
+++ b/tests/test_f054_cel_guardrails.py
@@ -312,7 +312,7 @@ async def test_cel_string_blocks(tmp_path):
   action: block
   message: High stakes blocked
 """
-    (tmp_path / "test.yaml").write_text(yaml_content)
+    (tmp_path / "test.yaml").write_text(yaml_content, encoding="utf-8")
 
     result = await evaluate_guardrails({"stakes": "high"}, guardrails_dir=tmp_path)
     assert not result.allowed
@@ -328,7 +328,7 @@ async def test_cel_string_allows_when_not_triggered(tmp_path):
   condition: "action.stakes == 'high'"
   action: block
 """
-    (tmp_path / "test.yaml").write_text(yaml_content)
+    (tmp_path / "test.yaml").write_text(yaml_content, encoding="utf-8")
 
     result = await evaluate_guardrails({"stakes": "medium"}, guardrails_dir=tmp_path)
     assert result.allowed
@@ -346,7 +346,7 @@ async def test_cel_dict_condition(tmp_path):
   action: warn
   message: Low confidence warning
 """
-    (tmp_path / "test.yaml").write_text(yaml_content)
+    (tmp_path / "test.yaml").write_text(yaml_content, encoding="utf-8")
 
     result = await evaluate_guardrails({"confidence": 0.3}, guardrails_dir=tmp_path)
     assert result.allowed  # warn does not block
@@ -366,7 +366,7 @@ async def test_legacy_jsonb_dict_auto_converts(tmp_path):
   action: block
   message: Legacy JSONB converted
 """
-    (tmp_path / "test.yaml").write_text(yaml_content)
+    (tmp_path / "test.yaml").write_text(yaml_content, encoding="utf-8")
 
     # Should block: high stakes + low confidence
     result = await evaluate_guardrails(
@@ -391,7 +391,7 @@ async def test_context_dict_via_cel(tmp_path):
   action: block
   message: Architecture review required
 """
-    (tmp_path / "test.yaml").write_text(yaml_content)
+    (tmp_path / "test.yaml").write_text(yaml_content, encoding="utf-8")
 
     # No review → blocked
     result = await evaluate_guardrails(
@@ -418,7 +418,7 @@ async def test_invalid_cel_fails_open(tmp_path):
   action: block
   message: Should not appear
 """
-    (tmp_path / "test.yaml").write_text(yaml_content)
+    (tmp_path / "test.yaml").write_text(yaml_content, encoding="utf-8")
 
     result = await evaluate_guardrails({"stakes": "high"}, guardrails_dir=tmp_path)
     assert result.allowed  # fail open
@@ -436,7 +436,7 @@ async def test_legacy_flat_format_still_works(tmp_path):
   action: block
   message: Legacy flat blocked
 """
-    (tmp_path / "test.yaml").write_text(yaml_content)
+    (tmp_path / "test.yaml").write_text(yaml_content, encoding="utf-8")
 
     result = await evaluate_guardrails(
         {"stakes": "high", "confidence": 0.3}, guardrails_dir=tmp_path
@@ -456,7 +456,7 @@ async def test_legacy_requires_still_works(tmp_path):
   action: block
   message: Code review required
 """
-    (tmp_path / "test.yaml").write_text(yaml_content)
+    (tmp_path / "test.yaml").write_text(yaml_content, encoding="utf-8")
 
     # code_review missing → blocked
     result = await evaluate_guardrails({"category": "tooling"}, guardrails_dir=tmp_path)
@@ -478,7 +478,7 @@ async def test_mcp_context_forwarded_to_cel(tmp_path):
   condition: "action.category == 'architecture' && !action.context.architecture_review"
   action: block
 """
-    (tmp_path / "test.yaml").write_text(yaml_content)
+    (tmp_path / "test.yaml").write_text(yaml_content, encoding="utf-8")
 
     # Simulate how _handle_check_action builds the flat context:
     # context dict items merged at top level
@@ -503,7 +503,7 @@ async def test_warn_action_does_not_block(tmp_path):
   action: warn
   message: High stakes warning
 """
-    (tmp_path / "test.yaml").write_text(yaml_content)
+    (tmp_path / "test.yaml").write_text(yaml_content, encoding="utf-8")
 
     result = await evaluate_guardrails({"stakes": "high"}, guardrails_dir=tmp_path)
     assert result.allowed  # warn doesn't block
@@ -519,7 +519,7 @@ async def test_complex_in_expression(tmp_path):
   condition: "action.stakes in ['high', 'critical']"
   action: block
 """
-    (tmp_path / "test.yaml").write_text(yaml_content)
+    (tmp_path / "test.yaml").write_text(yaml_content, encoding="utf-8")
 
     result_high = await evaluate_guardrails({"stakes": "high"}, guardrails_dir=tmp_path)
     assert not result_high.allowed

--- a/tests/test_f055_provenance_service.py
+++ b/tests/test_f055_provenance_service.py
@@ -20,6 +20,8 @@ Finding 8 — human actor signal required:
   now include actor_is_human=True and human_approval_count as appropriate.
 """
 
+import builtins
+import io
 import json
 import sqlite3
 import threading
@@ -532,6 +534,45 @@ class TestLoadRules:
         frameworks = {r["_framework"] for r in rules}
         assert "CSTP Attested" in frameworks
 
+    def test_rules_preserve_non_ascii_under_non_utf8_default_encoding(self, monkeypatch):
+        """Control text must decode as UTF-8 regardless of the platform default.
+
+        The mapping YAML files contain em-dashes in control_name and reason text,
+        and that text is copied verbatim into auditor-facing bundles. If load_rules
+        relies on the ambient locale encoding, a cp1252 host (Windows) silently
+        decodes those bytes as mojibake instead of raising — a corrupted regulatory
+        citation in a compliance artifact.
+
+        Simulates a cp1252 host by forcing that encoding on any text-mode open
+        that does not name one, so the test fails on UTF-8 platforms too.
+        """
+        real_open = io.open
+
+        def cp1252_default_open(
+            file, mode="r", buffering=-1, encoding=None, *args, **kwargs
+        ):
+            # Path.open() resolves an unspecified encoding to the sentinel
+            # "locale" before delegating, so both spellings mean "ambient default".
+            if "b" not in mode and encoding in (None, "locale"):
+                encoding = "cp1252"
+            return real_open(file, mode, buffering, encoding, *args, **kwargs)
+
+        monkeypatch.setattr(io, "open", cp1252_default_open)
+        monkeypatch.setattr(builtins, "open", cp1252_default_open)
+
+        rules = load_rules(MAPPINGS_DIR)
+
+        assert rules, "no rules loaded"
+        # U+2014 mis-decoded through cp1252 surfaces as this three-char sequence.
+        mojibake = [r for r in rules if "â€" in str(r)]
+        assert not mojibake, (
+            f"{len(mojibake)} of {len(rules)} rules decoded as mojibake — "
+            "load_rules is using the platform default encoding"
+        )
+        assert any("—" in str(r) for r in rules), (
+            "expected an em-dash somewhere in the shipped control text"
+        )
+
     def test_rules_have_required_fields(self):
         rules = load_rules(MAPPINGS_DIR)
         for rule in rules:
@@ -831,7 +872,7 @@ class TestPerClassCoverage:
         # The JSON bundle file also must not have a top-level coverage_pct
         json_path = result.get("json_path")
         assert json_path, "json_path missing from result"
-        bundle = json.loads(Path(json_path).read_text())
+        bundle = json.loads(Path(json_path).read_text(encoding="utf-8"))
         assert "coverage_pct" not in bundle, (
             "JSON bundle must not contain a top-level blended coverage_pct."
         )
@@ -1197,7 +1238,7 @@ class TestExportEvidenceBundle:
             "output_dir": str(tmp_path / "bundles"),
         }
         result = await export_evidence_bundle(params, "agent-1")
-        bundle = json.loads(Path(result["json_path"]).read_text())
+        bundle = json.loads(Path(result["json_path"]).read_text(encoding="utf-8"))
         for field in [
             "version", "tool_version", "generated_at", "chain_head_hash",
             "chain_intact", "coverage", "total_events",
@@ -1215,7 +1256,7 @@ class TestExportEvidenceBundle:
             "output_dir": str(tmp_path / "bundles"),
         }
         result = await export_evidence_bundle(params, "agent-1")
-        bundle = json.loads(Path(result["json_path"]).read_text())
+        bundle = json.loads(Path(result["json_path"]).read_text(encoding="utf-8"))
         assert "coverage_pct" not in bundle, (
             "JSON bundle must not have a blended coverage_pct at the top level"
         )
@@ -1467,7 +1508,7 @@ class TestEndToEndWorkflow:
             "output_dir": output_dir,
         }, "test-agent")
         assert export_result["chain_intact"] is True
-        bundle = json.loads(Path(export_result["json_path"]).read_text())
+        bundle = json.loads(Path(export_result["json_path"]).read_text(encoding="utf-8"))
         assert "coverage_pct" not in bundle  # No blended metric in JSON bundle
         assert bundle["coverage"]["observed"]["total_events"] == 3
 

--- a/tests/test_get_decision.py
+++ b/tests/test_get_decision.py
@@ -43,7 +43,7 @@ def decisions_dir():
         }
 
         filepath = month_dir / "2026-02-08-decision-abc12345.yaml"
-        with open(filepath, "w") as f:
+        with open(filepath, "w", encoding="utf-8") as f:
             yaml.dump(decision_data, f, default_flow_style=False)
 
         # Write another decision
@@ -59,7 +59,7 @@ def decisions_dir():
         }
 
         filepath_2 = month_dir / "2026-02-07-decision-def67890.yaml"
-        with open(filepath_2, "w") as f:
+        with open(filepath_2, "w", encoding="utf-8") as f:
             yaml.dump(decision_data_2, f, default_flow_style=False)
 
         yield tmpdir

--- a/tests/test_guardrails_service.py
+++ b/tests/test_guardrails_service.py
@@ -177,7 +177,7 @@ class TestEvaluateGuardrails:
   condition_confidence: "< 0.5"
   action: block
   message: High stakes decisions require confidence >= 0.5
-""")
+""", encoding="utf-8")
 
         # Should pass with high confidence
         result = await evaluate_guardrails(

--- a/tests/test_reason_stats.py
+++ b/tests/test_reason_stats.py
@@ -52,7 +52,7 @@ def _write_decision(tmp_dir: Path, decision_id: str, data: dict) -> None:
     year_dir = tmp_dir / "2026" / "02"
     year_dir.mkdir(parents=True, exist_ok=True)
     filepath = year_dir / f"2026-02-08-decision-{decision_id}.yaml"
-    with open(filepath, "w") as f:
+    with open(filepath, "w", encoding="utf-8") as f:
         yaml.dump(data, f)
 
 

--- a/website/.vitepress/config.mjs
+++ b/website/.vitepress/config.mjs
@@ -133,12 +133,19 @@ export default defineConfig({
           ]
         },
         {
+          text: 'v0.16.0 (F030, F054–F055)',
+          items: [
+            { text: 'F030 - Circuit Breaker Guardrails', link: '/specs/f030-circuit-breaker-guardrails' },
+            { text: 'F054 - CEL Expression Guardrails', link: '/specs/f054-cel-guardrails' },
+            { text: 'F055 - Decision Provenance', link: '/specs/f055-decision-provenance' },
+          ]
+        },
+        {
           text: 'Roadmap: Research',
           collapsed: true,
           items: [
             { text: 'F020 - Reasoning Traces', link: '/specs/f020-reasoning-traces' },
             { text: 'F029 - Task Router', link: '/specs/f029-task-router' },
-            { text: 'F030 - Circuit Breaker Guardrails', link: '/specs/f030-circuit-breaker-guardrails' },
             { text: 'F031 - Source Trust Scoring', link: '/specs/f031-source-trust-scoring' },
             { text: 'F032 - Error Amplification', link: '/specs/f032-error-amplification-tracking' },
           ]

--- a/website/changelog.md
+++ b/website/changelog.md
@@ -1,5 +1,70 @@
 # Changelog
 
+## v0.16.0 - Provenance, CEL Guardrails & Circuit Breakers
+*Unreleased — merged to `main`*
+
+Audit-grade decision provenance mapped to SR 11-7 and NIST AI RMF, CEL expression guardrails, circuit breakers, and the full-stack Docker demo.
+
+### F055: Decision Provenance & Control Evidence
+
+Five new JSON-RPC methods that turn CSTP's decision history into an artifact an auditor can accept. JSON-RPC only — no MCP tools.
+
+- **Two-class evidence model** — `observed` (third-party events the agent does not control) and `attested` (first-party CSTP records). Coverage is reported **separately per class**; there is no blended percentage anywhere in the API, the JSON bundle, or the PDF
+- **`cstp.ingestEvidence`** - ingest observed events (GitHub PR opens, reviews, approvals, merges) into a SHA-256 hash chain
+- **`cstp.linkEvidence`** - correlate an existing CSTP decision to observed events, stored as attested evidence
+- **`cstp.mapControls`** - run the YAML rules engine over stored evidence; returns per-class coverage, `insufficient_evidence` entries, and `attested_only_controls`
+- **`cstp.exportEvidenceBundle`** - emit the full bundle as JSON, or PDF with the optional `pdf` extra
+- **`cstp.verifyEvidenceChain`** - verify chain integrity; accepts `expected_head_hash` and falls back to the last bundle's head hash so tail truncation is detectable
+- **Control frameworks** - hand-written YAML rules for SR 11-7 (Federal Reserve MRM), NIST AI RMF 1.0, and CSTP-attested. Mappings are deliberately not ML-inferred
+- **Honest gaps** - where evidence does not support a control, the mapper emits `INSUFFICIENT_EVIDENCE` with a plain-English reason instead of stretching the mapping
+- **Separate store** - SQLite WAL database at `PROVENANCE_DB` (default `~/.cstp/provenance.db`), independent of the decision store
+
+### F055 Security Hardening
+
+13 verified findings from the PR #193 review were resolved before merge:
+
+- **Injective hash preimage** - preimage is now canonical JSON of all six fields (chain format version 2). The previous newline-delimited preimage allowed collisions on embedded newlines. **Breaking:** version 1 chains fail `verify_chain` and must be re-ingested
+- **Hash chain race** - `BEGIN IMMEDIATE` plus explicit `seq` serializes concurrent writers
+- **`db_path` RPC escape removed** - the service always uses the server-configured `PROVENANCE_DB`; callers can no longer redirect reads or writes to an arbitrary file
+- **Evidence class isolation** - mapping rules only match events of their own class
+- **Bot approvals fail closed** - MV-3 / MEASURE-2.5 require `actor_is_human`, CM-1 / MANAGE-1.1 require a human approval count above zero
+- Plus seq validation on `linkEvidence`, checkpoint state-machine fixes, non-dict payload rejection, atomic batch ingest, and collision-resistant bundle filenames
+
+### F054: CEL Expression Guardrails
+
+- **CEL conditions** - guardrail `condition` accepts a [CEL](https://github.com/google/cel-spec) expression string or `{"cel": "..."}` alongside the legacy key/value form
+- **Reaches `action.context.*`** - fixes the gap where MCP clients could not pass context, so category-specific rules like `require-architecture-review` no longer always block through MCP
+- **Legacy auto-conversion** - existing key/value conditions are converted to CEL at evaluation time; no guardrail files need changing and no migration is required
+- **Fails open** - an expression that fails to compile or raises at runtime is skipped and logged, never treated as a block
+- **Compiled once** - programs are cached per expression string
+- **New dependency** - `cel-python>=0.4,<1.0`, now a core dependency
+
+### F030: Circuit Breaker Guardrails
+
+- `cstp.listBreakers`, `cstp.getCircuitState`, `cstp.resetCircuit` and the `get_circuit_state` / `list_breakers` MCP tools
+- Category-specific code-review and architecture-review guardrails replace the earlier broad production guard
+- Guardrail `context` is now threaded through both the JSON-RPC and MCP check paths
+
+### F051: Docker-Compose Full Stack Demo
+
+- `demo/` brings up CSTP server, ChromaDB, dashboard, and a reference FORGE-protocol MCP agent
+- `demo/seed_data.py` generates sample decisions
+
+### Website
+
+- New [Nous](/nous) agent landing page, linked from the top nav
+- Mermaid removed from the VitePress build; diagrams are inline SVG
+
+### Bug Fixes
+
+- **F041** - `build_wisdom()` accepts an optional `now` parameter, removing wall-clock coupling that made the wisdom recency filter fail as fixture dates aged past the compaction threshold
+- **Encoding correctness on non-UTF-8 hosts** - every text-mode file operation across `a2a/`, `src/`, `scripts/`, and the test suite now passes `encoding="utf-8"` explicitly. Previously these relied on the platform default, which is cp1252 on Windows: F055 control rules loaded with 10 of 20 entries as mojibake, putting garbled regulatory text into auditor-facing bundles, and decision YAML could round-trip through a mis-decode into storage. Linux CI is UTF-8 by default, so none of it was visible there. Ruff `PLW1514` is now enabled to stop the defect class recurring
+
+### Packaging
+
+- `cel-python` added to core dependencies
+- New `pdf` extra (`reportlab>=4.0`) for F055 PDF bundles, included in `[all]`
+
 ## v0.15.0 - SQLite Storage & Performance
 *February 21, 2026*
 

--- a/website/reference/api.md
+++ b/website/reference/api.md
@@ -730,6 +730,265 @@ Delete and rebuild the ChromaDB collection from YAML files.
 
 ---
 
+## Provenance & Control Evidence (F055)
+
+Five methods that produce audit-grade evidence for regulated decisions. **JSON-RPC only — these
+have no MCP tool equivalents.**
+
+Evidence is stored in its own SQLite WAL database, separate from the decision store, at the path
+given by `PROVENANCE_DB` (default `~/.cstp/provenance.db`). The path is server-configured and
+cannot be overridden per request.
+
+### The Two-Class Evidence Model
+
+Every evidence record carries an `evidence_class` that is never nullable and never defaulted:
+
+| Class | Source | Trust |
+|-------|--------|-------|
+| `observed` | Third-party events from a system of record the agent does not control — GitHub PR opens, commits, reviews, approvals, merges | Hash-chained and tamper-evident |
+| `attested` | First-party CSTP decision records linked to observed events | Self-reported; an auditor discounts these |
+
+Coverage is reported **separately per class**. There is no blended `coverage_pct` in the API
+response, the JSON bundle, or the PDF — merging the two would weaken the strong half.
+
+---
+
+### `cstp.ingestEvidence` — Ingest Observed Events
+
+Append third-party events to the hash chain. All ingested events receive
+`evidence_class: "observed"`; this is not overridable. A batch is ingested atomically.
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `source` | string | ✅ | Ingest origin, e.g. `"github"` |
+| `events` | array | ✅ | Event objects with `event_type`, `ts`, and a `payload` object |
+
+**Example request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "cstp.ingestEvidence",
+  "params": {
+    "source": "github",
+    "events": [
+      {
+        "event_type": "pr_opened",
+        "ts": "2026-07-01T10:00:00Z",
+        "payload": {
+          "pr_number": 42,
+          "title": "Add risk scorer v2",
+          "is_agent_authored": true,
+          "agent_type": "Claude",
+          "approval_count": 0
+        }
+      },
+      {
+        "event_type": "pr_review_approved",
+        "ts": "2026-07-01T14:00:00Z",
+        "payload": { "pr_number": 42, "reviewer": "alice", "actor_is_human": true }
+      }
+    ]
+  },
+  "id": "ie-001"
+}
+```
+
+**Example response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "ingested": 2,
+    "head_hash": "65b58d83a0b5be919...",
+    "first_seq": 1
+  },
+  "id": "ie-001"
+}
+```
+
+---
+
+### `cstp.linkEvidence` — Correlate a Decision to Observed Events
+
+Links an existing CSTP decision to observed event sequence numbers, creating one
+`cstp_decision_linked` record with `evidence_class: "attested"`.
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `decision_id` | string | ✅ | Existing CSTP decision ID |
+| `event_seqs` | array | ✅ | Observed event `seq` values. Nonexistent, duplicate, and attested-class seqs are rejected |
+| `stakes` | string | ❌ | Stakes recorded on the attestation |
+| `has_outcome` | boolean | ❌ | Whether the decision has a reviewed outcome |
+
+**Example response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": { "linked": 3, "decision_id": "dec-7e2f9a", "attested_seq": 4 },
+  "id": "le-001"
+}
+```
+
+---
+
+### `cstp.mapControls` — Map Evidence to Control Frameworks
+
+Runs the YAML rules engine over all stored evidence. Rules only match events of their own
+evidence class.
+
+**Parameters:** none.
+
+**Example response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "coverage": {
+      "observed": { "total_events": 50, "mapped_events": 41, "unmapped_events": 9, "coverage_pct": 82.0 },
+      "attested": { "total_events": 3, "mapped_events": 3, "unmapped_events": 0, "coverage_pct": 100.0 }
+    },
+    "mappings": [
+      {
+        "seq": 1, "event_type": "pr_opened", "pr_number": 42,
+        "rule_id": "SR11-7-MV1-agent-pr-opened",
+        "framework": "SR 11-7", "stage": "Model Development",
+        "function_id": "MV-1", "control_name": "Agent-Authored Change Documentation",
+        "evidence_class": "observed", "type": "mapping"
+      }
+    ],
+    "insufficient_evidence": [
+      {
+        "seq": 10, "pr_number": 3, "framework": "SR 11-7",
+        "function_id": "MV-3", "control_name": "Independent Human Review and Approval",
+        "evidence_class": "observed", "type": "INSUFFICIENT_EVIDENCE",
+        "reason": "INSUFFICIENT EVIDENCE: Agent-authored PR was merged without any human approval..."
+      }
+    ],
+    "insufficient_evidence_count": 2,
+    "unmapped": [],
+    "attested_only_controls": ["MV-3"]
+  },
+  "id": "mc-001"
+}
+```
+
+Rules live in `a2a/cstp/provenance/mappings/`:
+
+| File | Framework | Evidence class |
+|------|-----------|----------------|
+| `sr11-7.yaml` | SR 11-7 (Federal Reserve MRM) | observed |
+| `nist-ai-rmf.yaml` | NIST AI RMF 1.0 | observed |
+| `cstp-attested.yaml` | CSTP Attested | attested |
+
+Mappings are hand-written on purpose — an ML-inferred control mapping is itself an audit
+liability. Where evidence does not honestly support a control, the engine emits
+`INSUFFICIENT_EVIDENCE` with a plain-English reason instead of stretching the mapping. Controls
+requiring human review (`MV-3`, `MEASURE-2.5`) fail closed unless `actor_is_human` is true;
+`CM-1` / `MANAGE-1.1` require a nonzero human approval count.
+
+---
+
+### `cstp.exportEvidenceBundle` — Export the Auditor Bundle
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `format` | string | ❌ | `"json"` (default) or `"pdf"`. Validated before any output directory is created |
+| `output_dir` | string | ❌ | Destination directory |
+
+PDF export requires the optional `pdf` extra (`pip install -e ".[pdf]"`, included in `[all]`).
+Without `reportlab` installed, a `format: "pdf"` request raises. Bundle filenames include a UUID
+and microsecond timestamp, so concurrent exports cannot collide.
+
+**Example response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "json_path": "/var/bundles/2026-Q3/bundle_20260809T173649Z.json",
+    "chain_head_hash": "65b58d83a0b5be919...",
+    "chain_intact": true,
+    "coverage": { "observed": {}, "attested": {} },
+    "insufficient_evidence_count": 2,
+    "attested_only_controls": ["MV-3"]
+  },
+  "id": "eb-001"
+}
+```
+
+The bundle persists `chain_head_hash` at generation time, which is what makes tail truncation
+detectable later.
+
+---
+
+### `cstp.verifyEvidenceChain` — Verify Chain Integrity
+
+**Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `expected_head_hash` | string | ❌ | Detects tail truncation. Defaults to the head hash stored by the most recent bundle export |
+
+**Example response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "intact": true,
+    "broken_at_seq": null,
+    "head_hash": "65b58d83a0b5be919...",
+    "expected_hash": "65b58d83a0b5be919...",
+    "tail_check": true
+  },
+  "id": "vc-001"
+}
+```
+
+If no hash is supplied and no bundle has ever been generated, tail-truncation detection is
+inactive and `tail_check` is `false` — internal tampering is still detected.
+
+::: warning Chain format version 2
+The hash preimage is the canonical JSON of `{seq, ts, event_type, evidence_class, payload,
+prev_hash}`. Stores written under format version 1 (newline-delimited preimage) fail
+`verify_chain` and must be re-ingested.
+:::
+
+See the [F055 spec](/specs/f055-decision-provenance) for the full evidence model and hash chain
+design.
+
+---
+
+## Methods Not Yet Documented Here
+
+The dispatcher registers 34 methods. Beyond those above, the following are live but not yet
+covered in this reference — see the linked specs for parameters and responses:
+
+| Method | Feature |
+|--------|---------|
+| `cstp.preAction` | [F046 Pre-Action Hook](/specs/f046-pre-action-hook) |
+| `cstp.getSessionContext` | [F047 Session Context](/specs/f047-session-context) |
+| `cstp.ready` | [F044 Agent Work Discovery](/specs/f044-agent-work-discovery) |
+| `cstp.linkDecisions`, `cstp.getGraph`, `cstp.getNeighbors` | [F045 Graph Storage](/specs/f045-graph-storage-layer) |
+| `cstp.compact`, `cstp.getCompacted`, `cstp.setPreserve`, `cstp.getWisdom` | [F041 Memory Compaction](/specs/f041-memory-compaction) |
+| `cstp.listDecisions`, `cstp.getStats` | F050 Structured Storage |
+| `cstp.listBreakers`, `cstp.getCircuitState`, `cstp.resetCircuit` | [F030 Circuit Breakers](/specs/f030-circuit-breaker-guardrails) |
+| `cstp.debugTracker` | Live deliberation tracker inspection |
+
+Most of these are also exposed as MCP tools — see the tool table below.
+
+---
+
 ## MCP Interface (Model Context Protocol)
 
 Since v0.9.0, CSTP exposes decision intelligence capabilities as **MCP tools** for native integration with any MCP-compliant agent. The MCP layer is a thin bridge — each tool maps 1:1 to an existing CSTP service method with zero code duplication.

--- a/website/reference/guardrails-authoring.md
+++ b/website/reference/guardrails-authoring.md
@@ -74,6 +74,101 @@ condition_decision_type: strategy_change
 | Less/equal | `field: "<= value"` | `condition_confidence: "<= 0.3"` |
 | Greater/equal | `field: ">= value"` | `condition_confidence: ">= 0.9"` |
 
+### CEL Expressions (F054) {#cel-expressions}
+
+The `condition` key accepts a [CEL](https://github.com/google/cel-spec) expression. This is the
+preferred format: it reaches any field, supports full boolean logic, and — unlike the flat
+`condition_*` keys — can read the caller-supplied `context` dict.
+
+```yaml
+# As a plain string
+- id: require-architecture-review
+  description: Architecture decisions require an architecture review
+  condition: "action.category == 'architecture' && !action.context.architecture_review"
+  action: block
+  message: "Architecture decisions require architecture_review: true"
+
+# Or as an explicit dict
+- id: no-high-stakes-low-confidence
+  description: High-stakes decisions require minimum confidence
+  condition:
+    cel: "action.stakes == 'high' && action.confidence < 0.5"
+  action: block
+  message: "High-stakes decisions require ≥50% confidence"
+```
+
+#### Activation Fields
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `action.description` | string | Defaults to `""` |
+| `action.stakes` | string | Defaults to `"medium"` |
+| `action.confidence` | double | Coerced to `0.0` when absent or null |
+| `action.category` | string | Defaults to `""` |
+| `action.tags` | list | Defaults to `[]` |
+| `action.reason_count` | int | Defaults to `0` |
+| `action.pattern` | string | Defaults to `""` |
+| `action.quality_score` | double | Defaults to `0.0` |
+| `action.has_tags` | bool | Derived from `tags` |
+| `action.has_pattern` | bool | Derived from `pattern` |
+| `action.phase`, `action.scope`, `action.project` | string | Present when the caller supplies them |
+| `action.deliberation_inputs_count`, `action.has_deliberation`, `action.has_reasoning` | — | Deliberation state |
+| `action.context.*` | any | **Everything else the caller passed.** This is the escape hatch — no schema change needed for a new field |
+
+Defaults are applied before evaluation, so comparisons never blow up on a missing field.
+
+#### More Examples
+
+```yaml
+# Require 2+ reasons for high-stakes decisions
+condition: "action.stakes == 'high' && action.reason_count < 2"
+
+# Untagged, unpatterned, and not low-stakes
+condition: "!action.has_tags && !action.has_pattern && action.stakes != 'low'"
+
+# Category-specific confidence floor
+condition: "action.category == 'security' && action.confidence < 0.7"
+
+# Substring match on the description plus a caller-supplied flag
+condition: "action.description.contains('trading') && !action.context.backtest_completed"
+
+# Membership test
+condition: "size(action.tags) == 0 && action.stakes in ['high', 'critical']"
+```
+
+#### Legacy Auto-Conversion
+
+A `condition:` dict without a `cel` key is converted to CEL automatically at load time. Existing
+guardrail files keep working with no migration:
+
+| Legacy key | Generated CEL |
+|------------|---------------|
+| `stakes: high` | `action.stakes == 'high'` |
+| `confidence_lt: 0.5` | `action.confidence < 0.5` |
+| `reason_count_lt: 1` | `action.reason_count < 1` |
+| `quality_lt: 0.5` | `action.quality_score < 0.5` |
+| `category: tooling` | `action.category == 'tooling'` |
+
+Suffixes `_lt`, `_gt`, `_lte`, and `_gte` map to `<`, `>`, `<=`, and `>=`. Keys that are not
+recognized activation fields resolve to `action.context.<key>`. Multiple keys are joined with `&&`.
+
+::: warning A `condition:` key disables the flat format
+When `condition:` is present, the guardrail is evaluated **only** through CEL — sibling
+`condition_*` and `requires_*` keys are ignored. Use the nested `requires:` dict (which is always
+parsed) or fold the requirement into the expression as `!action.context.<field>`.
+:::
+
+::: tip Fails open
+An expression that fails to compile, or raises at runtime, is skipped and a warning is logged —
+it never blocks. A broken rule silently stops enforcing, so check server logs for
+`CEL compile error` / `CEL eval error` after editing. The same applies if `cel-python` is not
+installed: every CEL guardrail is skipped.
+:::
+
+CEL evaluation runs only in `cstp.checkGuardrails` (and the `pre_action` path that calls it). It is
+not in the `queryDecisions` or `recordDecision` hot path. Programs are compiled once and cached per
+expression string.
+
 ### V2 Conditions (Advanced)
 
 For more complex scenarios, use the v2 structured condition format:

--- a/website/specs/f054-cel-guardrails.md
+++ b/website/specs/f054-cel-guardrails.md
@@ -162,7 +162,20 @@ Pure Python, maintained by Cloud Custodian (Google-backed). ~10KB, minimal trans
 | `a2a/mcp_schemas.py` | Add `context` field to `CheckActionInput` |
 | `a2a/mcp_server.py` | Forward `context` in `_build_guardrails_params` |
 | `pyproject.toml` | Add `cel-python` dependency |
-| `tests/test_guardrails.py` | New CEL tests + verify legacy compat |
+| `tests/test_f054_cel_guardrails.py` | New CEL tests + verify legacy compat |
+
+## As Shipped
+
+Two details differ from the plan above and are worth knowing when authoring rules:
+
+- **`condition:` disables the flat format.** When a `condition` key is present — string, `{"cel": …}`,
+  or legacy dict — the guardrail is evaluated only through CEL, and sibling `condition_*` /
+  `requires_*` keys are ignored. The nested `requires:` dict is still parsed.
+- **`cel-python` is a core dependency, not an extra.** If it is missing, the import fails softly and
+  every CEL guardrail is skipped rather than erroring at startup.
+
+See the [guardrails authoring guide](/reference/guardrails-authoring#cel-expressions) for the full
+activation field reference.
 
 ## Backward Compatibility
 

--- a/website/specs/f055-decision-provenance.md
+++ b/website/specs/f055-decision-provenance.md
@@ -1,6 +1,6 @@
 # F055: Decision Provenance & Control Evidence
 
-**Status:** Shipped (v0.16.0)
+**Status:** Shipped on `main`, unreleased (targets v0.16.0)
 **Priority:** High
 **Category:** Compliance & Auditability
 
@@ -263,17 +263,32 @@ and `tail_check` is `false`.
 
 ## Hash Chain
 
-The observed evidence store uses a SHA-256 hash chain. Hash preimage (UTF-8):
+The observed evidence store uses a SHA-256 hash chain. **Chain format version 2.** The preimage
+is the canonical JSON (sorted keys, no whitespace, UTF-8) of a six-field object:
 
+```json
+{"evidence_class":"…","event_type":"…","payload":{…},"prev_hash":"…","seq":1,"ts":"…"}
 ```
-{seq}\n{ts}\n{event_type}\n{evidence_class}\n{canonical_json(payload)}\n{prev_hash}
-```
+
+JSON-encoding every field makes the preimage injective: no two distinct
+`(seq, ts, event_type, evidence_class, payload, prev_hash)` tuples produce the same byte
+string, and embedded delimiters in string values cannot be used to forge a collision.
+
+::: warning Breaking change
+Format version 1 used a newline-delimited preimage
+(`{seq}\n{ts}\n{event_type}\n{evidence_class}\n{canonical_json(payload)}\n{prev_hash}`),
+which allowed collisions on embedded newlines. Any store written under version 1 will fail
+`verify_chain` and must be re-ingested. F055 is unreleased, so no migration path is provided.
+:::
 
 Note that `evidence_class` is included in the preimage. Reclassifying an event from
 `observed` to `attested` (or vice versa) breaks the chain at that record.
 
 `source` is intentionally excluded — it identifies the ingest origin but does not affect
 tamper-evidence.
+
+Writes use `BEGIN IMMEDIATE` with an explicit `seq`, so concurrent writers are serialized and
+cannot collide on a sequence number.
 
 ## Control Framework Mappings
 
@@ -319,8 +334,13 @@ The provenance DB is a SQLite WAL file at `$PROVENANCE_DB` (default:
 `~/.cstp/provenance.db`), separate from the decision store. Schema:
 
 ```sql
+CREATE TABLE schema_metadata (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
 CREATE TABLE events (
-    seq            INTEGER PRIMARY KEY AUTOINCREMENT,
+    seq            INTEGER PRIMARY KEY,
     ts             TEXT NOT NULL,
     source         TEXT NOT NULL,
     event_type     TEXT NOT NULL,
@@ -333,10 +353,18 @@ CREATE TABLE events (
 CREATE TABLE bundle_metadata (
     id           INTEGER PRIMARY KEY AUTOINCREMENT,
     generated_at TEXT NOT NULL,
+    head_seq     INTEGER NOT NULL DEFAULT 0,
     head_hash    TEXT NOT NULL,
     format       TEXT NOT NULL
 );
 ```
+
+`seq` is assigned explicitly rather than via `AUTOINCREMENT` so it can be allocated inside the
+`BEGIN IMMEDIATE` transaction that computes the chain hash.
+
+The `db_path` RPC parameter described in earlier drafts was removed: the service always resolves
+to the server-configured `PROVENANCE_DB`, so an authenticated caller cannot redirect reads or
+writes to an arbitrary file.
 
 ## Out of Scope
 

--- a/website/specs/index.md
+++ b/website/specs/index.md
@@ -52,6 +52,16 @@ F014–F017 (Hybrid Retrieval, Temporal Decay, Reason Diversity, Bridge Search) 
 | [F045](/specs/f045-graph-storage-layer) | Decision Graph Storage Layer |
 | [F048](/specs/f048-multi-vectordb) | Multi-Vector-DB Support (P1: ABCs + MemoryStore) |
 
+## Shipped (v0.16.0 — unreleased)
+
+Merged to `main`; no tag has been cut yet.
+
+| Spec | Feature |
+|------|---------|
+| [F030](/specs/f030-circuit-breaker-guardrails) | Circuit Breaker Guardrails |
+| [F054](/specs/f054-cel-guardrails) | CEL Expression Guardrails |
+| [F055](/specs/f055-decision-provenance) | Decision Provenance & Control Evidence |
+
 ## Roadmap
 
 ### Research & Observability
@@ -60,7 +70,6 @@ F014–F017 (Hybrid Retrieval, Temporal Decay, Reason Diversity, Bridge Search) 
 |------|---------|
 | [F020](/specs/f020-reasoning-traces) | Structured Reasoning Traces |
 | [F029](/specs/f029-task-router) | Task Router |
-| [F030](/specs/f030-circuit-breaker-guardrails) | Circuit Breaker Guardrails |
 | [F031](/specs/f031-source-trust-scoring) | Source Trust Scoring |
 | [F032](/specs/f032-error-amplification-tracking) | Error Amplification Tracking |
 

--- a/website/specs/index.md
+++ b/website/specs/index.md
@@ -52,6 +52,16 @@ F014–F017 (Hybrid Retrieval, Temporal Decay, Reason Diversity, Bridge Search) 
 | [F045](/specs/f045-graph-storage-layer) | Decision Graph Storage Layer |
 | [F048](/specs/f048-multi-vectordb) | Multi-Vector-DB Support (P1: ABCs + MemoryStore) |
 
+## Shipped (v0.14.0)
+
+| Spec | Feature |
+|------|---------|
+| [F041](/specs/f041-memory-compaction) | Memory Compaction |
+
+::: info
+F049 (Live Deliberation Viewer) also shipped in v0.14.0, and F050 (SQLite Storage Layer) in v0.15.0. Both were implementation plans in `docs/features/` rather than published specs — see the [changelog](/changelog) for details.
+:::
+
 ## Shipped (v0.16.0 — unreleased)
 
 Merged to `main`; no tag has been cut yet.
@@ -95,9 +105,9 @@ Merged to `main`; no tag has been cut yet.
 | Spec | Feature |
 |------|---------|
 | [F040](/specs/f040-task-decision-graph) | Task-Decision Graph |
-| [F041](/specs/f041-memory-compaction) | Memory Compaction |
-| [F042](/specs/f042-decision-dependencies) | Decision Dependencies |
+| [F042](/specs/f042-decision-dependencies) | Decision Dependencies — *partial: the `depends_on` edge type landed with F045* |
 | [F043](/specs/f043-distributed-merge) | Distributed Merge |
+
 ### Infrastructure
 
 *F048 Multi-Vector-DB shipped in v0.12.0. Weaviate and pgvector backends planned as P2.*


### PR DESCRIPTION
Three related changes that had accumulated on this branch, plus one correction.

## 1. UTF-8 file IO (`1a02809`)
Pass `encoding="utf-8"` explicitly to every text-mode `open()` / `read_text()` / `write_text()` across `a2a/`, `src/`, `scripts/` and `tests/`. Mechanical — no behaviour change on a UTF-8 locale, but removes the dependency on the ambient locale (Windows / minimal containers default to cp1252 or ASCII and corrupt em-dashes in decision YAML).

## 2. v0.16.0 documentation (`4524a58`)
- `website/changelog.md` — v0.16.0 entry (Provenance, CEL Guardrails, Circuit Breakers)
- `website/specs/f054-cel-guardrails.md` — new spec
- `website/specs/f055-decision-provenance.md` — expanded
- `website/reference/api.md`, `website/reference/guardrails-authoring.md` — new reference pages
- Moves F030 out of Roadmap into a new Shipped (v0.16.0 — unreleased) section

## 3. Spec-index corrections (`b0f877e`)
`website/specs/index.md` still listed **F041 Memory Compaction** under the Beads roadmap although it shipped in **v0.14.0**. F049 and F050 were missing from the index entirely.

- Add Shipped (v0.14.0) with F041
- Info note: F049 (v0.14.0) and F050 (v0.15.0) shipped from `docs/features/` implementation plans with no published spec — same pattern as the existing F014–F017 note
- Annotate F042 as *partial* — only the `depends_on` edge type landed, with F045
- Fix a missing blank line before `### Infrastructure` that swallowed the end of the preceding table

### Verification of the shipped/roadmap claims
Checked against test files and service modules on `main`, not against memory:

| Feature | Evidence | Status |
|---|---|---|
| F030 | `circuit_breaker_service.py`, `test_f030_circuit_breaker.py` | shipped |
| F041 | `compaction_service.py`, `test_f041_compaction*.py`, changelog v0.14.0 | shipped |
| F050 | `test_f050_migration.py`, `test_f050_sqlite_storage.py`, changelog v0.15.0 | shipped |
| F042 | only `depends_on` in `models.py`/`graph_service.py` | partial |
| F033, F040, F043 | no matches in `a2a/` or `tests/` | correctly roadmap |

Note: an earlier claim of mine that F033 and F040–F045 were all mislabelled was **wrong** — only the F041 row was actually stale.

## Downstream
The new Astro/Starlight site consumes this Markdown via `npm run docs:sync`. Once this merges I'll re-sync so the published docs pick up v0.16.0 — they're currently a release behind.